### PR TITLE
Use .ConstantName defining target enum states for waiters

### DIFF
--- a/.codegen/service.py.tmpl
+++ b/.codegen/service.py.tmpl
@@ -113,8 +113,8 @@ class {{.Name}}API:{{if .Description}}
     def {{.SnakeName}}(self{{range .Binding}}, {{.PollField.SnakeName}}: {{template "type-nq" .PollField.Entity}}{{end}},
       timeout=timedelta(minutes={{.Timeout}}), callback: Optional[Callable[[{{.Poll.Response.PascalName}}], None]] = None) -> {{.Poll.Response.PascalName}}:
       deadline = time.time() + timeout.total_seconds()
-      target_states = ({{range .Success}}{{.Entity.PascalName}}.{{.Content}}, {{end}}){{if .Failure}}
-      failure_states = ({{range .Failure}}{{.Entity.PascalName}}.{{.Content}}, {{end}}){{end}}
+      target_states = ({{range .Success}}{{.Entity.PascalName}}.{{.ConstantName}}, {{end}}){{if .Failure}}
+      failure_states = ({{range .Failure}}{{.Entity.PascalName}}.{{.ConstantName}}, {{end}}){{end}}
       status_message = 'polling...'
       attempt = 1
       while time.time() < deadline:

--- a/databricks/sdk/service/compute.py
+++ b/databricks/sdk/service/compute.py
@@ -4284,8 +4284,8 @@ class CommandExecutionAPI:
             timeout=timedelta(minutes=20),
             callback: Optional[Callable[[CommandStatusResponse], None]] = None) -> CommandStatusResponse:
         deadline = time.time() + timeout.total_seconds()
-        target_states = (CommandStatus.Cancelled, )
-        failure_states = (CommandStatus.Error, )
+        target_states = (CommandStatus.CANCELLED, )
+        failure_states = (CommandStatus.ERROR, )
         status_message = 'polling...'
         attempt = 1
         while time.time() < deadline:
@@ -4319,8 +4319,8 @@ class CommandExecutionAPI:
             timeout=timedelta(minutes=20),
             callback: Optional[Callable[[CommandStatusResponse], None]] = None) -> CommandStatusResponse:
         deadline = time.time() + timeout.total_seconds()
-        target_states = (CommandStatus.Finished, CommandStatus.Error, )
-        failure_states = (CommandStatus.Cancelled, CommandStatus.Cancelling, )
+        target_states = (CommandStatus.FINISHED, CommandStatus.ERROR, )
+        failure_states = (CommandStatus.CANCELLED, CommandStatus.CANCELLING, )
         status_message = 'polling...'
         attempt = 1
         while time.time() < deadline:
@@ -4351,8 +4351,8 @@ class CommandExecutionAPI:
             timeout=timedelta(minutes=20),
             callback: Optional[Callable[[ContextStatusResponse], None]] = None) -> ContextStatusResponse:
         deadline = time.time() + timeout.total_seconds()
-        target_states = (ContextStatus.Running, )
-        failure_states = (ContextStatus.Error, )
+        target_states = (ContextStatus.RUNNING, )
+        failure_states = (ContextStatus.ERROR, )
         status_message = 'polling...'
         attempt = 1
         while time.time() < deadline:


### PR DESCRIPTION
## Changes
Uses of enums in generated code need to be updated to use `{{.ConstantName}}` instead of `{{.Content}}`.

## Tests

- [ ] `make test` run locally
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

