### PR TITLE
Fix/add dataclass permission level

### DIFF
--- a/databricks/sdk/service/iam.py
+++ b/databricks/sdk/service/iam.py
@@ -594,7 +594,7 @@ class PermissionAssignments:
     def from_dict(cls, d: Dict[str, any]) -> 'PermissionAssignments':
         return cls(permission_assignments=_repeated(d, 'permission_assignments', PermissionAssignment))
 
-
+@dataclass
 class PermissionLevel(Enum):
     """Permission level"""
 

--- a/tests/integration/test_jobs.py
+++ b/tests/integration/test_jobs.py
@@ -112,4 +112,4 @@ def test_permission_level_job(w):
         )
     ]
 
-    w.jobs.create(job_clusters=[cluster], tasks=[task1], access_control_list = [access_control_list])
+    w.jobs.create(job_clusters=[cluster], tasks=[task1], access_control_list = access_control_list)


### PR DESCRIPTION
## Changes
I added the @classdata decorator in iam.PemissionLevel(Enum) class. The PemissionLevel class in unrecognized when using this SDK in a python code.

## Tests

I created the test_permission_level_job function in the test_jobs.py module. I instantiate a cluster, a task, and a permission level setting two permissions configurations.


- [ ] `make test` run locally
- [x] `make fmt` applied
- [ ] relevant integration tests applied

