### PR TITLE
Fix job delete call in run_now_jobs_api_full_integration.py

### DIFF
--- a/examples/jobs/run_now_jobs_api_full_integration.py
+++ b/examples/jobs/run_now_jobs_api_full_integration.py
@@ -23,4 +23,4 @@ created_job = w.jobs.create(name=f'sdk-{time.time_ns()}',
 run_by_id = w.jobs.run_now(job_id=created_job.job_id).result()
 
 # cleanup
-w.jobs.delete(delete=created_job.job_id)
+w.jobs.delete(job_id=created_job.job_id)


### PR DESCRIPTION
jobs. delete method requires job_id as param.

## Changes
Modified delete job call by replacing the param with job_id instead of delete.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] `make fmt` applied
- [x] relevant integration tests applied

