### PR TITLE
Removed experimental redacting logger filter for `dbutils.secrets.get('scope', 'key')`

### DIFF
--- a/databricks/sdk/dbutils.py
+++ b/databricks/sdk/dbutils.py
@@ -1,6 +1,5 @@
 import base64
 import json
-import logging
 import threading
 import typing
 from collections import namedtuple
@@ -126,56 +125,6 @@ class _FsUtil:
         return fs.refreshMounts()
 
 
-class _RedactingFilter(logging.Filter):
-    """Best-effort secret redaction logger"""
-
-    def __init__(self):
-        super().__init__()
-        self._secrets = set()
-
-    def register_secret(self, secret):
-        _RedactingFilter.register()
-        self._secrets.add(secret)
-
-    def filter(self, record):
-        record.msg = self._redact(record.msg)
-        if isinstance(record.args, dict):
-            for k in record.args.keys():
-                record.args[k] = self._redact(record.args[k])
-        else:
-            record.args = tuple(self._redact(arg) for arg in record.args)
-        return True
-
-    def _redact(self, msg):
-        msg = str(msg)
-        for secrets in self._secrets:
-            msg = msg.replace(secrets, '[REDACTED]')
-        return msg
-
-    @staticmethod
-    def _has_redactor(logger) -> bool:
-        if not hasattr(logger, 'filters'):
-            return True
-        for f in logger.filters:
-            if type(f) == _RedactingFilter:
-                return True
-        return False
-
-    @staticmethod
-    def register():
-        other_loggers = list(logging.Logger.manager.loggerDict.values())
-        all_loggers = [logging.Logger.manager.root] + other_loggers
-        # inject redacting filter into every initialized logger
-        for logger in all_loggers:
-            if _RedactingFilter._has_redactor(logger):
-                # skip adding this filter twice
-                continue
-            logger.filters.append(_FILTER)
-
-
-_FILTER = _RedactingFilter()
-
-
 class _SecretsUtil:
     """Remote equivalent of secrets util"""
 
@@ -192,11 +141,6 @@ class _SecretsUtil:
         """Gets the string representation of a secret value for the specified secrets scope and key."""
         val = self.getBytes(scope, key)
         string_value = val.decode()
-
-        # to comply with the expected best-effort behavior from DBR DBUtils,
-        # add secret for redaction only after dbutils.secrets.get()
-        _FILTER.register_secret(string_value)
-
         return string_value
 
     def list(self, scope) -> typing.List[SecretMetadata]:

--- a/tests/test_dbutils.py
+++ b/tests/test_dbutils.py
@@ -1,5 +1,3 @@
-import logging
-
 import pytest as pytest
 
 from .conftest import raises
@@ -202,13 +200,11 @@ def test_any_proxy(dbutils_proxy):
     assertions()
 
 
-def test_secrets_get_and_redacting_logs(dbutils, mocker, caplog):
+def test_secrets_get_and_redacting_logs(dbutils, mocker):
     inner = mocker.patch('databricks.sdk.core.ApiClient.do', return_value={'value': 'aGVsbG8='})
 
     value = dbutils.secrets.get('foo', 'bar')
-    logging.info(f'Secret is {value}')
 
     inner.assert_called_with('GET', '/api/2.0/secrets/get', query={'key': 'bar', 'scope': 'foo'})
 
     assert value == 'hello'
-    assert 'Secret is [REDACTED]' in caplog.text


### PR DESCRIPTION
## Changes

It seems that `dbutils.secrets.get('scope', 'key')` is conflicting with internal working of Jupyter Kernel.

This PR removing experimental basic, best-effort, logging filter to redact secrets from accidental logging. `sys.stdout`, `sys.stderr`, and `print()` statements are not handled.

# This won't work anymore:
<img width="1083" alt="databricks-sdk-py_–_test_dbutils_py" src="https://user-images.githubusercontent.com/259697/227218521-0a4f14f8-8445-4a6b-9f6f-ecc073e43524.png">

## Tests
- [x] `make test` run locally
- [x] `make fmt` applied
- [x] relevant integration tests applied

