### PR TITLE
Databricks Metadata Service credential provider

### DIFF
--- a/databricks/sdk/core.py
+++ b/databricks/sdk/core.py
@@ -448,7 +448,7 @@ class Config:
     debug_headers: bool = ConfigAttribute(env='DATABRICKS_DEBUG_HEADERS')
     rate_limit: int = ConfigAttribute(env='DATABRICKS_RATE_LIMIT')
     retry_timeout_seconds: int = ConfigAttribute()
-    metadata_service_url = ConfigAttribute(env='DATABRICKS_METADATA_SERVICE_URL', auth='metadata-service')
+    metadata_service_url = ConfigAttribute(env='DATABRICKS_METADATA_SERVICE_URL', auth='metadata-service', sensitive=True)
 
     def __init__(self,
                  *,

--- a/databricks/sdk/core.py
+++ b/databricks/sdk/core.py
@@ -448,7 +448,9 @@ class Config:
     debug_headers: bool = ConfigAttribute(env='DATABRICKS_DEBUG_HEADERS')
     rate_limit: int = ConfigAttribute(env='DATABRICKS_RATE_LIMIT')
     retry_timeout_seconds: int = ConfigAttribute()
-    metadata_service_url = ConfigAttribute(env='DATABRICKS_METADATA_SERVICE_URL', auth='metadata-service', sensitive=True)
+    metadata_service_url = ConfigAttribute(env='DATABRICKS_METADATA_SERVICE_URL',
+                                           auth='metadata-service',
+                                           sensitive=True)
 
     def __init__(self,
                  *,

--- a/databricks/sdk/core.py
+++ b/databricks/sdk/core.py
@@ -312,6 +312,57 @@ def bricks_cli(cfg: 'Config') -> Optional[HeaderFactory]:
     return inner
 
 
+class MetadataServiceTokenSource(Refreshable):
+    """ Obtain the token granted by Databricks Metadata Service """
+    MetadataServiceVersion = "1"
+    MetadataServiceVersionHeader = "X-Databricks-Metadata-Version"
+    MetadataServiceHostHeader = "X-Databricks-Host"
+    _metadata_service_timeout = 10 # seconds
+
+    def __init__(self, cfg: 'Config'):
+        super().__init__()
+        self.url = cfg.metadata_service_url
+        self.host = cfg.host
+
+    def refresh(self) -> Token:
+        resp = requests.get(self.url,
+                            timeout=self._metadata_service_timeout,
+                            headers={
+                                self.MetadataServiceVersionHeader: self.MetadataServiceVersion,
+                                self.MetadataServiceHostHeader: self.host
+                            })
+        json_resp: dict[str, str] = resp.json()
+        access_token = json_resp.get("access_token", None)
+        if access_token is None:
+            raise ValueError("Metadata Service returned empty token")
+        token_type = json_resp.get("token_type", None)
+        if token_type is None:
+            raise ValueError("Metadata Service returned empty token type")
+        if json_resp["expires_on"] in ["", None]:
+            raise ValueError("Metadata Service returned invalid expiry")
+        try:
+            expiry = datetime.fromtimestamp(json_resp["expires_on"])
+        except:
+            raise ValueError("Metadata Service returned invalid expiry")
+
+        return Token(access_token=access_token, token_type=token_type, expiry=expiry)
+
+
+@credentials_provider('metadata-service', ['host', 'metadata_service_url'])
+def metadata_service(cfg: 'Config') -> Optional[HeaderFactory]:
+    """ Adds refreshed token granted by Databricks Metadata Service to every request. """
+
+    token_source = MetadataServiceTokenSource(cfg)
+    token_source.token()
+    logger.info("Using Databricks Metadata Service authentication")
+
+    def inner() -> Dict[str, str]:
+        token = token_source.token()
+        return {'Authorization': f'{token.token_type} {token.access_token}'}
+
+    return inner
+
+
 class DefaultCredentials:
     """ Select the first applicable credential provider from the chain """
 
@@ -323,8 +374,8 @@ class DefaultCredentials:
 
     def __call__(self, cfg: 'Config') -> HeaderFactory:
         auth_providers = [
-            pat_auth, basic_auth, oauth_service_principal, azure_service_principal, azure_cli,
-            external_browser, bricks_cli, runtime_native_auth
+            pat_auth, basic_auth, metadata_service, oauth_service_principal, azure_service_principal,
+            azure_cli, external_browser, bricks_cli, runtime_native_auth
         ]
         for provider in auth_providers:
             auth_type = provider.auth_type()
@@ -397,6 +448,7 @@ class Config:
     debug_headers: bool = ConfigAttribute(env='DATABRICKS_DEBUG_HEADERS')
     rate_limit: int = ConfigAttribute(env='DATABRICKS_RATE_LIMIT')
     retry_timeout_seconds: int = ConfigAttribute()
+    metadata_service_url = ConfigAttribute(env='DATABRICKS_METADATA_SERVICE_URL', auth='metadata-service')
 
     def __init__(self,
                  *,

--- a/databricks/sdk/core.py
+++ b/databricks/sdk/core.py
@@ -314,9 +314,9 @@ def bricks_cli(cfg: 'Config') -> Optional[HeaderFactory]:
 
 class MetadataServiceTokenSource(Refreshable):
     """ Obtain the token granted by Databricks Metadata Service """
-    MetadataServiceVersion = "1"
-    MetadataServiceVersionHeader = "X-Databricks-Metadata-Version"
-    MetadataServiceHostHeader = "X-Databricks-Host"
+    METADATA_SERVICE_VERSION = "1"
+    METADATA_SERVICE_VERSION_HEADER = "X-Databricks-Metadata-Version"
+    METADATA_SERVICE_HOST_HEADER = "X-Databricks-Host"
     _metadata_service_timeout = 10 # seconds
 
     def __init__(self, cfg: 'Config'):
@@ -328,8 +328,8 @@ class MetadataServiceTokenSource(Refreshable):
         resp = requests.get(self.url,
                             timeout=self._metadata_service_timeout,
                             headers={
-                                self.MetadataServiceVersionHeader: self.MetadataServiceVersion,
-                                self.MetadataServiceHostHeader: self.host
+                                self.METADATA_SERVICE_VERSION_HEADER: self.METADATA_SERVICE_VERSION,
+                                self.METADATA_SERVICE_HOST_HEADER: self.host
                             })
         json_resp: dict[str, str] = resp.json()
         access_token = json_resp.get("access_token", None)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,7 +1,12 @@
 # These are auto-generated tests for Unified Authentication
 # In case of editing this file, make sure the change is propagated to all Databricks SDK codebases
 
-from databricks.sdk.core import Config
+import json
+from datetime import datetime, timedelta
+
+import requests
+
+from databricks.sdk.core import Config, MetadataServiceTokenSource
 
 from .conftest import __tests__, raises
 
@@ -254,3 +259,76 @@ def test_config_auth_type_from_env(monkeypatch):
 
     assert cfg.auth_type == 'basic'
     assert cfg.host == 'https://x'
+
+
+def get_test_server(host: str, token: str, expires_after: int):
+    counter = 0
+
+    def inner(*args, **kwargs):
+        nonlocal counter
+        headers = kwargs['headers']
+        if headers.get(MetadataServiceTokenSource.MetadataServiceVersionHeader
+                       ) != MetadataServiceTokenSource.MetadataServiceVersion:
+            resp = requests.Response()
+            resp.status_code = 400
+            return resp
+        if headers.get(MetadataServiceTokenSource.MetadataServiceHostHeader) != host:
+            resp = requests.Response()
+            resp.status_code = 404
+            return resp
+
+        json_data = {
+            "access_token": f"{token}-{counter}",
+            "expires_on": int((datetime.now() + timedelta(seconds=expires_after)).timestamp()),
+            "token_type": "Bearer"
+        }
+        resp = requests.Response()
+        resp.status_code = 200
+        resp._content = json.dumps(json_data).encode('utf-8')
+        counter += 1
+        return resp
+
+    return inner
+
+
+def test_config_metadata_service(monkeypatch):
+    monkeypatch.setattr(requests, 'get', get_test_server('https://x', 'token', 100))
+    monkeypatch.setenv('DATABRICKS_HOST', 'x')
+    monkeypatch.setenv('DATABRICKS_METADATA_SERVICE_URL', 'http://y')
+    cfg = Config()
+
+    assert cfg.auth_type == 'metadata-service'
+    assert cfg.host == 'https://x'
+    assert cfg.metadata_service_url == 'http://y'
+
+
+def test_config_metadata_service_athenticate(monkeypatch):
+    monkeypatch.setattr(requests, 'get', get_test_server('https://x', 'token', 1000))
+    monkeypatch.setenv('DATABRICKS_HOST', 'x')
+    monkeypatch.setenv('DATABRICKS_METADATA_SERVICE_URL', 'http://y')
+    cfg = Config()
+
+    assert cfg.auth_type == 'metadata-service'
+    assert cfg.host == 'https://x'
+    assert cfg.metadata_service_url == 'http://y'
+
+    headers = cfg.authenticate()
+    assert headers.get("Authorization") == "Bearer token-0"
+
+
+def test_config_metadata_service_refresh(monkeypatch):
+    monkeypatch.setattr(requests, 'get', get_test_server('https://x', 'token', 10))
+    monkeypatch.setenv('DATABRICKS_HOST', 'x')
+    monkeypatch.setenv('DATABRICKS_METADATA_SERVICE_URL', 'http://y')
+    cfg = Config()
+
+    assert cfg.auth_type == 'metadata-service'
+    assert cfg.host == 'https://x'
+    assert cfg.metadata_service_url == 'http://y'
+
+    headers = cfg.authenticate()
+    # the first refresh happens when initialising config. So this is the second refresh
+    assert headers.get("Authorization") == "Bearer token-1"
+
+    headers = cfg.authenticate()
+    assert headers.get("Authorization") == "Bearer token-2"

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -267,12 +267,12 @@ def get_test_server(host: str, token: str, expires_after: int):
     def inner(*args, **kwargs):
         nonlocal counter
         headers = kwargs['headers']
-        if headers.get(MetadataServiceTokenSource.MetadataServiceVersionHeader
-                       ) != MetadataServiceTokenSource.MetadataServiceVersion:
+        if headers.get(MetadataServiceTokenSource.METADATA_SERVICE_VERSION_HEADER
+                       ) != MetadataServiceTokenSource.METADATA_SERVICE_VERSION:
             resp = requests.Response()
             resp.status_code = 400
             return resp
-        if headers.get(MetadataServiceTokenSource.MetadataServiceHostHeader) != host:
+        if headers.get(MetadataServiceTokenSource.METADATA_SERVICE_HOST_HEADER) != host:
             resp = requests.Response()
             resp.status_code = 404
             return resp

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,12 +1,9 @@
 # These are auto-generated tests for Unified Authentication
 # In case of editing this file, make sure the change is propagated to all Databricks SDK codebases
 
-import json
-from datetime import datetime, timedelta
 
-import requests
 
-from databricks.sdk.core import Config, MetadataServiceTokenSource
+from databricks.sdk.core import Config
 
 from .conftest import __tests__, raises
 
@@ -259,76 +256,3 @@ def test_config_auth_type_from_env(monkeypatch):
 
     assert cfg.auth_type == 'basic'
     assert cfg.host == 'https://x'
-
-
-def get_test_server(host: str, token: str, expires_after: int):
-    counter = 0
-
-    def inner(*args, **kwargs):
-        nonlocal counter
-        headers = kwargs['headers']
-        if headers.get(MetadataServiceTokenSource.METADATA_SERVICE_VERSION_HEADER
-                       ) != MetadataServiceTokenSource.METADATA_SERVICE_VERSION:
-            resp = requests.Response()
-            resp.status_code = 400
-            return resp
-        if headers.get(MetadataServiceTokenSource.METADATA_SERVICE_HOST_HEADER) != host:
-            resp = requests.Response()
-            resp.status_code = 404
-            return resp
-
-        json_data = {
-            "access_token": f"{token}-{counter}",
-            "expires_on": int((datetime.now() + timedelta(seconds=expires_after)).timestamp()),
-            "token_type": "Bearer"
-        }
-        resp = requests.Response()
-        resp.status_code = 200
-        resp._content = json.dumps(json_data).encode('utf-8')
-        counter += 1
-        return resp
-
-    return inner
-
-
-def test_config_metadata_service(monkeypatch):
-    monkeypatch.setattr(requests, 'get', get_test_server('https://x', 'token', 100))
-    monkeypatch.setenv('DATABRICKS_HOST', 'x')
-    monkeypatch.setenv('DATABRICKS_METADATA_SERVICE_URL', 'http://y')
-    cfg = Config()
-
-    assert cfg.auth_type == 'metadata-service'
-    assert cfg.host == 'https://x'
-    assert cfg.metadata_service_url == 'http://y'
-
-
-def test_config_metadata_service_athenticate(monkeypatch):
-    monkeypatch.setattr(requests, 'get', get_test_server('https://x', 'token', 1000))
-    monkeypatch.setenv('DATABRICKS_HOST', 'x')
-    monkeypatch.setenv('DATABRICKS_METADATA_SERVICE_URL', 'http://y')
-    cfg = Config()
-
-    assert cfg.auth_type == 'metadata-service'
-    assert cfg.host == 'https://x'
-    assert cfg.metadata_service_url == 'http://y'
-
-    headers = cfg.authenticate()
-    assert headers.get("Authorization") == "Bearer token-0"
-
-
-def test_config_metadata_service_refresh(monkeypatch):
-    monkeypatch.setattr(requests, 'get', get_test_server('https://x', 'token', 10))
-    monkeypatch.setenv('DATABRICKS_HOST', 'x')
-    monkeypatch.setenv('DATABRICKS_METADATA_SERVICE_URL', 'http://y')
-    cfg = Config()
-
-    assert cfg.auth_type == 'metadata-service'
-    assert cfg.host == 'https://x'
-    assert cfg.metadata_service_url == 'http://y'
-
-    headers = cfg.authenticate()
-    # the first refresh happens when initialising config. So this is the second refresh
-    assert headers.get("Authorization") == "Bearer token-1"
-
-    headers = cfg.authenticate()
-    assert headers.get("Authorization") == "Bearer token-2"

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,8 +1,6 @@
 # These are auto-generated tests for Unified Authentication
 # In case of editing this file, make sure the change is propagated to all Databricks SDK codebases
 
-
-
 from databricks.sdk.core import Config
 
 from .conftest import __tests__, raises

--- a/tests/test_metadata_service_auth.py
+++ b/tests/test_metadata_service_auth.py
@@ -1,0 +1,79 @@
+import json
+from datetime import datetime, timedelta
+
+import requests
+
+from databricks.sdk.core import Config, MetadataServiceTokenSource
+
+
+def get_test_server(host: str, token: str, expires_after: int):
+    counter = 0
+
+    def inner(*args, **kwargs):
+        nonlocal counter
+        headers = kwargs['headers']
+        if headers.get(MetadataServiceTokenSource.METADATA_SERVICE_VERSION_HEADER
+                       ) != MetadataServiceTokenSource.METADATA_SERVICE_VERSION:
+            resp = requests.Response()
+            resp.status_code = 400
+            return resp
+        if headers.get(MetadataServiceTokenSource.METADATA_SERVICE_HOST_HEADER) != host:
+            resp = requests.Response()
+            resp.status_code = 404
+            return resp
+
+        json_data = {
+            "access_token": f"{token}-{counter}",
+            "expires_on": int((datetime.now() + timedelta(seconds=expires_after)).timestamp()),
+            "token_type": "Bearer"
+        }
+        resp = requests.Response()
+        resp.status_code = 200
+        resp._content = json.dumps(json_data).encode('utf-8')
+        counter += 1
+        return resp
+
+    return inner
+
+
+def test_config_metadata_service(monkeypatch):
+    monkeypatch.setattr(requests, 'get', get_test_server('https://x', 'token', 100))
+    monkeypatch.setenv('DATABRICKS_HOST', 'x')
+    monkeypatch.setenv('DATABRICKS_METADATA_SERVICE_URL', 'http://y')
+    cfg = Config()
+
+    assert cfg.auth_type == 'metadata-service'
+    assert cfg.host == 'https://x'
+    assert cfg.metadata_service_url == 'http://y'
+
+
+def test_config_metadata_service_athenticate(monkeypatch):
+    monkeypatch.setattr(requests, 'get', get_test_server('https://x', 'token', 1000))
+    monkeypatch.setenv('DATABRICKS_HOST', 'x')
+    monkeypatch.setenv('DATABRICKS_METADATA_SERVICE_URL', 'http://y')
+    cfg = Config()
+
+    assert cfg.auth_type == 'metadata-service'
+    assert cfg.host == 'https://x'
+    assert cfg.metadata_service_url == 'http://y'
+
+    headers = cfg.authenticate()
+    assert headers.get("Authorization") == "Bearer token-0"
+
+
+def test_config_metadata_service_refresh(monkeypatch):
+    monkeypatch.setattr(requests, 'get', get_test_server('https://x', 'token', 10))
+    monkeypatch.setenv('DATABRICKS_HOST', 'x')
+    monkeypatch.setenv('DATABRICKS_METADATA_SERVICE_URL', 'http://y')
+    cfg = Config()
+
+    assert cfg.auth_type == 'metadata-service'
+    assert cfg.host == 'https://x'
+    assert cfg.metadata_service_url == 'http://y'
+
+    headers = cfg.authenticate()
+    # the first refresh happens when initialising config. So this is the second refresh
+    assert headers.get("Authorization") == "Bearer token-1"
+
+    headers = cfg.authenticate()
+    assert headers.get("Authorization") == "Bearer token-2"


### PR DESCRIPTION
## Changes
* Port databricks metadata service credential provider from go sdk.

## Tests
* unit tests

- [x] `make test` run locally
- [x] `make fmt` applied

