### PR TITLE
Add Issue Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,5 +1,5 @@
 ---
-name: Feature request
+name: Feature Request
 about: Suggest a new feature or improvement for the Python SDK for Databricks.
 title: "[FEATURE] "
 labels: ''

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest a new feature or improvement for the Python SDK for Databricks.
+title: "[FEATURE] "
+labels: ''
+assignees: ''
+
+---
+
+**Problem Statement**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Proposed Solution**
+A clear and concise description of what you want to happen.
+
+**Additional Context**
+Add any other context, references or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/sdk-issue.md
+++ b/.github/ISSUE_TEMPLATE/sdk-issue.md
@@ -1,0 +1,27 @@
+---
+name: SDK Issue
+about: Use this to report an issue with the Python SDK for Databricks.
+title: "[ISSUE] "
+labels: ''
+assignees: ''
+
+---
+
+**Description**
+A clear and concise description of what the bug is.
+
+**Reproduction**
+A minimal code sample demonstrating the bug.
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Debug Logs**
+The SDK logs helpful debugging information when debug logging is enabled. Set the log level to debug by adding `logging.basicConfig(level=logging.DEBUG)` to your program, and include the logs here.
+
+**Other Information**
+ - OS: [e.g. macOS]
+ - Version: [e.g. 0.1.0]
+
+**Additional context**
+Add any other context about the problem here.


### PR DESCRIPTION
Add two basic issue templates to the Python SDK repo, one for SDK issues and one for feature requests.