### PR TITLE
Fix enum deserialization

### DIFF
--- a/databricks/sdk/service/_internal.py
+++ b/databricks/sdk/service/_internal.py
@@ -18,7 +18,9 @@ def _repeated(d: Dict[str, any], field: str, cls: Type) -> any:
 def _enum(d: Dict[str, any], field: str, cls: Type) -> any:
     if field not in d or not d[field]:
         return None
-    return getattr(cls, '__members__').get(d[field], None)
+    if d[field] not in getattr(cls, '__members__').values():
+        return None
+    return d[field]
 
 
 ReturnType = TypeVar('ReturnType')


### PR DESCRIPTION
## Changes
In #230, enums were changed so that enum field names did not necessarily match the enum value itself. However, the `_enum` helper method used during deserialization of a response containing an enum was not updated to handle this case. This PR corrects this method to check through the values of the `__members__` of an enum, as opposed to the keys.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

