### PR TITLE
Make dbutils typecast use a valid type variable

### DIFF
--- a/databricks/sdk/runtime/__init__.py
+++ b/databricks/sdk/runtime/__init__.py
@@ -38,16 +38,16 @@ except ImportError:
     # OSS implementation
     is_local_implementation = True
 
-    try:
-        from . import stub
-        from .stub import *
-        dbutils_type = Type[stub.dbutils]
-    except (ImportError, NameError):
-        from databricks.sdk.dbutils import RemoteDbUtils
+    from databricks.sdk.dbutils import RemoteDbUtils
 
+    from . import stub
+    dbutils_type = Type[stub.dbutils] | RemoteDbUtils
+
+    try:
+        from .stub import *
+    except (ImportError, NameError):
         # this assumes that all environment variables are set
         dbutils = RemoteDbUtils()
-        dbutils_type = RemoteDbUtils
 
     dbutils = cast(dbutils_type, dbutils)
 


### PR DESCRIPTION
## Changes
* We used an variable for collecting type information about dbutils. This behaviour was patched in a recent release of pyright (https://github.com/microsoft/pyright/commit/6169e0fb3cc966e530578b98fe24a395ed67e8e4). Now we need to use an explicit type variable. 
## Tests
- [x] tested manually on vscode with pylance `v2023.7.40` and type checking mode set to `strict`
- [x] `make test` run locally
- [x] `make fmt` applied
- [x] relevant integration tests applied

