### PR TITLE
[PROD-37531] Exposing REPL credential provider to Python SDK

### DIFF
--- a/databricks/sdk/runtime/__init__.py
+++ b/databricks/sdk/runtime/__init__.py
@@ -6,7 +6,8 @@ is_local_implementation = True
 # available to be imported from databricks.sdk.runtime.globals. This import can be used
 # in Python modules so users can access these objects from Files more easily.
 dbruntime_objects = [
-    "display", "displayHTML", "dbutils", "table", "sql", "udf", "getArgument", "sc", "sqlContext", "spark"
+    "display", "displayHTML", "dbutils", "table", "sql", "udf", "getArgument", "sc", "sqlContext", "spark",
+    "init_runtime_native_auth"
 ]
 
 RuntimeAuth = Tuple[str, Callable[[], Dict[str, str]]]

--- a/databricks/sdk/runtime/__init__.py
+++ b/databricks/sdk/runtime/__init__.py
@@ -24,6 +24,8 @@ try:
     userNamespaceGlobals = UserNamespaceInitializer.getOrCreate().get_namespace_globals()
     _globals = globals()
     for var in dbruntime_objects:
+        if var not in userNamespaceGlobals:
+            continue
         _globals[var] = userNamespaceGlobals[var]
     is_local_implementation = False
 except ImportError:


### PR DESCRIPTION
## Changes
In previous [PR](https://github.com/databricks/universe/pull/316192), we expose a function that will be used by Python SDK's `runtime_native_auth` so that in notebook environment it directly access information from command execution to authenticate. This PR import it from Python runtime to put on last piece of puzzle.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [x] `make fmt` applied
- [x] relevant integration tests applied

