### PR TITLE
Added `bricks` CLI authentication

### DIFF
--- a/databricks/sdk/core.py
+++ b/databricks/sdk/core.py
@@ -207,7 +207,8 @@ class CliTokenSource(Refreshable):
         except ValueError as e:
             raise ValueError(f"cannot unmarshal CLI result: {e}")
         except subprocess.CalledProcessError as e:
-            raise IOError(f'cannot get access token: {e.output.decode().strip()}') from e
+            message = e.output.decode().strip()
+            raise IOError(f'cannot get access token: {message}') from e
 
 
 class AzureCliTokenSource(CliTokenSource):
@@ -266,6 +267,11 @@ def bricks_cli(cfg: 'Config') -> Optional[HeaderFactory]:
     except FileNotFoundError:
         logger.debug(f'Most likely Bricks CLI is not installed.')
         return None
+    except IOError as e:
+        if 'databricks OAuth is not' in str(e):
+            logger.debug(f'OAuth not configured or not available: {e}')
+            return None
+        raise e
 
     logger.info("Using Bricks CLI authentication")
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -180,7 +180,7 @@ def test_config_azure_cli_host(monkeypatch):
 
 
 @raises(
-    "default auth: azure-cli: cannot get access token: This is just a failing script.\n. Config: azure_workspace_resource_id=/sub/rg/ws"
+    "default auth: azure-cli: cannot get access token: This is just a failing script. Config: azure_workspace_resource_id=/sub/rg/ws"
 )
 def test_config_azure_cli_host_fail(monkeypatch):
     monkeypatch.setenv('FAIL', 'yes')


### PR DESCRIPTION
## Changes
Added integration with `bricks auth login` & `bricks auth token` commands

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] `make fmt` applied
- [x] relevant integration tests applied

