### PR TITLE
Fix `dbutils.fs.put()` utility

### DIFF
--- a/databricks/sdk/dbutils.py
+++ b/databricks/sdk/dbutils.py
@@ -67,7 +67,8 @@ class _FsUtil:
 
     def put(self, file: str, contents: str, overwrite: bool = False) -> bool:
         """Writes the given String out to a file, encoded in UTF-8 """
-        self._dbfs.put(file, contents=contents, overwrite=overwrite)
+        with self._dbfs.open(file, write=True, overwrite=overwrite) as f:
+            f.write(contents.encode('utf8'))
         return True
 
     def rm(self, dir: str, recurse: bool = False) -> bool:

--- a/tests/integration/test_dbutils.py
+++ b/tests/integration/test_dbutils.py
@@ -22,6 +22,16 @@ def test_proxy_dbfs_mounts(w, env_or_skip):
     assert len(x) > 1
 
 
+def test_dbutils_put(w):
+    fs = w.dbutils.fs
+
+    path = "/tmp/dbc_qa_file"
+    fs.put(path, "test", True)
+    output = fs.head(path)
+
+    assert output == 'test'
+
+
 def test_secrets(w, random):
     random_scope = f'scope-{random()}'
     key_for_string = f'string-{random()}'


### PR DESCRIPTION
## Changes

Properly encodes file payload with base64 before sending it to DBFS API

## Tests

Added `test_dbutils_put`