### PR TITLE
Make ApiClient more `pyodide` friendly

### DIFF
--- a/databricks/sdk/core.py
+++ b/databricks/sdk/core.py
@@ -707,12 +707,14 @@ class DatabricksError(IOError):
         self.kwargs = kwargs
 
 
-class ApiClient(requests.Session):
+class ApiClient:
     _cfg: Config
 
     def __init__(self, cfg: Config = None):
-        super().__init__()
         self._cfg = Config() if not cfg else cfg
+        self._debug_truncate_bytes = cfg.debug_truncate_bytes if cfg.debug_truncate_bytes else 96
+        self._user_agent_base = cfg.user_agent
+
         retry_strategy = Retry(
             total=6,
             backoff_factor=1,
@@ -721,11 +723,10 @@ class ApiClient(requests.Session):
             respect_retry_after_header=True,
             raise_on_status=False, # return original response when retries have been exhausted
         )
-        self._debug_truncate_bytes = cfg.debug_truncate_bytes if cfg.debug_truncate_bytes else 96
-        self._user_agent_base = cfg.user_agent
-        self.auth = self._authenticate
 
-        self.mount("https://", HTTPAdapter(max_retries=retry_strategy))
+        self._session = requests.Session()
+        self._session.auth = self._authenticate
+        self._session.mount("https://", HTTPAdapter(max_retries=retry_strategy))
 
     @property
     def account_id(self) -> str:
@@ -743,7 +744,7 @@ class ApiClient(requests.Session):
 
     def do(self, method: str, path: str, query: dict = None, body: dict = None) -> dict:
         headers = {'Accept': 'application/json', 'User-Agent': self._user_agent_base}
-        response = self.request(method, f"{self._cfg.host}{path}", params=query, json=body, headers=headers)
+        response = self._session.request(method, f"{self._cfg.host}{path}", params=query, json=body, headers=headers)
         try:
             self._record_request_log(response)
             if not response.ok:


### PR DESCRIPTION
## Changes
Embed `requests.Session` into ApiClient instead of extending it, so that `pyodide-http` [picks it up](https://github.com/koenvo/pyodide-http#supported-packages).

## Tests

- [x] `make test` run locally
- [ ] `make fmt` applied
- [x] relevant integration tests applied

