### PR TITLE
Improve long-running operations

### DIFF
--- a/.codegen/service.py.tmpl
+++ b/.codegen/service.py.tmpl
@@ -3,7 +3,7 @@
 from dataclasses import dataclass
 from datetime import timedelta
 from enum import Enum
-from typing import Dict, List, Any, Iterator, Type
+from typing import Dict, List, Any, Iterator, Type, Callable
 import time
 import random
 import logging
@@ -52,7 +52,7 @@ class {{.PascalName}}{{if eq "List" .PascalName}}Request{{end}}:{{if .Descriptio
 {{- define "as_request_type" -}}
 	{{- if not .Entity }}None # ERROR: No Type
 	{{- else if .Entity.ArrayValue }}[{{if .Entity.ArrayValue.IsObject}}v.as_dict(){{else}}v{{end}} for v in self.{{.SnakeName}}]
-	{{- else if .Entity.IsObject }}self.{{.SnakeName}}.as_dict()
+	{{- else if or .Entity.IsObject .Entity.IsExternal }}self.{{.SnakeName}}.as_dict()
 	{{- else if .Entity.Enum }}self.{{.SnakeName}}.value
 	{{- else}}self.{{.SnakeName}}{{- end -}}
 {{- end -}}
@@ -89,7 +89,8 @@ class {{.Name}}API:{{if .Description}}
     def __init__(self, api_client):
         self._api = api_client
     {{range .Waits}}
-    def {{.SnakeName}}(self{{range .Binding}}, {{.PollField.SnakeName}}: {{template "type-nq" .PollField.Entity}}{{end}}, timeout=timedelta(minutes={{.Timeout}})) -> {{.Poll.Response.PascalName}}:
+    def {{.SnakeName}}(self{{range .Binding}}, {{.PollField.SnakeName}}: {{template "type-nq" .PollField.Entity}}{{end}},
+      timeout=timedelta(minutes={{.Timeout}}), callback: Callable[[{{.Poll.Response.PascalName}}], None] = None) -> {{.Poll.Response.PascalName}}:
       deadline = time.time() + timeout.total_seconds()
       target_states = ({{range .Success}}{{.Entity.PascalName}}.{{.Content}}, {{end}}){{if .Failure}}
       failure_states = ({{range .Failure}}{{.Entity.PascalName}}.{{.Content}}, {{end}}){{end}}
@@ -109,6 +110,8 @@ class {{.Name}}API:{{if .Description}}
         {{- end}}
         if status in target_states:
           return poll
+        if callback:
+          callback(poll)
         {{if .Failure -}}
         if status in failure_states:
           msg = f'failed to reach {{range $i, $e := .Success}}{{if $i}} or {{end}}{{$e.Content}}{{end}}, got {status}: {status_message}'
@@ -166,8 +169,9 @@ class {{.Name}}API:{{if .Description}}
 
 {{define "method-call-retried" -}}
         {{if .Response}}op_response = {{end}}{{template "method-do" .}}
-        return Wait(self.{{.Wait.SnakeName}}, {{range $i, $b := .Wait.Binding}}{{if $i}}, {{end}}
-          {{.PollField.SnakeName}}={{if .IsResponseBind}}op_response['{{.Bind.Name}}']{{else}}request.{{.Bind.SnakeName}}{{end}}
+        return Wait(self.{{.Wait.SnakeName}}
+          {{if .Response}}, response = {{.Response.PascalName}}.from_dict(op_response){{end}}
+          {{range .Wait.Binding}}, {{.PollField.SnakeName}}={{if .IsResponseBind}}op_response['{{.Bind.Name}}']{{else}}request.{{.Bind.SnakeName}}{{end}}
         {{- end}})
 {{- end}}
 

--- a/README.md
+++ b/README.md
@@ -220,6 +220,8 @@ info = w.clusters.create_and_wait(cluster_name='Created cluster',
 logging.info(f'Created: {info}')
 ```
 
+Please look at the `examples/starting_job_and_waiting.py` for a more advanced usage.
+
 ## Paginated responses
 
 On the platform side the Databricks APIs have different wait to deal with pagination:
@@ -239,6 +241,8 @@ w = WorkspaceClient()
 for repo in w.repos.list():
    logging.info(f'Found repo: {repo.path}')
 ```
+
+Please look at the `examples/last_job_runs.py` for a more advanced usage.
 
 ## Single-Sign-On (SSO) with OAuth
 

--- a/examples/last_job_runs.py
+++ b/examples/last_job_runs.py
@@ -1,0 +1,39 @@
+#!env python3
+import logging
+import sys
+from collections import defaultdict
+from datetime import datetime, timezone
+from databricks.sdk import WorkspaceClient
+
+
+if __name__ == '__main__':
+    logging.basicConfig(stream=sys.stdout, level=logging.INFO,
+                        format='%(asctime)s [%(name)s][%(levelname)s] %(message)s')
+
+    latest_state = {}
+    all_jobs = {}
+    durations = defaultdict(list)
+
+    w = WorkspaceClient()
+    for job in w.jobs.list():
+        all_jobs[job.job_id] = job
+        for run in w.jobs.list_runs(job_id=job.job_id, expand_tasks=False):
+            durations[job.job_id].append(run.run_duration)
+            if job.job_id not in latest_state:
+                latest_state[job.job_id] = run
+                continue
+            if run.end_time < latest_state[job.job_id].end_time:
+                continue
+            latest_state[job.job_id] = run
+
+    summary = []
+    for job_id, run in latest_state.items():
+        summary.append({
+            'job_name': all_jobs[job_id].settings.name,
+            'last_status': run.state.result_state,
+            'last_finished': datetime.fromtimestamp(run.end_time/1000, timezone.utc),
+            'average_duration': sum(durations[job_id]) / len(durations[job_id])
+        })
+
+    for line in sorted(summary, key=lambda s: s['last_finished'], reverse=True):
+        logging.info(f'Latest: {line}')

--- a/examples/starting_job_and_waiting.py
+++ b/examples/starting_job_and_waiting.py
@@ -1,0 +1,89 @@
+#!env python3
+""" Detailed demonstration of long-running operations
+
+This example goes over the advanced usage of long-running operations like:
+
+    - w.clusters.create
+    - w.clusters.delete
+    - w.clusters.edit
+    - w.clusters.resize
+    - w.clusters.restart
+    - w.clusters.start
+    - w.command_execution.cancel
+    - w.command_execution.create
+    - w.command_execution.execute
+    - a.workspaces.create
+    - a.workspaces.update
+    - w.serving_endpoints.create
+    - w.serving_endpoints.update_config
+    - w.jobs.cancel_run
+    - w.jobs.repair_run
+    - w.jobs.run_now
+    - w.jobs.submit
+    - w.pipelines.reset
+    - w.pipelines.stop
+    - w.warehouses.create
+    - w.warehouses.delete
+    - w.warehouses.edit
+    - w.warehouses.start
+    - w.warehouses.stop
+
+In this example, you'll learn how block main thread until operation reaches a terminal state or times out.
+You'll also learn how to add a custom callback for intermediate state updates.
+
+You can change `logging.INFO` to `logging.DEBUG` to see HTTP traffic performed by SDK under the hood.
+"""
+
+import datetime
+import logging
+import sys
+import time
+
+from databricks.sdk import WorkspaceClient
+import databricks.sdk.service.jobs as j
+
+if __name__ == '__main__':
+    logging.basicConfig(stream=sys.stdout, level=logging.INFO,
+                        format='%(asctime)s [%(name)s][%(levelname)s] %(message)s')
+
+    w = WorkspaceClient()
+
+    # create a dummy file on DBFS that just sleeps for 10 seconds
+    py_on_dbfs = f'/home/{w.current_user.me().user_name}/sample.py'
+    with w.dbfs.open(py_on_dbfs, write=True, overwrite=True) as f:
+        f.write(b'import time; time.sleep(10); print("Hello, World!")')
+
+    # trigger one-time-run job and get waiter object
+    waiter = w.jobs.submit(run_name=f'py-sdk-run-{time.time()}', tasks=[
+        j.RunSubmitTaskSettings(
+            task_key='hello_world',
+            new_cluster=j.BaseClusterInfo(
+                spark_version=w.clusters.select_spark_version(long_term_support=True),
+                node_type_id=w.clusters.select_node_type(local_disk=True),
+                num_workers=1
+            ),
+            spark_python_task=j.SparkPythonTask(
+                python_file=f'dbfs:{py_on_dbfs}'
+            ),
+        )
+    ])
+
+    logging.info(f'starting to poll: {waiter.run_id}')
+
+    # callback, that receives a polled entity between state updates
+    def print_status(run: j.Run):
+        statuses = [f'{t.task_key}: {t.state.life_cycle_state}' for t in run.tasks]
+        logging.info(f'workflow intermediate status: {", ".join(statuses)}')
+
+    # If you want to perform polling in a separate thread, process, or service,
+    # you can use w.jobs.wait_get_run_job_terminated_or_skipped(
+    #   run_id=waiter.run_id,
+    #   timeout=datetime.timedelta(minutes=15),
+    #   callback=print_status) to achieve the same results.
+    #
+    # Waiter interface allows for `w.jobs.submit(..).result()` simplicity in
+    # the scenarios, where you need to block the calling thread for the job to finish.
+    run = waiter.result(timeout=datetime.timedelta(minutes=15),
+                        callback=print_status)
+
+    logging.info(f'job finished: {run.run_page_url}')

--- a/tests/integration/test_jobs.py
+++ b/tests/integration/test_jobs.py
@@ -1,3 +1,4 @@
+import datetime
 import logging
 
 
@@ -7,3 +8,66 @@ def test_jobs(w):
         logging.info(f'Looking at {job.settings.name}')
         found += 1
     assert found > 0
+
+
+def test_submitting_jobs(w, random, env_or_skip):
+    import databricks.sdk.service.jobs as j
+
+    py_on_dbfs = f'/home/{w.current_user.me().user_name}/sample.py'
+    with w.dbfs.open(py_on_dbfs, write=True, overwrite=True) as f:
+        f.write(b'import time; time.sleep(10); print("Hello, World!")')
+
+    waiter = w.jobs.submit(run_name=f'py-sdk-{random(8)}',
+                           tasks=[
+                               j.RunSubmitTaskSettings(
+                                   task_key='pi',
+                                   new_cluster=j.BaseClusterInfo(
+                                       spark_version=w.clusters.select_spark_version(long_term_support=True),
+                                       # node_type_id=w.clusters.select_node_type(local_disk=True),
+                                       instance_pool_id=env_or_skip('TEST_INSTANCE_POOL_ID'),
+                                       num_workers=1),
+                                   spark_python_task=j.SparkPythonTask(python_file=f'dbfs:{py_on_dbfs}'),
+                               )
+                           ])
+
+    logging.info(f'starting to poll: {waiter.run_id}')
+
+    def print_status(run: j.Run):
+        statuses = [f'{t.task_key}: {t.state.life_cycle_state}' for t in run.tasks]
+        logging.info(f'workflow intermediate status: {", ".join(statuses)}')
+
+    run = waiter.result(timeout=datetime.timedelta(minutes=15), callback=print_status)
+
+    logging.info(f'job finished: {run.run_page_url}')
+
+
+def test_last_job_runs(w):
+    from collections import defaultdict
+    from datetime import datetime, timezone
+
+    latest_state = {}
+    all_jobs = {}
+    durations = defaultdict(list)
+
+    for job in w.jobs.list():
+        all_jobs[job.job_id] = job
+        for run in w.jobs.list_runs(job_id=job.job_id, expand_tasks=False):
+            durations[job.job_id].append(run.run_duration)
+            if job.job_id not in latest_state:
+                latest_state[job.job_id] = run
+                continue
+            if run.end_time < latest_state[job.job_id].end_time:
+                continue
+            latest_state[job.job_id] = run
+
+    summary = []
+    for job_id, run in latest_state.items():
+        summary.append({
+            'job_name': all_jobs[job_id].settings.name,
+            'last_status': run.state.result_state,
+            'last_finished': datetime.fromtimestamp(run.end_time / 1000, timezone.utc),
+            'average_duration': sum(durations[job_id]) / len(durations[job_id])
+        })
+
+    for line in sorted(summary, key=lambda s: s['last_finished'], reverse=True):
+        logging.info(f'Latest: {line}')


### PR DESCRIPTION
## Changes
- Adds `callback` optional argument to every waiter.
- Adds typed response where applicable to `Wait` instances.
- Exposes `.bind()` on `Wait` for cross-process-boundary waiting.
- `examples/starting_job_and_waiting.py` for a detailed demonstration.

## Tests

- [x] `make test` run locally
- [x] `make fmt` applied
- [x] relevant integration tests applied

