### PR TITLE
(bugfix) Catalog GrantAPI: securable_type enum value

### DIFF
--- a/databricks/sdk/service/catalog.py
+++ b/databricks/sdk/service/catalog.py
@@ -3498,7 +3498,7 @@ class GrantsAPI:
 
         json = self._api.do(
             'GET',
-            f'/api/2.1/unity-catalog/permissions/{request.securable_type}/{request.full_name}',
+            f'/api/2.1/unity-catalog/permissions/{request.securable_type.value}/{request.full_name}',
             query=query)
         return PermissionsList.from_dict(json)
 
@@ -3522,7 +3522,7 @@ class GrantsAPI:
 
         json = self._api.do(
             'GET',
-            f'/api/2.1/unity-catalog/effective-permissions/{request.securable_type}/{request.full_name}',
+            f'/api/2.1/unity-catalog/effective-permissions/{request.securable_type.value}/{request.full_name}',
             query=query)
         return EffectivePermissionsList.from_dict(json)
 
@@ -3542,7 +3542,7 @@ class GrantsAPI:
 
         json = self._api.do(
             'PATCH',
-            f'/api/2.1/unity-catalog/permissions/{request.securable_type}/{request.full_name}',
+            f'/api/2.1/unity-catalog/permissions/{request.securable_type.value}/{request.full_name}',
             body=body)
         return PermissionsList.from_dict(json)
 


### PR DESCRIPTION

## Changes
Change the render value of securable_type attribute to have the real Enum value and not the __repr__ value.
This will render the API URI call as the following : PATCH /api/2.1/unity-catalog/permissions/CATALOG/<catalog_id>
instead of /api/2.1/unity-catalog/permissions/SecurableType.CATALOG/<catalog_id>

## Tests
Tested locally

- [ ] `make test` run locally
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

