### PR TITLE
Use ctx.workspaceUrl instead of ctx.browserHostName

### DIFF
--- a/databricks/sdk/core.py
+++ b/databricks/sdk/core.py
@@ -102,7 +102,7 @@ def runtime_native_auth(cfg: 'Config') -> Optional[HeaderFactory]:
         if ctx is None:
             logger.debug('Empty REPL context returned, skipping runtime auth')
             return None
-        cfg.host = f'https://{ctx.browserHostName}'
+        cfg.host = f'https://{ctx.workspaceUrl}'
 
         def inner() -> Dict[str, str]:
             ctx = get_context()


### PR DESCRIPTION
## Changes
Change runtime authentication to use ctx.workspaceUrl instead of ctx.browserHostName. The latter is only defined in interactive environments, whereas the former is always defined, in both jobs and interactive environments.

Fixes #202.

## Tests
Tested by running a notebook interactively and in a job. 
Job:
![Screenshot 2023-06-29 at 15 03 43](https://github.com/databricks/databricks-sdk-py/assets/1850319/e65bfb5f-d91a-4eac-bd3c-fc21e0d11767)
Interactive:
![Screenshot 2023-06-29 at 15 06 14](https://github.com/databricks/databricks-sdk-py/assets/1850319/e0907638-07a4-4555-b8e9-f265ceb0f081)



- [ ] `make test` run locally
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

