### PR TITLE
Removed redundant newlines from AAD OAuth responses

### DIFF
--- a/databricks/sdk/oauth.py
+++ b/databricks/sdk/oauth.py
@@ -91,6 +91,7 @@ def retrieve_token(client_id,
             err = resp.json()
             code = err.get('errorCode', err.get('error', 'unknown'))
             summary = err.get('errorSummary', err.get('error_description', 'unknown'))
+            summary = summary.replace("\r\n", ' ')
             raise ValueError(f'{code}: {summary}')
         raise ValueError(resp.content)
     try:


### PR DESCRIPTION
## Changes

Removed redundant newlines from AAD OAuth responses

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] `make fmt` applied
- [x] relevant integration tests applied

