### PR TITLE
Ignore .netrc when sending unauthenticated requests for OAuth handshake

### DIFF
--- a/databricks/sdk/oauth.py
+++ b/databricks/sdk/oauth.py
@@ -21,6 +21,7 @@ NO_ORIGIN_FOR_SPA_CLIENT_ERROR = 'AADSTS9002327'
 
 logger = logging.getLogger(__name__)
 
+
 class IgnoreNetrcAuth(requests.auth.AuthBase):
     """This auth method is a no-op.
 


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

This PR closes #107 by applying the fix described there. 

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

Tested manually while developing the same fix for dbt-databricks (see linked issue).

- [ ] `make test` run locally
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

