### PR TITLE
Fixed error handling for SCIM and CommandExecution APIs

### DIFF
--- a/tests/integration/test_clusters.py
+++ b/tests/integration/test_clusters.py
@@ -1,6 +1,10 @@
 import logging
 from datetime import timedelta
 
+import pytest
+
+from databricks.sdk.core import DatabricksError
+
 
 def test_smallest_node_type(w):
     node_type_id = w.clusters.select_node_type(local_disk=True)
@@ -33,3 +37,11 @@ def test_create_cluster(w, env_or_skip, random):
                              num_workers=1,
                              timeout=timedelta(minutes=10))
     logging.info(f'Created: {info}')
+
+
+def test_error_unmarshall(w, random):
+    with pytest.raises(DatabricksError) as exc_info:
+        w.clusters.get('__non_existing__')
+    err = exc_info.value
+    assert 'Cluster __non_existing__ does not exist' in str(err)
+    assert 'INVALID_PARAMETER_VALUE' == err.error_code

--- a/tests/integration/test_commands.py
+++ b/tests/integration/test_commands.py
@@ -1,0 +1,11 @@
+import pytest
+
+from databricks.sdk.core import DatabricksError
+
+
+def test_error_unmarshall(w, random):
+    with pytest.raises(DatabricksError) as exc_info:
+        w.command_execution.execute(cluster_id='__non_existing__')
+    err = exc_info.value
+    assert 'requirement failed: missing contextId' in str(err)
+    assert err.error_code is None

--- a/tests/integration/test_groups.py
+++ b/tests/integration/test_groups.py
@@ -1,0 +1,15 @@
+import pytest
+
+from databricks.sdk.core import DatabricksError
+
+
+def test_filtering_groups(w, random):
+    all = w.groups.list(filter=f'displayName eq any-{random(12)}')
+    found = len(list(all))
+    assert found == 0
+
+
+def test_scim_error_unmarshall(w, random):
+    with pytest.raises(DatabricksError) as exc_info:
+        w.groups.list(filter=random(12))
+    assert 'Given filter operator is not supported' in str(exc_info.value)


### PR DESCRIPTION
## Changes

- `DatabricksError` and `_make_nicer_error` were not integration tested before
- this PR adds proper kwarg resolution

## Tests

- [x] `make test` run locally
- [x] `make fmt` applied
- [x] relevant integration tests applied

