### PR TITLE
Strip quotes from env vars

### DIFF
--- a/databricks/sdk/core.py
+++ b/databricks/sdk/core.py
@@ -357,7 +357,7 @@ class MetadataServiceTokenSource(Refreshable):
     METADATA_SERVICE_VERSION = "1"
     METADATA_SERVICE_VERSION_HEADER = "X-Databricks-Metadata-Version"
     METADATA_SERVICE_HOST_HEADER = "X-Databricks-Host"
-    _metadata_service_timeout = 10 # seconds
+    _metadata_service_timeout = 10  # seconds
 
     def __init__(self, cfg: 'Config'):
         super().__init__()
@@ -746,7 +746,7 @@ class Config:
             value = os.environ.get(attr.env)
             if not value:
                 continue
-            self._inner[attr.name] = value
+            self._inner[attr.name] = value.strip('"').strip("'")
             found = True
         if found:
             logger.debug('Loaded from environment')
@@ -877,7 +877,7 @@ class ApiClient:
             status_forcelist=[429],
             allowed_methods={"POST"} | set(Retry.DEFAULT_ALLOWED_METHODS),
             respect_retry_after_header=True,
-            raise_on_status=False, # return original response when retries have been exhausted
+            raise_on_status=False,  # return original response when retries have been exhausted
         )
 
         self._session = requests.Session()


### PR DESCRIPTION
## Changes
* SDK does not strip quotes when loading from environment variables. This is based on the assumption that os.environ already handles quote stripping. Something like `profile="something"` works. 
* But, there are cases where quotes might be escaped (not on purpose). Eg, when copying environment variables to pycharm, if the value has quotes, the quotes are escaped. 
<img width="490" alt="image" src="https://github.com/databricks/databricks-sdk-py/assets/88345179/f78a764e-3071-4f05-b78f-580f061b6fe9">
is parsed as 
<img width="447" alt="image" src="https://github.com/databricks/databricks-sdk-py/assets/88345179/58d850f6-01f9-4bbe-935e-03cb60fc6058">
**Note: '"10"'**

This is not handled properly by sdk. The quotes are note stripped. This PR adds stripping for these. 

## Tests
- [ ] `make test` run locally
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

