### PR TITLE
fix/224 Permissionslist for shares missing definition

### DIFF
--- a/databricks/sdk/service/sharing.py
+++ b/databricks/sdk/service/sharing.py
@@ -1324,7 +1324,7 @@ class SharesAPI:
             request = SharePermissionsRequest(name=name)
 
         json = self._api.do('GET', f'/api/2.1/unity-catalog/shares/{request.name}/permissions')
-        return PermissionsList.from_dict(json)
+        return catalog.PermissionsList.from_dict(json)
 
     def update(self,
                name: str,


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
The method *share_permissions* returns PermissionsList which is in catalog.
catalog was missing from the return statement, so the interpreter didn't know where to look for the PermissionsList 
## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] `make fmt` applied
- [x] relevant integration tests applied

