### PR TITLE
use shell for opening az cli

### DIFF
--- a/databricks/sdk/core.py
+++ b/databricks/sdk/core.py
@@ -224,7 +224,7 @@ class CliTokenSource(Refreshable):
 
     def refresh(self) -> Token:
         try:
-            out = subprocess.check_output(self._cmd, stderr=subprocess.STDOUT)
+            out = subprocess.check_output(self._cmd, stderr=subprocess.STDOUT, shell=True)
             it = json.loads(out.decode())
             expires_on = self._parse_expiry(it[self._expiry_field])
             return Token(access_token=it[self._access_token_field],

--- a/databricks/sdk/core.py
+++ b/databricks/sdk/core.py
@@ -4,12 +4,12 @@ import configparser
 import functools
 import json
 import logging
-import sys
 import os
 import pathlib
 import platform
 import re
 import subprocess
+import sys
 import urllib.parse
 from datetime import datetime
 from json import JSONDecodeError

--- a/databricks/sdk/core.py
+++ b/databricks/sdk/core.py
@@ -4,6 +4,7 @@ import configparser
 import functools
 import json
 import logging
+import sys
 import os
 import pathlib
 import platform
@@ -224,7 +225,10 @@ class CliTokenSource(Refreshable):
 
     def refresh(self) -> Token:
         try:
-            out = subprocess.check_output(self._cmd, stderr=subprocess.STDOUT, shell=True)
+            is_windows = sys.platform.startswith('win')
+            #windows requires shell=True to be able to execute 'az login' or other commands
+            #cannot use shell=True all the time, as it breaks macOS
+            out = subprocess.check_output(self._cmd, stderr=subprocess.STDOUT, shell=is_windows)
             it = json.loads(out.decode())
             expires_on = self._parse_expiry(it[self._expiry_field])
             return Token(access_token=it[self._access_token_field],

--- a/databricks/sdk/core.py
+++ b/databricks/sdk/core.py
@@ -226,8 +226,8 @@ class CliTokenSource(Refreshable):
     def refresh(self) -> Token:
         try:
             is_windows = sys.platform.startswith('win')
-            #windows requires shell=True to be able to execute 'az login' or other commands
-            #cannot use shell=True all the time, as it breaks macOS
+            # windows requires shell=True to be able to execute 'az login' or other commands
+            # cannot use shell=True all the time, as it breaks macOS
             out = subprocess.check_output(self._cmd, stderr=subprocess.STDOUT, shell=is_windows)
             it = json.loads(out.decode())
             expires_on = self._parse_expiry(it[self._expiry_field])


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
handle calling `az login` or alike cmd commands on windows 10 (and possibly other versions of windows). it seems that windows (and only windows) requires `shell=True` when executing sub processes. 

code checks if running on windows and only uses shell execution mode.

## Tests

- [x] `make test` run locally
- [x] `make fmt` applied
- [x] relevant integration tests applied
- [x] tested additionally conditional code on windows machine, but outside of build system, just on sample copied code (build tests on windows machine are not working yet...).

