### PR TITLE
Call .value when serializing lists of enum values

### DIFF
--- a/.codegen/service.py.tmpl
+++ b/.codegen/service.py.tmpl
@@ -55,7 +55,7 @@ class {{.PascalName}}{{if eq "List" .PascalName}}Request{{end}}:{{if .Descriptio
 {{- end -}}
 {{- define "as_request_type" -}}
 	{{- if not .Entity }}None # ERROR: No Type
-	{{- else if .Entity.ArrayValue }}[{{if or .Entity.ArrayValue.IsObject .Entity.ArrayValue.IsExternal}}v.as_dict(){{else}}v{{end}} for v in self.{{.SnakeName}}]
+	{{- else if .Entity.ArrayValue }}[{{if or .Entity.ArrayValue.IsObject .Entity.ArrayValue.IsExternal}}v.as_dict(){{ else if .Entity.ArrayValue.Enum }}v.value{{else}}v{{end}} for v in self.{{.SnakeName}}]
 	{{- else if or .Entity.IsObject .Entity.IsExternal }}self.{{.SnakeName}}.as_dict()
 	{{- else if .Entity.Enum }}self.{{.SnakeName}}.value
 	{{- else}}self.{{.SnakeName}}{{- end -}}

--- a/.codegen/service.py.tmpl
+++ b/.codegen/service.py.tmpl
@@ -55,6 +55,7 @@ class {{.PascalName}}{{if eq "List" .PascalName}}Request{{end}}:{{if .Descriptio
 {{- end -}}
 {{- define "as_request_type" -}}
 	{{- if not .Entity }}None # ERROR: No Type
+	{{- /* This should be done recursively, but recursion in text templates is not supported. */ -}}
 	{{- else if .Entity.ArrayValue }}[{{if or .Entity.ArrayValue.IsObject .Entity.ArrayValue.IsExternal}}v.as_dict(){{ else if .Entity.ArrayValue.Enum }}v.value{{else}}v{{end}} for v in self.{{.SnakeName}}]
 	{{- else if or .Entity.IsObject .Entity.IsExternal }}self.{{.SnakeName}}.as_dict()
 	{{- else if .Entity.Enum }}self.{{.SnakeName}}.value

--- a/databricks/sdk/service/catalog.py
+++ b/databricks/sdk/service/catalog.py
@@ -1940,9 +1940,9 @@ class PermissionsChange:
 
     def as_dict(self) -> dict:
         body = {}
-        if self.add: body['add'] = [v for v in self.add]
+        if self.add: body['add'] = [v.value for v in self.add]
         if self.principal is not None: body['principal'] = self.principal
-        if self.remove: body['remove'] = [v for v in self.remove]
+        if self.remove: body['remove'] = [v.value for v in self.remove]
         return body
 
     @classmethod
@@ -2024,7 +2024,7 @@ class PrivilegeAssignment:
     def as_dict(self) -> dict:
         body = {}
         if self.principal is not None: body['principal'] = self.principal
-        if self.privileges: body['privileges'] = [v for v in self.privileges]
+        if self.privileges: body['privileges'] = [v.value for v in self.privileges]
         return body
 
     @classmethod

--- a/databricks/sdk/service/compute.py
+++ b/databricks/sdk/service/compute.py
@@ -199,7 +199,7 @@ class CloudProviderNodeInfo:
 
     def as_dict(self) -> dict:
         body = {}
-        if self.status: body['status'] = [v for v in self.status]
+        if self.status: body['status'] = [v.value for v in self.status]
         return body
 
     @classmethod
@@ -1679,7 +1679,7 @@ class GetEvents:
         body = {}
         if self.cluster_id is not None: body['cluster_id'] = self.cluster_id
         if self.end_time is not None: body['end_time'] = self.end_time
-        if self.event_types: body['event_types'] = [v for v in self.event_types]
+        if self.event_types: body['event_types'] = [v.value for v in self.event_types]
         if self.limit is not None: body['limit'] = self.limit
         if self.offset is not None: body['offset'] = self.offset
         if self.order is not None: body['order'] = self.order.value

--- a/databricks/sdk/service/iam.py
+++ b/databricks/sdk/service/iam.py
@@ -499,7 +499,7 @@ class PartialUpdate:
         body = {}
         if self.id is not None: body['id'] = self.id
         if self.operations: body['Operations'] = [v.as_dict() for v in self.operations]
-        if self.schema: body['schema'] = [v for v in self.schema]
+        if self.schema: body['schema'] = [v.value for v in self.schema]
         return body
 
     @classmethod
@@ -569,7 +569,7 @@ class PermissionAssignment:
     def as_dict(self) -> dict:
         body = {}
         if self.error is not None: body['error'] = self.error
-        if self.permissions: body['permissions'] = [v for v in self.permissions]
+        if self.permissions: body['permissions'] = [v.value for v in self.permissions]
         if self.principal: body['principal'] = self.principal.as_dict()
         return body
 
@@ -810,7 +810,7 @@ class UpdateWorkspaceAssignments:
 
     def as_dict(self) -> dict:
         body = {}
-        if self.permissions: body['permissions'] = [v for v in self.permissions]
+        if self.permissions: body['permissions'] = [v.value for v in self.permissions]
         if self.principal_id is not None: body['principal_id'] = self.principal_id
         if self.workspace_id is not None: body['workspace_id'] = self.workspace_id
         return body

--- a/databricks/sdk/service/ml.py
+++ b/databricks/sdk/service/ml.py
@@ -134,7 +134,7 @@ class CommentObject:
 
     def as_dict(self) -> dict:
         body = {}
-        if self.available_actions: body['available_actions'] = [v for v in self.available_actions]
+        if self.available_actions: body['available_actions'] = [v.value for v in self.available_actions]
         if self.comment is not None: body['comment'] = self.comment
         if self.creation_timestamp is not None: body['creation_timestamp'] = self.creation_timestamp
         if self.id is not None: body['id'] = self.id
@@ -308,7 +308,7 @@ class CreateRegistryWebhook:
     def as_dict(self) -> dict:
         body = {}
         if self.description is not None: body['description'] = self.description
-        if self.events: body['events'] = [v for v in self.events]
+        if self.events: body['events'] = [v.value for v in self.events]
         if self.http_url_spec: body['http_url_spec'] = self.http_url_spec.as_dict()
         if self.job_spec: body['job_spec'] = self.job_spec.as_dict()
         if self.model_name is not None: body['model_name'] = self.model_name
@@ -1418,7 +1418,7 @@ class RegistryWebhook:
         body = {}
         if self.creation_timestamp is not None: body['creation_timestamp'] = self.creation_timestamp
         if self.description is not None: body['description'] = self.description
-        if self.events: body['events'] = [v for v in self.events]
+        if self.events: body['events'] = [v.value for v in self.events]
         if self.http_url_spec: body['http_url_spec'] = self.http_url_spec.as_dict()
         if self.id is not None: body['id'] = self.id
         if self.job_spec: body['job_spec'] = self.job_spec.as_dict()
@@ -2025,7 +2025,7 @@ class TransitionRequest:
 
     def as_dict(self) -> dict:
         body = {}
-        if self.available_actions: body['available_actions'] = [v for v in self.available_actions]
+        if self.available_actions: body['available_actions'] = [v.value for v in self.available_actions]
         if self.comment is not None: body['comment'] = self.comment
         if self.creation_timestamp is not None: body['creation_timestamp'] = self.creation_timestamp
         if self.to_stage is not None: body['to_stage'] = self.to_stage.value
@@ -2149,7 +2149,7 @@ class UpdateRegistryWebhook:
     def as_dict(self) -> dict:
         body = {}
         if self.description is not None: body['description'] = self.description
-        if self.events: body['events'] = [v for v in self.events]
+        if self.events: body['events'] = [v.value for v in self.events]
         if self.http_url_spec: body['http_url_spec'] = self.http_url_spec.as_dict()
         if self.id is not None: body['id'] = self.id
         if self.job_spec: body['job_spec'] = self.job_spec.as_dict()

--- a/databricks/sdk/service/provisioning.py
+++ b/databricks/sdk/service/provisioning.py
@@ -146,7 +146,7 @@ class CreateCustomerManagedKeyRequest:
         body = {}
         if self.aws_key_info: body['aws_key_info'] = self.aws_key_info.as_dict()
         if self.gcp_key_info: body['gcp_key_info'] = self.gcp_key_info.as_dict()
-        if self.use_cases: body['use_cases'] = [v for v in self.use_cases]
+        if self.use_cases: body['use_cases'] = [v.value for v in self.use_cases]
         return body
 
     @classmethod
@@ -355,7 +355,7 @@ class CustomerManagedKey:
         if self.customer_managed_key_id is not None:
             body['customer_managed_key_id'] = self.customer_managed_key_id
         if self.gcp_key_info: body['gcp_key_info'] = self.gcp_key_info.as_dict()
-        if self.use_cases: body['use_cases'] = [v for v in self.use_cases]
+        if self.use_cases: body['use_cases'] = [v.value for v in self.use_cases]
         return body
 
     @classmethod

--- a/databricks/sdk/service/sharing.py
+++ b/databricks/sdk/service/sharing.py
@@ -665,7 +665,7 @@ class PrivilegeAssignment:
     def as_dict(self) -> dict:
         body = {}
         if self.principal is not None: body['principal'] = self.principal
-        if self.privileges: body['privileges'] = [v for v in self.privileges]
+        if self.privileges: body['privileges'] = [v.value for v in self.privileges]
         return body
 
     @classmethod

--- a/databricks/sdk/service/sql.py
+++ b/databricks/sdk/service/sql.py
@@ -212,7 +212,6 @@ class ChannelInfo:
 
 
 class ChannelName(Enum):
-    """Name of the channel"""
 
     CHANNEL_NAME_CURRENT = 'CHANNEL_NAME_CURRENT'
     CHANNEL_NAME_CUSTOM = 'CHANNEL_NAME_CUSTOM'

--- a/databricks/sdk/service/sql.py
+++ b/databricks/sdk/service/sql.py
@@ -1540,7 +1540,7 @@ class QueryFilter:
     def as_dict(self) -> dict:
         body = {}
         if self.query_start_time_range: body['query_start_time_range'] = self.query_start_time_range.as_dict()
-        if self.statuses: body['statuses'] = [v for v in self.statuses]
+        if self.statuses: body['statuses'] = [v.value for v in self.statuses]
         if self.user_ids: body['user_ids'] = [v for v in self.user_ids]
         if self.warehouse_ids: body['warehouse_ids'] = [v for v in self.warehouse_ids]
         return body

--- a/examples/permissions/set_generic_permissions.py
+++ b/examples/permissions/set_generic_permissions.py
@@ -11,12 +11,12 @@ group = w.groups.create(display_name=f'sdk-{time.time_ns()}')
 
 obj = w.workspace.get_status(get_status=notebook_path)
 
-w.permissions.set(request_object_type="notebooks",
-                  request_object_id="%d" % (obj.object_id),
-                  access_control_list=[
-                      iam.AccessControlRequest(group_name=group.display_name,
-                                               permission_level=iam.PermissionLevel.CAN_RUN)
-                  ])
+_ = w.permissions.set(request_object_type="notebooks",
+                      request_object_id="%d" % (obj.object_id),
+                      access_control_list=[
+                          iam.AccessControlRequest(group_name=group.display_name,
+                                                   permission_level=iam.PermissionLevel.CAN_RUN)
+                      ])
 
 # cleanup
 w.groups.delete(delete=group.id)

--- a/tests/integration/test_clusters.py
+++ b/tests/integration/test_clusters.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 import pytest
 
 from databricks.sdk.core import DatabricksError
+from databricks.sdk.service.compute import EventType
 
 
 def test_smallest_node_type(w):
@@ -19,7 +20,7 @@ def test_latest_runtime(w):
 def test_cluster_events(w, env_or_skip):
     cluster_id = env_or_skip("TEST_DEFAULT_CLUSTER_ID")
     count = 0
-    for e in w.clusters.events(cluster_id):
+    for e in w.clusters.events(cluster_id, event_types=[EventType.STARTING, EventType.TERMINATING]):
         count += 1
     assert count > 0
 


### PR DESCRIPTION
## Changes
Currently, lists of enum values in request objects are incorrectly serialized in the `as_dict()` method. Instead of putting the enum directly into the resulting dictionary, the enum's value needs to be added to the dictionary.

Closes #214.

## Tests
Updated test_cluster_events to add a filter on EventType, which is a list of enum values. 

