### PR TITLE
Removed `**kwargs` from methods

### DIFF
--- a/.codegen/service.py.tmpl
+++ b/.codegen/service.py.tmpl
@@ -197,8 +197,8 @@ class {{.Name}}API:{{if .Description}}
         {{if or .Request.HasJsonField .Request.HasQueryField -}}
         {{if .Request.HasJsonField}}body = {}{{end}}{{if .Request.HasQueryField}}
         query = {}{{end}}
-        {{- range .Request.Fields}}
-        if {{.SnakeName}} is not None: {{if .IsQuery}}query{{else}}body{{end}}['{{.Name}}'] = {{template "method-param-bind" .}}{{end}}
+        {{- range .Request.Fields}}{{if not .IsPath}}
+        if {{.SnakeName}} is not None: {{if .IsQuery}}query{{else}}body{{end}}['{{.Name}}'] = {{template "method-param-bind" .}}{{end}}{{end}}
         {{- end}}
 {{- end}}
 

--- a/.codegen/service.py.tmpl
+++ b/.codegen/service.py.tmpl
@@ -8,7 +8,7 @@ import time
 import random
 import logging
 from ..errors import OperationTimeout, OperationFailed
-from ._internal import _enum, _from_dict, _repeated, _validated, Wait
+from ._internal import _enum, _from_dict, _repeated, Wait
 
 _LOG = logging.getLogger('databricks.sdk')
 
@@ -204,9 +204,9 @@ class {{.Name}}API:{{if .Description}}
 
 {{- define "method-param-bind" -}}
       {{- if not .Entity }}None # ERROR: No Type
-      {{- else if .Entity.ArrayValue }}[{{if .Entity.ArrayValue.IsObject}}_validated('{{.SnakeName}} item', {{.Entity.ArrayValue.PascalName}}, v){{else}}v{{end}} for v in {{.SnakeName}}]
-      {{- else if .Entity.IsObject }}_validated('{{.SnakeName}}', {{.Entity.PascalName}}, {{.SnakeName}})
-      {{- else if .Entity.Enum }}_validated('{{.SnakeName}}', {{.Entity.PascalName}}, {{.SnakeName}})
+      {{- else if .Entity.ArrayValue }}[{{if .Entity.ArrayValue.IsObject}}v.as_dict(){{else}}v{{end}} for v in {{.SnakeName}}]
+      {{- else if .Entity.IsObject }}{{.SnakeName}}.as_dict()
+      {{- else if .Entity.Enum }}{{.SnakeName}}.value
       {{- else}}{{.SnakeName}}{{- end -}}
 {{- end -}}
 

--- a/.codegen/service.py.tmpl
+++ b/.codegen/service.py.tmpl
@@ -8,7 +8,7 @@ import time
 import random
 import logging
 from ..errors import OperationTimeout, OperationFailed
-from ._internal import _enum, _from_dict, _repeated, Wait
+from ._internal import _enum, _from_dict, _repeated, _validated, Wait
 
 _LOG = logging.getLogger('databricks.sdk')
 
@@ -17,7 +17,7 @@ from databricks.sdk.service import {{.Package.Name}}{{end}}
 
 # all definitions in this file are in alphabetical order
 {{range .Types}}
-{{if .Fields -}}@dataclass
+{{if .Fields -}}{{if not .IsRequest}}@dataclass
 class {{.PascalName}}{{if eq "List" .PascalName}}Request{{end}}:{{if .Description}}
     """{{.Comment "    " 100}}"""
     {{end}}{{- range .RequiredFields | alphanumOnly}}
@@ -34,7 +34,7 @@ class {{.PascalName}}{{if eq "List" .PascalName}}Request{{end}}:{{if .Descriptio
     def from_dict(cls, d: Dict[str, any]) -> '{{.PascalName}}{{if eq "List" .PascalName}}Request{{end}}':
         return cls({{range $i, $f := .Fields | alphanumOnly}}{{if $i}}, {{end}}{{$f.SnakeName}}={{template "from_dict_type" $f}}{{end}})
     {{end}}
-
+{{end}}
 {{else if .ArrayValue}}type {{.PascalName}} []{{template "type" .ArrayValue}}
 {{else if .MapValue}}{{.PascalName}} = {{template "type-nq" .}}
 {{else if .Enum}}class {{.PascalName}}(Enum):
@@ -156,7 +156,7 @@ class {{.Name}}API:{{if .Description}}
       {{range .Request.RequiredFields}}, {{.SnakeName}}: {{template "type-nq" .Entity}}{{end}}
       {{if .Request.NonRequiredFields}}, *
         {{range .Request.NonRequiredFields}}, {{.SnakeName}}: Optional[{{template "type-nq" .Entity}}] = None{{end}}
-      {{- end}}, **kwargs
+      {{- end}}
     {{- end}}){{template "method-return-type" .}}:
         {{if .Description}}"""{{.Comment "        " 110 | trimSuffix "\"" }}
         {{with .Request}}{{range .RequiredFields}}
@@ -179,9 +179,7 @@ class {{.Name}}API:{{if .Description}}
           {{template "type-doc" .Response}}
         {{- end}}{{end}}
         """{{end}}
-        {{if .Request -}}request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-          request = {{template "type-nq" .Request}}({{range $i, $f := .Request.Fields}}{{if $i}}, {{end}}{{.SnakeName}}={{.SnakeName}}{{end}})
+        {{if .Request -}}
         {{template "method-serialize" .}}
         {{- end}}
         {{template "method-call" .}}
@@ -196,12 +194,21 @@ class {{.Name}}API:{{if .Description}}
 {{- end}}
 
 {{define "method-serialize" -}}
-        {{if .Request.HasJsonField}}body = request.as_dict(){{end}}{{if .Request.HasQueryField}}
-        query = {}
-        {{- range .Request.Fields}}{{if .IsQuery}}
-        if {{.SnakeName}}: query['{{.Name}}'] = {{template "method-param-bind" .}}{{end}}{{end}}
-        {{end}}
+        {{if or .Request.HasJsonField .Request.HasQueryField -}}
+        {{if .Request.HasJsonField}}body = {}{{end}}{{if .Request.HasQueryField}}
+        query = {}{{end}}
+        {{- range .Request.Fields}}
+        if {{.SnakeName}} is not None: {{if .IsQuery}}query{{else}}body{{end}}['{{.Name}}'] = {{template "method-param-bind" .}}{{end}}
+        {{- end}}
 {{- end}}
+
+{{- define "method-param-bind" -}}
+      {{- if not .Entity }}None # ERROR: No Type
+      {{- else if .Entity.ArrayValue }}[{{if .Entity.ArrayValue.IsObject}}_validated('{{.SnakeName}} item', {{.Entity.ArrayValue.PascalName}}, v){{else}}v{{end}} for v in {{.SnakeName}}]
+      {{- else if .Entity.IsObject }}_validated('{{.SnakeName}}', {{.Entity.PascalName}}, {{.SnakeName}})
+      {{- else if .Entity.Enum }}_validated('{{.SnakeName}}', {{.Entity.PascalName}}, {{.SnakeName}})
+      {{- else}}{{.SnakeName}}{{- end -}}
+{{- end -}}
 
 {{define "method-call" -}}
         {{if .Pagination -}}{{template "method-call-paginated" .}}
@@ -213,7 +220,7 @@ class {{.Name}}API:{{if .Description}}
         {{if .Response}}op_response = {{end}}{{template "method-do" .}}
         return Wait(self.{{.Wait.SnakeName}}
           {{if .Response}}, response = {{.Response.PascalName}}.from_dict(op_response){{end}}
-          {{range .Wait.Binding}}, {{.PollField.SnakeName}}={{if .IsResponseBind}}op_response['{{.Bind.Name}}']{{else}}request.{{.Bind.SnakeName}}{{end}}
+          {{range .Wait.Binding}}, {{.PollField.SnakeName}}={{if .IsResponseBind}}op_response['{{.Bind.Name}}']{{else}}{{.Bind.SnakeName}}{{end}}
         {{- end}})
 {{- end}}
 
@@ -269,7 +276,7 @@ class {{.Name}}API:{{if .Description}}
 
 {{define "method-do" -}}
 self._api.do('{{.Verb}}', {{if .PathParts -}}
-  f'{{range  .PathParts}}{{.Prefix}}{{if .Field}}{{"{"}}request.{{.Field.SnakeName}}{{with .Field.Entity.Enum}}.value{{end}}{{"}"}}{{else if .IsAccountId}}{{"{self._api.account_id}"}}{{end}}{{ end }}'
+  f'{{range  .PathParts}}{{.Prefix}}{{if .Field}}{{"{"}}{{.Field.SnakeName}}{{with .Field.Entity.Enum}}.value{{end}}{{"}"}}{{else if .IsAccountId}}{{"{self._api.account_id}"}}{{end}}{{ end }}'
 {{- else}}'{{.Path}}'{{end}}{{if .Request}}{{if .Request.HasQueryField}}, query=query{{end}}{{if .Request.HasJsonField}}, body=body{{end}}{{end}})
 {{- end}}
 
@@ -288,10 +295,3 @@ self._api.do('{{.Verb}}', {{if .PathParts -}}
   {{- end}}{{end}}
 {{- end}}
 
-{{- define "method-param-bind" -}}
-{{- if not .Entity }}None # ERROR: No Type
-{{- else if .Entity.ArrayValue }}[{{if .Entity.ArrayValue.IsObject}}v.as_dict(){{else}}v{{end}} for v in request.{{.SnakeName}}]
-{{- else if .Entity.IsObject }}request.{{.SnakeName}}.as_dict()
-{{- else if .Entity.Enum }}request.{{.SnakeName}}.value
-{{- else}}request.{{.SnakeName}}{{- end -}}
-{{- end -}}

--- a/.codegen/service.py.tmpl
+++ b/.codegen/service.py.tmpl
@@ -204,7 +204,10 @@ class {{.Name}}API:{{if .Description}}
 
 {{- define "method-param-bind" -}}
       {{- if not .Entity }}None # ERROR: No Type
-      {{- else if .Entity.ArrayValue }}[{{if .Entity.ArrayValue.IsObject}}v.as_dict(){{else}}v{{end}} for v in {{.SnakeName}}]
+      {{- else if .Entity.ArrayValue }}[
+        {{- if .Entity.ArrayValue.IsObject -}}v.as_dict()
+        {{- else if .Entity.ArrayValue.Enum -}}v.value
+        {{- else}}v{{end}} for v in {{.SnakeName}}]
       {{- else if .Entity.IsObject }}{{.SnakeName}}.as_dict()
       {{- else if .Entity.Enum }}{{.SnakeName}}.value
       {{- else}}{{.SnakeName}}{{- end -}}

--- a/databricks/sdk/service/_internal.py
+++ b/databricks/sdk/service/_internal.py
@@ -1,4 +1,5 @@
 import datetime
+from enum import Enum
 from typing import Callable, Dict, Generic, Type, TypeVar
 
 
@@ -19,6 +20,20 @@ def _enum(d: Dict[str, any], field: str, cls: Type) -> any:
     if field not in d or not d[field]:
         return None
     return next((v for v in getattr(cls, '__members__').values() if v.value == d[field]), None)
+
+
+def _fqcn(x: any) -> str:
+    return f'{x.__module__}.{x.__name__}'
+
+
+def _validated(name: str, cls: Type, inst: any) -> any:
+    if not isinstance(inst, cls):
+        raise ValueError(f'{name} is expected to be {_fqcn(cls)}, but got {_fqcn(inst.__class__)}')
+    if issubclass(cls, Enum):
+        return getattr(inst, 'value')
+    if hasattr(inst, 'as_dict'):
+        return getattr(inst, 'as_dict')()
+    return inst
 
 
 ReturnType = TypeVar('ReturnType')

--- a/databricks/sdk/service/_internal.py
+++ b/databricks/sdk/service/_internal.py
@@ -1,5 +1,4 @@
 import datetime
-from enum import Enum
 from typing import Callable, Dict, Generic, Type, TypeVar
 
 
@@ -20,20 +19,6 @@ def _enum(d: Dict[str, any], field: str, cls: Type) -> any:
     if field not in d or not d[field]:
         return None
     return next((v for v in getattr(cls, '__members__').values() if v.value == d[field]), None)
-
-
-def _fqcn(x: any) -> str:
-    return f'{x.__module__}.{x.__name__}'
-
-
-def _validated(name: str, cls: Type, inst: any) -> any:
-    if not isinstance(inst, cls):
-        raise ValueError(f'{name} is expected to be {_fqcn(cls)}, but got {_fqcn(inst.__class__)}')
-    if issubclass(cls, Enum):
-        return getattr(inst, 'value')
-    if hasattr(inst, 'as_dict'):
-        return getattr(inst, 'as_dict')()
-    return inst
 
 
 ReturnType = TypeVar('ReturnType')

--- a/databricks/sdk/service/catalog.py
+++ b/databricks/sdk/service/catalog.py
@@ -854,108 +854,6 @@ class DatabricksGcpServiceAccountResponse:
 
 
 @dataclass
-class DeleteAccountMetastoreAssignmentRequest:
-    """Delete a metastore assignment"""
-
-    workspace_id: int
-    metastore_id: str
-
-
-@dataclass
-class DeleteAccountMetastoreRequest:
-    """Delete a metastore"""
-
-    metastore_id: str
-    force: Optional[bool] = None
-
-
-@dataclass
-class DeleteAccountStorageCredentialRequest:
-    """Delete a storage credential"""
-
-    metastore_id: str
-    name: str
-    force: Optional[bool] = None
-
-
-@dataclass
-class DeleteCatalogRequest:
-    """Delete a catalog"""
-
-    name: str
-    force: Optional[bool] = None
-
-
-@dataclass
-class DeleteConnectionRequest:
-    """Delete a connection"""
-
-    name_arg: str
-
-
-@dataclass
-class DeleteExternalLocationRequest:
-    """Delete an external location"""
-
-    name: str
-    force: Optional[bool] = None
-
-
-@dataclass
-class DeleteFunctionRequest:
-    """Delete a function"""
-
-    name: str
-    force: Optional[bool] = None
-
-
-@dataclass
-class DeleteMetastoreRequest:
-    """Delete a metastore"""
-
-    id: str
-    force: Optional[bool] = None
-
-
-@dataclass
-class DeleteSchemaRequest:
-    """Delete a schema"""
-
-    full_name: str
-
-
-@dataclass
-class DeleteStorageCredentialRequest:
-    """Delete a credential"""
-
-    name: str
-    force: Optional[bool] = None
-
-
-@dataclass
-class DeleteTableConstraintRequest:
-    """Delete a table constraint"""
-
-    full_name: str
-    constraint_name: str
-    cascade: bool
-
-
-@dataclass
-class DeleteTableRequest:
-    """Delete a table"""
-
-    full_name: str
-
-
-@dataclass
-class DeleteVolumeRequest:
-    """Delete a Volume"""
-
-    full_name_arg: str
-
-
-@dataclass
 class DeltaRuntimePropertiesKvPairs:
     """Properties pertaining to the current state of the delta table as given by the commit server.
     This does not contain **delta.*** (input) properties in __TableInfo.properties__."""
@@ -990,14 +888,6 @@ class Dependency:
     def from_dict(cls, d: Dict[str, any]) -> 'Dependency':
         return cls(function=_from_dict(d, 'function', FunctionDependency),
                    table=_from_dict(d, 'table', TableDependency))
-
-
-@dataclass
-class DisableRequest:
-    """Disable a system schema"""
-
-    metastore_id: str
-    schema_name: 'DisableSchemaName'
 
 
 class DisableSchemaName(Enum):
@@ -1095,14 +985,6 @@ class EnableAutoMaintenance(Enum):
     DISABLE = 'DISABLE'
     ENABLE = 'ENABLE'
     INHERIT = 'INHERIT'
-
-
-@dataclass
-class EnableRequest:
-    """Enable a system schema"""
-
-    metastore_id: str
-    schema_name: 'EnableSchemaName'
 
 
 class EnableSchemaName(Enum):
@@ -1411,81 +1293,6 @@ class FunctionParameterType(Enum):
 
 
 @dataclass
-class GetAccountMetastoreAssignmentRequest:
-    """Gets the metastore assignment for a workspace"""
-
-    workspace_id: int
-
-
-@dataclass
-class GetAccountMetastoreRequest:
-    """Get a metastore"""
-
-    metastore_id: str
-
-
-@dataclass
-class GetAccountStorageCredentialRequest:
-    """Gets the named storage credential"""
-
-    metastore_id: str
-    name: str
-
-
-@dataclass
-class GetCatalogRequest:
-    """Get a catalog"""
-
-    name: str
-
-
-@dataclass
-class GetConnectionRequest:
-    """Get a connection"""
-
-    name_arg: str
-
-
-@dataclass
-class GetEffectiveRequest:
-    """Get effective permissions"""
-
-    securable_type: 'SecurableType'
-    full_name: str
-    principal: Optional[str] = None
-
-
-@dataclass
-class GetExternalLocationRequest:
-    """Get an external location"""
-
-    name: str
-
-
-@dataclass
-class GetFunctionRequest:
-    """Get a function"""
-
-    name: str
-
-
-@dataclass
-class GetGrantRequest:
-    """Get permissions"""
-
-    securable_type: 'SecurableType'
-    full_name: str
-    principal: Optional[str] = None
-
-
-@dataclass
-class GetMetastoreRequest:
-    """Get a metastore"""
-
-    id: str
-
-
-@dataclass
 class GetMetastoreSummaryResponse:
     cloud: Optional[str] = None
     created_at: Optional[int] = None
@@ -1566,54 +1373,11 @@ class GetMetastoreSummaryResponseDeltaSharingScope(Enum):
     INTERNAL_AND_EXTERNAL = 'INTERNAL_AND_EXTERNAL'
 
 
-@dataclass
-class GetSchemaRequest:
-    """Get a schema"""
-
-    full_name: str
-
-
-@dataclass
-class GetStorageCredentialRequest:
-    """Get a credential"""
-
-    name: str
-
-
-@dataclass
-class GetTableRequest:
-    """Get a table"""
-
-    full_name: str
-    include_delta_metadata: Optional[bool] = None
-
-
-@dataclass
-class GetWorkspaceBindingRequest:
-    """Get catalog workspace bindings"""
-
-    name: str
-
-
 class IsolationMode(Enum):
     """Whether the current securable is accessible from all workspaces or a specific set of workspaces."""
 
     ISOLATED = 'ISOLATED'
     OPEN = 'OPEN'
-
-
-@dataclass
-class ListAccountMetastoreAssignmentsRequest:
-    """Get all workspaces assigned to a metastore"""
-
-    metastore_id: str
-
-
-@dataclass
-class ListAccountStorageCredentialsRequest:
-    """Get all storage credentials assigned to a metastore"""
-
-    metastore_id: str
 
 
 @dataclass
@@ -1660,14 +1424,6 @@ class ListExternalLocationsResponse:
 
 
 @dataclass
-class ListFunctionsRequest:
-    """List functions"""
-
-    catalog_name: str
-    schema_name: str
-
-
-@dataclass
 class ListFunctionsResponse:
     functions: Optional['List[FunctionInfo]'] = None
 
@@ -1693,13 +1449,6 @@ class ListMetastoresResponse:
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'ListMetastoresResponse':
         return cls(metastores=_repeated(d, 'metastores', MetastoreInfo))
-
-
-@dataclass
-class ListSchemasRequest:
-    """List schemas"""
-
-    catalog_name: str
 
 
 @dataclass
@@ -1729,24 +1478,6 @@ class ListStorageCredentialsResponse:
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'ListStorageCredentialsResponse':
         return cls(storage_credentials=_repeated(d, 'storage_credentials', StorageCredentialInfo))
-
-
-@dataclass
-class ListSummariesRequest:
-    """List table summaries"""
-
-    catalog_name: str
-    max_results: Optional[int] = None
-    page_token: Optional[str] = None
-    schema_name_pattern: Optional[str] = None
-    table_name_pattern: Optional[str] = None
-
-
-@dataclass
-class ListSystemSchemasRequest:
-    """List system schemas"""
-
-    metastore_id: str
 
 
 @dataclass
@@ -1781,17 +1512,6 @@ class ListTableSummariesResponse:
 
 
 @dataclass
-class ListTablesRequest:
-    """List tables"""
-
-    catalog_name: str
-    schema_name: str
-    include_delta_metadata: Optional[bool] = None
-    max_results: Optional[int] = None
-    page_token: Optional[str] = None
-
-
-@dataclass
 class ListTablesResponse:
     next_page_token: Optional[str] = None
     tables: Optional['List[TableInfo]'] = None
@@ -1805,14 +1525,6 @@ class ListTablesResponse:
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'ListTablesResponse':
         return cls(next_page_token=d.get('next_page_token', None), tables=_repeated(d, 'tables', TableInfo))
-
-
-@dataclass
-class ListVolumesRequest:
-    """List Volumes"""
-
-    catalog_name: str
-    schema_name: str
 
 
 @dataclass
@@ -2047,13 +1759,6 @@ class PrivilegeAssignment:
 
 
 PropertiesKvPairs = Dict[str, str]
-
-
-@dataclass
-class ReadVolumeRequest:
-    """Get a Volume"""
-
-    full_name_arg: str
 
 
 @dataclass
@@ -2456,14 +2161,6 @@ class TableType(Enum):
 
 
 @dataclass
-class UnassignRequest:
-    """Delete an assignment"""
-
-    workspace_id: int
-    metastore_id: str
-
-
-@dataclass
 class UpdateCatalog:
     comment: Optional[str] = None
     isolation_mode: Optional['IsolationMode'] = None
@@ -2757,24 +2454,6 @@ class UpdateStorageCredential:
 
 
 @dataclass
-class UpdateTableRequest:
-    """Update a table owner."""
-
-    full_name: str
-    owner: Optional[str] = None
-
-    def as_dict(self) -> dict:
-        body = {}
-        if self.full_name is not None: body['full_name'] = self.full_name
-        if self.owner is not None: body['owner'] = self.owner
-        return body
-
-    @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> 'UpdateTableRequest':
-        return cls(full_name=d.get('full_name', None), owner=d.get('owner', None))
-
-
-@dataclass
 class UpdateVolumeRequestContent:
     comment: Optional[str] = None
     full_name_arg: Optional[str] = None
@@ -2983,8 +2662,7 @@ class AccountMetastoreAssignmentsAPI:
                workspace_id: int,
                metastore_id: str,
                *,
-               metastore_assignment: Optional[CreateMetastoreAssignment] = None,
-               **kwargs):
+               metastore_assignment: Optional[CreateMetastoreAssignment] = None):
         """Assigns a workspace to a metastore.
         
         Creates an assignment to a metastore for a workspace
@@ -2997,18 +2675,14 @@ class AccountMetastoreAssignmentsAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = AccountsCreateMetastoreAssignment(metastore_assignment=metastore_assignment,
-                                                        metastore_id=metastore_id,
-                                                        workspace_id=workspace_id)
-        body = request.as_dict()
+        body = {}
+        if metastore_assignment is not None: body['metastore_assignment'] = metastore_assignment.as_dict()
         self._api.do(
             'POST',
-            f'/api/2.0/accounts/{self._api.account_id}/workspaces/{request.workspace_id}/metastores/{request.metastore_id}',
+            f'/api/2.0/accounts/{self._api.account_id}/workspaces/{workspace_id}/metastores/{metastore_id}',
             body=body)
 
-    def delete(self, workspace_id: int, metastore_id: str, **kwargs):
+    def delete(self, workspace_id: int, metastore_id: str):
         """Delete a metastore assignment.
         
         Deletes a metastore assignment to a workspace, leaving the workspace with no metastore.
@@ -3020,17 +2694,12 @@ class AccountMetastoreAssignmentsAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = DeleteAccountMetastoreAssignmentRequest(metastore_id=metastore_id,
-                                                              workspace_id=workspace_id)
 
         self._api.do(
             'DELETE',
-            f'/api/2.0/accounts/{self._api.account_id}/workspaces/{request.workspace_id}/metastores/{request.metastore_id}'
-        )
+            f'/api/2.0/accounts/{self._api.account_id}/workspaces/{workspace_id}/metastores/{metastore_id}')
 
-    def get(self, workspace_id: int, **kwargs) -> AccountsMetastoreAssignment:
+    def get(self, workspace_id: int) -> AccountsMetastoreAssignment:
         """Gets the metastore assignment for a workspace.
         
         Gets the metastore assignment, if any, for the workspace specified by ID. If the workspace is assigned
@@ -3042,15 +2711,12 @@ class AccountMetastoreAssignmentsAPI:
         
         :returns: :class:`AccountsMetastoreAssignment`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = GetAccountMetastoreAssignmentRequest(workspace_id=workspace_id)
 
-        json = self._api.do(
-            'GET', f'/api/2.0/accounts/{self._api.account_id}/workspaces/{request.workspace_id}/metastore')
+        json = self._api.do('GET',
+                            f'/api/2.0/accounts/{self._api.account_id}/workspaces/{workspace_id}/metastore')
         return AccountsMetastoreAssignment.from_dict(json)
 
-    def list(self, metastore_id: str, **kwargs) -> Iterator[MetastoreAssignment]:
+    def list(self, metastore_id: str) -> Iterator[MetastoreAssignment]:
         """Get all workspaces assigned to a metastore.
         
         Gets a list of all Databricks workspace IDs that have been assigned to given metastore.
@@ -3060,20 +2726,16 @@ class AccountMetastoreAssignmentsAPI:
         
         :returns: Iterator over :class:`MetastoreAssignment`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = ListAccountMetastoreAssignmentsRequest(metastore_id=metastore_id)
 
-        json = self._api.do(
-            'GET', f'/api/2.0/accounts/{self._api.account_id}/metastores/{request.metastore_id}/workspaces')
+        json = self._api.do('GET',
+                            f'/api/2.0/accounts/{self._api.account_id}/metastores/{metastore_id}/workspaces')
         return [MetastoreAssignment.from_dict(v) for v in json]
 
     def update(self,
                workspace_id: int,
                metastore_id: str,
                *,
-               metastore_assignment: Optional[UpdateMetastoreAssignment] = None,
-               **kwargs):
+               metastore_assignment: Optional[UpdateMetastoreAssignment] = None):
         """Updates a metastore assignment to a workspaces.
         
         Updates an assignment to a metastore for a workspace. Currently, only the default catalog may be
@@ -3087,15 +2749,11 @@ class AccountMetastoreAssignmentsAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = AccountsUpdateMetastoreAssignment(metastore_assignment=metastore_assignment,
-                                                        metastore_id=metastore_id,
-                                                        workspace_id=workspace_id)
-        body = request.as_dict()
+        body = {}
+        if metastore_assignment is not None: body['metastore_assignment'] = metastore_assignment.as_dict()
         self._api.do(
             'PUT',
-            f'/api/2.0/accounts/{self._api.account_id}/workspaces/{request.workspace_id}/metastores/{request.metastore_id}',
+            f'/api/2.0/accounts/{self._api.account_id}/workspaces/{workspace_id}/metastores/{metastore_id}',
             body=body)
 
 
@@ -3106,7 +2764,7 @@ class AccountMetastoresAPI:
     def __init__(self, api_client):
         self._api = api_client
 
-    def create(self, *, metastore_info: Optional[CreateMetastore] = None, **kwargs) -> AccountsMetastoreInfo:
+    def create(self, *, metastore_info: Optional[CreateMetastore] = None) -> AccountsMetastoreInfo:
         """Create metastore.
         
         Creates a Unity Catalog metastore.
@@ -3115,15 +2773,13 @@ class AccountMetastoresAPI:
         
         :returns: :class:`AccountsMetastoreInfo`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = AccountsCreateMetastore(metastore_info=metastore_info)
-        body = request.as_dict()
+        body = {}
+        if metastore_info is not None: body['metastore_info'] = metastore_info.as_dict()
 
         json = self._api.do('POST', f'/api/2.0/accounts/{self._api.account_id}/metastores', body=body)
         return AccountsMetastoreInfo.from_dict(json)
 
-    def delete(self, metastore_id: str, *, force: Optional[bool] = None, **kwargs):
+    def delete(self, metastore_id: str, *, force: Optional[bool] = None):
         """Delete a metastore.
         
         Deletes a Unity Catalog metastore for an account, both specified by ID.
@@ -3135,18 +2791,14 @@ class AccountMetastoresAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = DeleteAccountMetastoreRequest(force=force, metastore_id=metastore_id)
 
         query = {}
-        if force: query['force'] = request.force
-
+        if force is not None: query['force'] = force
         self._api.do('DELETE',
-                     f'/api/2.0/accounts/{self._api.account_id}/metastores/{request.metastore_id}',
+                     f'/api/2.0/accounts/{self._api.account_id}/metastores/{metastore_id}',
                      query=query)
 
-    def get(self, metastore_id: str, **kwargs) -> AccountsMetastoreInfo:
+    def get(self, metastore_id: str) -> AccountsMetastoreInfo:
         """Get a metastore.
         
         Gets a Unity Catalog metastore from an account, both specified by ID.
@@ -3156,12 +2808,8 @@ class AccountMetastoresAPI:
         
         :returns: :class:`AccountsMetastoreInfo`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = GetAccountMetastoreRequest(metastore_id=metastore_id)
 
-        json = self._api.do('GET',
-                            f'/api/2.0/accounts/{self._api.account_id}/metastores/{request.metastore_id}')
+        json = self._api.do('GET', f'/api/2.0/accounts/{self._api.account_id}/metastores/{metastore_id}')
         return AccountsMetastoreInfo.from_dict(json)
 
     def list(self) -> ListMetastoresResponse:
@@ -3178,8 +2826,7 @@ class AccountMetastoresAPI:
     def update(self,
                metastore_id: str,
                *,
-               metastore_info: Optional[UpdateMetastore] = None,
-               **kwargs) -> AccountsMetastoreInfo:
+               metastore_info: Optional[UpdateMetastore] = None) -> AccountsMetastoreInfo:
         """Update a metastore.
         
         Updates an existing Unity Catalog metastore.
@@ -3190,13 +2837,11 @@ class AccountMetastoresAPI:
         
         :returns: :class:`AccountsMetastoreInfo`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = AccountsUpdateMetastore(metastore_id=metastore_id, metastore_info=metastore_info)
-        body = request.as_dict()
+        body = {}
+        if metastore_info is not None: body['metastore_info'] = metastore_info.as_dict()
 
         json = self._api.do('PUT',
-                            f'/api/2.0/accounts/{self._api.account_id}/metastores/{request.metastore_id}',
+                            f'/api/2.0/accounts/{self._api.account_id}/metastores/{metastore_id}',
                             body=body)
         return AccountsMetastoreInfo.from_dict(json)
 
@@ -3210,8 +2855,7 @@ class AccountStorageCredentialsAPI:
     def create(self,
                metastore_id: str,
                *,
-               credential_info: Optional[CreateStorageCredential] = None,
-               **kwargs) -> StorageCredentialInfo:
+               credential_info: Optional[CreateStorageCredential] = None) -> StorageCredentialInfo:
         """Create a storage credential.
         
         Creates a new storage credential. The request object is specific to the cloud:
@@ -3228,19 +2872,16 @@ class AccountStorageCredentialsAPI:
         
         :returns: :class:`StorageCredentialInfo`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = AccountsCreateStorageCredential(credential_info=credential_info,
-                                                      metastore_id=metastore_id)
-        body = request.as_dict()
+        body = {}
+        if credential_info is not None: body['credential_info'] = credential_info.as_dict()
 
         json = self._api.do(
             'POST',
-            f'/api/2.0/accounts/{self._api.account_id}/metastores/{request.metastore_id}/storage-credentials',
+            f'/api/2.0/accounts/{self._api.account_id}/metastores/{metastore_id}/storage-credentials',
             body=body)
         return StorageCredentialInfo.from_dict(json)
 
-    def delete(self, metastore_id: str, name: str, *, force: Optional[bool] = None, **kwargs):
+    def delete(self, metastore_id: str, name: str, *, force: Optional[bool] = None):
         """Delete a storage credential.
         
         Deletes a storage credential from the metastore. The caller must be an owner of the storage
@@ -3255,19 +2896,15 @@ class AccountStorageCredentialsAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = DeleteAccountStorageCredentialRequest(force=force, metastore_id=metastore_id, name=name)
 
         query = {}
-        if force: query['force'] = request.force
-
+        if force is not None: query['force'] = force
         self._api.do(
             'DELETE',
-            f'/api/2.0/accounts/{self._api.account_id}/metastores/{request.metastore_id}/storage-credentials/',
+            f'/api/2.0/accounts/{self._api.account_id}/metastores/{metastore_id}/storage-credentials/',
             query=query)
 
-    def get(self, metastore_id: str, name: str, **kwargs) -> StorageCredentialInfo:
+    def get(self, metastore_id: str, name: str) -> StorageCredentialInfo:
         """Gets the named storage credential.
         
         Gets a storage credential from the metastore. The caller must be a metastore admin, the owner of the
@@ -3280,17 +2917,12 @@ class AccountStorageCredentialsAPI:
         
         :returns: :class:`StorageCredentialInfo`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = GetAccountStorageCredentialRequest(metastore_id=metastore_id, name=name)
 
         json = self._api.do(
-            'GET',
-            f'/api/2.0/accounts/{self._api.account_id}/metastores/{request.metastore_id}/storage-credentials/'
-        )
+            'GET', f'/api/2.0/accounts/{self._api.account_id}/metastores/{metastore_id}/storage-credentials/')
         return StorageCredentialInfo.from_dict(json)
 
-    def list(self, metastore_id: str, **kwargs) -> ListStorageCredentialsResponse:
+    def list(self, metastore_id: str) -> ListStorageCredentialsResponse:
         """Get all storage credentials assigned to a metastore.
         
         Gets a list of all storage credentials that have been assigned to given metastore.
@@ -3300,21 +2932,16 @@ class AccountStorageCredentialsAPI:
         
         :returns: :class:`ListStorageCredentialsResponse`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = ListAccountStorageCredentialsRequest(metastore_id=metastore_id)
 
         json = self._api.do(
-            'GET',
-            f'/api/2.0/accounts/{self._api.account_id}/metastores/{request.metastore_id}/storage-credentials')
+            'GET', f'/api/2.0/accounts/{self._api.account_id}/metastores/{metastore_id}/storage-credentials')
         return ListStorageCredentialsResponse.from_dict(json)
 
     def update(self,
                metastore_id: str,
                name: str,
                *,
-               credential_info: Optional[UpdateStorageCredential] = None,
-               **kwargs) -> StorageCredentialInfo:
+               credential_info: Optional[UpdateStorageCredential] = None) -> StorageCredentialInfo:
         """Updates a storage credential.
         
         Updates a storage credential on the metastore. The caller must be the owner of the storage credential.
@@ -3328,16 +2955,12 @@ class AccountStorageCredentialsAPI:
         
         :returns: :class:`StorageCredentialInfo`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = AccountsUpdateStorageCredential(credential_info=credential_info,
-                                                      metastore_id=metastore_id,
-                                                      name=name)
-        body = request.as_dict()
+        body = {}
+        if credential_info is not None: body['credential_info'] = credential_info.as_dict()
 
         json = self._api.do(
             'PUT',
-            f'/api/2.0/accounts/{self._api.account_id}/metastores/{request.metastore_id}/storage-credentials/',
+            f'/api/2.0/accounts/{self._api.account_id}/metastores/{metastore_id}/storage-credentials/',
             body=body)
         return StorageCredentialInfo.from_dict(json)
 
@@ -3361,8 +2984,7 @@ class CatalogsAPI:
                properties: Optional[Dict[str, str]] = None,
                provider_name: Optional[str] = None,
                share_name: Optional[str] = None,
-               storage_root: Optional[str] = None,
-               **kwargs) -> CatalogInfo:
+               storage_root: Optional[str] = None) -> CatalogInfo:
         """Create a catalog.
         
         Creates a new catalog instance in the parent metastore if the caller is a metastore admin or has the
@@ -3387,21 +3009,19 @@ class CatalogsAPI:
         
         :returns: :class:`CatalogInfo`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = CreateCatalog(comment=comment,
-                                    connection_name=connection_name,
-                                    name=name,
-                                    properties=properties,
-                                    provider_name=provider_name,
-                                    share_name=share_name,
-                                    storage_root=storage_root)
-        body = request.as_dict()
+        body = {}
+        if comment is not None: body['comment'] = comment
+        if connection_name is not None: body['connection_name'] = connection_name
+        if name is not None: body['name'] = name
+        if properties is not None: body['properties'] = properties
+        if provider_name is not None: body['provider_name'] = provider_name
+        if share_name is not None: body['share_name'] = share_name
+        if storage_root is not None: body['storage_root'] = storage_root
 
         json = self._api.do('POST', '/api/2.1/unity-catalog/catalogs', body=body)
         return CatalogInfo.from_dict(json)
 
-    def delete(self, name: str, *, force: Optional[bool] = None, **kwargs):
+    def delete(self, name: str, *, force: Optional[bool] = None):
         """Delete a catalog.
         
         Deletes the catalog that matches the supplied name. The caller must be a metastore admin or the owner
@@ -3414,16 +3034,12 @@ class CatalogsAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = DeleteCatalogRequest(force=force, name=name)
 
         query = {}
-        if force: query['force'] = request.force
+        if force is not None: query['force'] = force
+        self._api.do('DELETE', f'/api/2.1/unity-catalog/catalogs/{name}', query=query)
 
-        self._api.do('DELETE', f'/api/2.1/unity-catalog/catalogs/{request.name}', query=query)
-
-    def get(self, name: str, **kwargs) -> CatalogInfo:
+    def get(self, name: str) -> CatalogInfo:
         """Get a catalog.
         
         Gets the specified catalog in a metastore. The caller must be a metastore admin, the owner of the
@@ -3434,11 +3050,8 @@ class CatalogsAPI:
         
         :returns: :class:`CatalogInfo`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = GetCatalogRequest(name=name)
 
-        json = self._api.do('GET', f'/api/2.1/unity-catalog/catalogs/{request.name}')
+        json = self._api.do('GET', f'/api/2.1/unity-catalog/catalogs/{name}')
         return CatalogInfo.from_dict(json)
 
     def list(self) -> Iterator[CatalogInfo]:
@@ -3461,8 +3074,7 @@ class CatalogsAPI:
                comment: Optional[str] = None,
                isolation_mode: Optional[IsolationMode] = None,
                owner: Optional[str] = None,
-               properties: Optional[Dict[str, str]] = None,
-               **kwargs) -> CatalogInfo:
+               properties: Optional[Dict[str, str]] = None) -> CatalogInfo:
         """Update a catalog.
         
         Updates the catalog that matches the supplied name. The caller must be either the owner of the
@@ -3481,16 +3093,13 @@ class CatalogsAPI:
         
         :returns: :class:`CatalogInfo`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = UpdateCatalog(comment=comment,
-                                    isolation_mode=isolation_mode,
-                                    name=name,
-                                    owner=owner,
-                                    properties=properties)
-        body = request.as_dict()
+        body = {}
+        if comment is not None: body['comment'] = comment
+        if isolation_mode is not None: body['isolation_mode'] = isolation_mode.value
+        if owner is not None: body['owner'] = owner
+        if properties is not None: body['properties'] = properties
 
-        json = self._api.do('PATCH', f'/api/2.1/unity-catalog/catalogs/{request.name}', body=body)
+        json = self._api.do('PATCH', f'/api/2.1/unity-catalog/catalogs/{name}', body=body)
         return CatalogInfo.from_dict(json)
 
 
@@ -3515,8 +3124,7 @@ class ConnectionsAPI:
                comment: Optional[str] = None,
                owner: Optional[str] = None,
                properties_kvpairs: Optional[Dict[str, str]] = None,
-               read_only: Optional[bool] = None,
-               **kwargs) -> ConnectionInfo:
+               read_only: Optional[bool] = None) -> ConnectionInfo:
         """Create a connection.
         
         Creates a new connection
@@ -3541,21 +3149,19 @@ class ConnectionsAPI:
         
         :returns: :class:`ConnectionInfo`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = CreateConnection(comment=comment,
-                                       connection_type=connection_type,
-                                       name=name,
-                                       options_kvpairs=options_kvpairs,
-                                       owner=owner,
-                                       properties_kvpairs=properties_kvpairs,
-                                       read_only=read_only)
-        body = request.as_dict()
+        body = {}
+        if comment is not None: body['comment'] = comment
+        if connection_type is not None: body['connection_type'] = connection_type.value
+        if name is not None: body['name'] = name
+        if options_kvpairs is not None: body['options_kvpairs'] = options_kvpairs
+        if owner is not None: body['owner'] = owner
+        if properties_kvpairs is not None: body['properties_kvpairs'] = properties_kvpairs
+        if read_only is not None: body['read_only'] = read_only
 
         json = self._api.do('POST', '/api/2.1/unity-catalog/connections', body=body)
         return ConnectionInfo.from_dict(json)
 
-    def delete(self, name_arg: str, **kwargs):
+    def delete(self, name_arg: str):
         """Delete a connection.
         
         Deletes the connection that matches the supplied name.
@@ -3565,13 +3171,10 @@ class ConnectionsAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = DeleteConnectionRequest(name_arg=name_arg)
 
-        self._api.do('DELETE', f'/api/2.1/unity-catalog/connections/{request.name_arg}')
+        self._api.do('DELETE', f'/api/2.1/unity-catalog/connections/{name_arg}')
 
-    def get(self, name_arg: str, **kwargs) -> ConnectionInfo:
+    def get(self, name_arg: str) -> ConnectionInfo:
         """Get a connection.
         
         Gets a connection from it's name.
@@ -3581,11 +3184,8 @@ class ConnectionsAPI:
         
         :returns: :class:`ConnectionInfo`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = GetConnectionRequest(name_arg=name_arg)
 
-        json = self._api.do('GET', f'/api/2.1/unity-catalog/connections/{request.name_arg}')
+        json = self._api.do('GET', f'/api/2.1/unity-catalog/connections/{name_arg}')
         return ConnectionInfo.from_dict(json)
 
     def list(self) -> Iterator[ConnectionInfo]:
@@ -3599,7 +3199,7 @@ class ConnectionsAPI:
         json = self._api.do('GET', '/api/2.1/unity-catalog/connections')
         return [ConnectionInfo.from_dict(v) for v in json.get('connections', [])]
 
-    def update(self, name: str, options_kvpairs: Dict[str, str], name_arg: str, **kwargs) -> ConnectionInfo:
+    def update(self, name: str, options_kvpairs: Dict[str, str], name_arg: str) -> ConnectionInfo:
         """Update a connection.
         
         Updates the connection that matches the supplied name.
@@ -3613,12 +3213,11 @@ class ConnectionsAPI:
         
         :returns: :class:`ConnectionInfo`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = UpdateConnection(name=name, name_arg=name_arg, options_kvpairs=options_kvpairs)
-        body = request.as_dict()
+        body = {}
+        if name is not None: body['name'] = name
+        if options_kvpairs is not None: body['options_kvpairs'] = options_kvpairs
 
-        json = self._api.do('PATCH', f'/api/2.1/unity-catalog/connections/{request.name_arg}', body=body)
+        json = self._api.do('PATCH', f'/api/2.1/unity-catalog/connections/{name_arg}', body=body)
         return ConnectionInfo.from_dict(json)
 
 
@@ -3646,8 +3245,7 @@ class ExternalLocationsAPI:
                comment: Optional[str] = None,
                encryption_details: Optional[EncryptionDetails] = None,
                read_only: Optional[bool] = None,
-               skip_validation: Optional[bool] = None,
-               **kwargs) -> ExternalLocationInfo:
+               skip_validation: Optional[bool] = None) -> ExternalLocationInfo:
         """Create an external location.
         
         Creates a new external location entry in the metastore. The caller must be a metastore admin or have
@@ -3673,22 +3271,20 @@ class ExternalLocationsAPI:
         
         :returns: :class:`ExternalLocationInfo`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = CreateExternalLocation(access_point=access_point,
-                                             comment=comment,
-                                             credential_name=credential_name,
-                                             encryption_details=encryption_details,
-                                             name=name,
-                                             read_only=read_only,
-                                             skip_validation=skip_validation,
-                                             url=url)
-        body = request.as_dict()
+        body = {}
+        if access_point is not None: body['access_point'] = access_point
+        if comment is not None: body['comment'] = comment
+        if credential_name is not None: body['credential_name'] = credential_name
+        if encryption_details is not None: body['encryption_details'] = encryption_details.as_dict()
+        if name is not None: body['name'] = name
+        if read_only is not None: body['read_only'] = read_only
+        if skip_validation is not None: body['skip_validation'] = skip_validation
+        if url is not None: body['url'] = url
 
         json = self._api.do('POST', '/api/2.1/unity-catalog/external-locations', body=body)
         return ExternalLocationInfo.from_dict(json)
 
-    def delete(self, name: str, *, force: Optional[bool] = None, **kwargs):
+    def delete(self, name: str, *, force: Optional[bool] = None):
         """Delete an external location.
         
         Deletes the specified external location from the metastore. The caller must be the owner of the
@@ -3701,16 +3297,12 @@ class ExternalLocationsAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = DeleteExternalLocationRequest(force=force, name=name)
 
         query = {}
-        if force: query['force'] = request.force
+        if force is not None: query['force'] = force
+        self._api.do('DELETE', f'/api/2.1/unity-catalog/external-locations/{name}', query=query)
 
-        self._api.do('DELETE', f'/api/2.1/unity-catalog/external-locations/{request.name}', query=query)
-
-    def get(self, name: str, **kwargs) -> ExternalLocationInfo:
+    def get(self, name: str) -> ExternalLocationInfo:
         """Get an external location.
         
         Gets an external location from the metastore. The caller must be either a metastore admin, the owner
@@ -3721,11 +3313,8 @@ class ExternalLocationsAPI:
         
         :returns: :class:`ExternalLocationInfo`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = GetExternalLocationRequest(name=name)
 
-        json = self._api.do('GET', f'/api/2.1/unity-catalog/external-locations/{request.name}')
+        json = self._api.do('GET', f'/api/2.1/unity-catalog/external-locations/{name}')
         return ExternalLocationInfo.from_dict(json)
 
     def list(self) -> Iterator[ExternalLocationInfo]:
@@ -3751,8 +3340,7 @@ class ExternalLocationsAPI:
                force: Optional[bool] = None,
                owner: Optional[str] = None,
                read_only: Optional[bool] = None,
-               url: Optional[str] = None,
-               **kwargs) -> ExternalLocationInfo:
+               url: Optional[str] = None) -> ExternalLocationInfo:
         """Update an external location.
         
         Updates an external location in the metastore. The caller must be the owner of the external location,
@@ -3780,20 +3368,17 @@ class ExternalLocationsAPI:
         
         :returns: :class:`ExternalLocationInfo`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = UpdateExternalLocation(access_point=access_point,
-                                             comment=comment,
-                                             credential_name=credential_name,
-                                             encryption_details=encryption_details,
-                                             force=force,
-                                             name=name,
-                                             owner=owner,
-                                             read_only=read_only,
-                                             url=url)
-        body = request.as_dict()
+        body = {}
+        if access_point is not None: body['access_point'] = access_point
+        if comment is not None: body['comment'] = comment
+        if credential_name is not None: body['credential_name'] = credential_name
+        if encryption_details is not None: body['encryption_details'] = encryption_details.as_dict()
+        if force is not None: body['force'] = force
+        if owner is not None: body['owner'] = owner
+        if read_only is not None: body['read_only'] = read_only
+        if url is not None: body['url'] = url
 
-        json = self._api.do('PATCH', f'/api/2.1/unity-catalog/external-locations/{request.name}', body=body)
+        json = self._api.do('PATCH', f'/api/2.1/unity-catalog/external-locations/{name}', body=body)
         return ExternalLocationInfo.from_dict(json)
 
 
@@ -3829,8 +3414,7 @@ class FunctionsAPI:
                external_language: Optional[str] = None,
                external_name: Optional[str] = None,
                properties: Optional[Dict[str, str]] = None,
-               sql_path: Optional[str] = None,
-               **kwargs) -> FunctionInfo:
+               sql_path: Optional[str] = None) -> FunctionInfo:
         """Create a function.
         
         Creates a new function
@@ -3887,35 +3471,34 @@ class FunctionsAPI:
         
         :returns: :class:`FunctionInfo`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = CreateFunction(catalog_name=catalog_name,
-                                     comment=comment,
-                                     data_type=data_type,
-                                     external_language=external_language,
-                                     external_name=external_name,
-                                     full_data_type=full_data_type,
-                                     input_params=input_params,
-                                     is_deterministic=is_deterministic,
-                                     is_null_call=is_null_call,
-                                     name=name,
-                                     parameter_style=parameter_style,
-                                     properties=properties,
-                                     return_params=return_params,
-                                     routine_body=routine_body,
-                                     routine_definition=routine_definition,
-                                     routine_dependencies=routine_dependencies,
-                                     schema_name=schema_name,
-                                     security_type=security_type,
-                                     specific_name=specific_name,
-                                     sql_data_access=sql_data_access,
-                                     sql_path=sql_path)
-        body = request.as_dict()
+        body = {}
+        if catalog_name is not None: body['catalog_name'] = catalog_name
+        if comment is not None: body['comment'] = comment
+        if data_type is not None: body['data_type'] = data_type.value
+        if external_language is not None: body['external_language'] = external_language
+        if external_name is not None: body['external_name'] = external_name
+        if full_data_type is not None: body['full_data_type'] = full_data_type
+        if input_params is not None: body['input_params'] = [v.as_dict() for v in input_params]
+        if is_deterministic is not None: body['is_deterministic'] = is_deterministic
+        if is_null_call is not None: body['is_null_call'] = is_null_call
+        if name is not None: body['name'] = name
+        if parameter_style is not None: body['parameter_style'] = parameter_style.value
+        if properties is not None: body['properties'] = properties
+        if return_params is not None: body['return_params'] = [v.as_dict() for v in return_params]
+        if routine_body is not None: body['routine_body'] = routine_body.value
+        if routine_definition is not None: body['routine_definition'] = routine_definition
+        if routine_dependencies is not None:
+            body['routine_dependencies'] = [v.as_dict() for v in routine_dependencies]
+        if schema_name is not None: body['schema_name'] = schema_name
+        if security_type is not None: body['security_type'] = security_type.value
+        if specific_name is not None: body['specific_name'] = specific_name
+        if sql_data_access is not None: body['sql_data_access'] = sql_data_access.value
+        if sql_path is not None: body['sql_path'] = sql_path
 
         json = self._api.do('POST', '/api/2.1/unity-catalog/functions', body=body)
         return FunctionInfo.from_dict(json)
 
-    def delete(self, name: str, *, force: Optional[bool] = None, **kwargs):
+    def delete(self, name: str, *, force: Optional[bool] = None):
         """Delete a function.
         
         Deletes the function that matches the supplied name. For the deletion to succeed, the user must
@@ -3932,16 +3515,12 @@ class FunctionsAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = DeleteFunctionRequest(force=force, name=name)
 
         query = {}
-        if force: query['force'] = request.force
+        if force is not None: query['force'] = force
+        self._api.do('DELETE', f'/api/2.1/unity-catalog/functions/{name}', query=query)
 
-        self._api.do('DELETE', f'/api/2.1/unity-catalog/functions/{request.name}', query=query)
-
-    def get(self, name: str, **kwargs) -> FunctionInfo:
+    def get(self, name: str) -> FunctionInfo:
         """Get a function.
         
         Gets a function from within a parent catalog and schema. For the fetch to succeed, the user must
@@ -3957,14 +3536,11 @@ class FunctionsAPI:
         
         :returns: :class:`FunctionInfo`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = GetFunctionRequest(name=name)
 
-        json = self._api.do('GET', f'/api/2.1/unity-catalog/functions/{request.name}')
+        json = self._api.do('GET', f'/api/2.1/unity-catalog/functions/{name}')
         return FunctionInfo.from_dict(json)
 
-    def list(self, catalog_name: str, schema_name: str, **kwargs) -> Iterator[FunctionInfo]:
+    def list(self, catalog_name: str, schema_name: str) -> Iterator[FunctionInfo]:
         """List functions.
         
         List functions within the specified parent catalog and schema. If the user is a metastore admin, all
@@ -3980,18 +3556,15 @@ class FunctionsAPI:
         
         :returns: Iterator over :class:`FunctionInfo`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = ListFunctionsRequest(catalog_name=catalog_name, schema_name=schema_name)
 
         query = {}
-        if catalog_name: query['catalog_name'] = request.catalog_name
-        if schema_name: query['schema_name'] = request.schema_name
+        if catalog_name is not None: query['catalog_name'] = catalog_name
+        if schema_name is not None: query['schema_name'] = schema_name
 
         json = self._api.do('GET', '/api/2.1/unity-catalog/functions', query=query)
         return [FunctionInfo.from_dict(v) for v in json.get('functions', [])]
 
-    def update(self, name: str, *, owner: Optional[str] = None, **kwargs) -> FunctionInfo:
+    def update(self, name: str, *, owner: Optional[str] = None) -> FunctionInfo:
         """Update a function.
         
         Updates the function that matches the supplied name. Only the owner of the function can be updated. If
@@ -4009,12 +3582,10 @@ class FunctionsAPI:
         
         :returns: :class:`FunctionInfo`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = UpdateFunction(name=name, owner=owner)
-        body = request.as_dict()
+        body = {}
+        if owner is not None: body['owner'] = owner
 
-        json = self._api.do('PATCH', f'/api/2.1/unity-catalog/functions/{request.name}', body=body)
+        json = self._api.do('PATCH', f'/api/2.1/unity-catalog/functions/{name}', body=body)
         return FunctionInfo.from_dict(json)
 
 
@@ -4036,8 +3607,7 @@ class GrantsAPI:
             securable_type: SecurableType,
             full_name: str,
             *,
-            principal: Optional[str] = None,
-            **kwargs) -> PermissionsList:
+            principal: Optional[str] = None) -> PermissionsList:
         """Get permissions.
         
         Gets the permissions for a securable.
@@ -4051,25 +3621,20 @@ class GrantsAPI:
         
         :returns: :class:`PermissionsList`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = GetGrantRequest(full_name=full_name, principal=principal, securable_type=securable_type)
 
         query = {}
-        if principal: query['principal'] = request.principal
+        if principal is not None: query['principal'] = principal
 
-        json = self._api.do(
-            'GET',
-            f'/api/2.1/unity-catalog/permissions/{request.securable_type.value}/{request.full_name}',
-            query=query)
+        json = self._api.do('GET',
+                            f'/api/2.1/unity-catalog/permissions/{securable_type.value}/{full_name}',
+                            query=query)
         return PermissionsList.from_dict(json)
 
     def get_effective(self,
                       securable_type: SecurableType,
                       full_name: str,
                       *,
-                      principal: Optional[str] = None,
-                      **kwargs) -> EffectivePermissionsList:
+                      principal: Optional[str] = None) -> EffectivePermissionsList:
         """Get effective permissions.
         
         Gets the effective permissions for a securable.
@@ -4084,18 +3649,13 @@ class GrantsAPI:
         
         :returns: :class:`EffectivePermissionsList`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = GetEffectiveRequest(full_name=full_name,
-                                          principal=principal,
-                                          securable_type=securable_type)
 
         query = {}
-        if principal: query['principal'] = request.principal
+        if principal is not None: query['principal'] = principal
 
         json = self._api.do(
             'GET',
-            f'/api/2.1/unity-catalog/effective-permissions/{request.securable_type.value}/{request.full_name}',
+            f'/api/2.1/unity-catalog/effective-permissions/{securable_type.value}/{full_name}',
             query=query)
         return EffectivePermissionsList.from_dict(json)
 
@@ -4103,8 +3663,7 @@ class GrantsAPI:
                securable_type: SecurableType,
                full_name: str,
                *,
-               changes: Optional[List[PermissionsChange]] = None,
-               **kwargs) -> PermissionsList:
+               changes: Optional[List[PermissionsChange]] = None) -> PermissionsList:
         """Update permissions.
         
         Updates the permissions for a securable.
@@ -4118,15 +3677,12 @@ class GrantsAPI:
         
         :returns: :class:`PermissionsList`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = UpdatePermissions(changes=changes, full_name=full_name, securable_type=securable_type)
-        body = request.as_dict()
+        body = {}
+        if changes is not None: body['changes'] = [v.as_dict() for v in changes]
 
-        json = self._api.do(
-            'PATCH',
-            f'/api/2.1/unity-catalog/permissions/{request.securable_type.value}/{request.full_name}',
-            body=body)
+        json = self._api.do('PATCH',
+                            f'/api/2.1/unity-catalog/permissions/{securable_type.value}/{full_name}',
+                            body=body)
         return PermissionsList.from_dict(json)
 
 
@@ -4146,7 +3702,7 @@ class MetastoresAPI:
     def __init__(self, api_client):
         self._api = api_client
 
-    def assign(self, metastore_id: str, default_catalog_name: str, workspace_id: int, **kwargs):
+    def assign(self, metastore_id: str, default_catalog_name: str, workspace_id: int):
         """Create an assignment.
         
         Creates a new metastore assignment. If an assignment for the same __workspace_id__ exists, it will be
@@ -4162,20 +3718,12 @@ class MetastoresAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = CreateMetastoreAssignment(default_catalog_name=default_catalog_name,
-                                                metastore_id=metastore_id,
-                                                workspace_id=workspace_id)
-        body = request.as_dict()
-        self._api.do('PUT', f'/api/2.1/unity-catalog/workspaces/{request.workspace_id}/metastore', body=body)
+        body = {}
+        if default_catalog_name is not None: body['default_catalog_name'] = default_catalog_name
+        if metastore_id is not None: body['metastore_id'] = metastore_id
+        self._api.do('PUT', f'/api/2.1/unity-catalog/workspaces/{workspace_id}/metastore', body=body)
 
-    def create(self,
-               name: str,
-               storage_root: str,
-               *,
-               region: Optional[str] = None,
-               **kwargs) -> MetastoreInfo:
+    def create(self, name: str, storage_root: str, *, region: Optional[str] = None) -> MetastoreInfo:
         """Create a metastore.
         
         Creates a new metastore based on a provided name and storage root path.
@@ -4190,10 +3738,10 @@ class MetastoresAPI:
         
         :returns: :class:`MetastoreInfo`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = CreateMetastore(name=name, region=region, storage_root=storage_root)
-        body = request.as_dict()
+        body = {}
+        if name is not None: body['name'] = name
+        if region is not None: body['region'] = region
+        if storage_root is not None: body['storage_root'] = storage_root
 
         json = self._api.do('POST', '/api/2.1/unity-catalog/metastores', body=body)
         return MetastoreInfo.from_dict(json)
@@ -4209,7 +3757,7 @@ class MetastoresAPI:
         json = self._api.do('GET', '/api/2.1/unity-catalog/current-metastore-assignment')
         return MetastoreAssignment.from_dict(json)
 
-    def delete(self, id: str, *, force: Optional[bool] = None, **kwargs):
+    def delete(self, id: str, *, force: Optional[bool] = None):
         """Delete a metastore.
         
         Deletes a metastore. The caller must be a metastore admin.
@@ -4221,17 +3769,12 @@ class MetastoresAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = DeleteMetastoreRequest(force=force, id=id)
 
         query = {}
-        if force: query['force'] = request.force
+        if force is not None: query['force'] = force
+        self._api.do('DELETE', f'/api/2.1/unity-catalog/metastores/{id}', query=query)
 
-        self._api.do('DELETE', f'/api/2.1/unity-catalog/metastores/{request.id}', query=query)
-
-    def enable_optimization(self, metastore_id: str, enable: bool,
-                            **kwargs) -> UpdatePredictiveOptimizationResponse:
+    def enable_optimization(self, metastore_id: str, enable: bool) -> UpdatePredictiveOptimizationResponse:
         """Toggle predictive optimization on the metastore.
         
         Enables or disables predictive optimization on the metastore.
@@ -4243,15 +3786,14 @@ class MetastoresAPI:
         
         :returns: :class:`UpdatePredictiveOptimizationResponse`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = UpdatePredictiveOptimization(enable=enable, metastore_id=metastore_id)
-        body = request.as_dict()
+        body = {}
+        if enable is not None: body['enable'] = enable
+        if metastore_id is not None: body['metastore_id'] = metastore_id
 
         json = self._api.do('PATCH', '/api/2.0/predictive-optimization/service', body=body)
         return UpdatePredictiveOptimizationResponse.from_dict(json)
 
-    def get(self, id: str, **kwargs) -> MetastoreInfo:
+    def get(self, id: str) -> MetastoreInfo:
         """Get a metastore.
         
         Gets a metastore that matches the supplied ID. The caller must be a metastore admin to retrieve this
@@ -4262,11 +3804,8 @@ class MetastoresAPI:
         
         :returns: :class:`MetastoreInfo`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = GetMetastoreRequest(id=id)
 
-        json = self._api.do('GET', f'/api/2.1/unity-catalog/metastores/{request.id}')
+        json = self._api.do('GET', f'/api/2.1/unity-catalog/metastores/{id}')
         return MetastoreInfo.from_dict(json)
 
     def list(self) -> Iterator[MetastoreInfo]:
@@ -4293,7 +3832,7 @@ class MetastoresAPI:
         json = self._api.do('GET', '/api/2.1/unity-catalog/metastore_summary')
         return GetMetastoreSummaryResponse.from_dict(json)
 
-    def unassign(self, workspace_id: int, metastore_id: str, **kwargs):
+    def unassign(self, workspace_id: int, metastore_id: str):
         """Delete an assignment.
         
         Deletes a metastore assignment. The caller must be an account administrator.
@@ -4305,16 +3844,10 @@ class MetastoresAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = UnassignRequest(metastore_id=metastore_id, workspace_id=workspace_id)
 
         query = {}
-        if metastore_id: query['metastore_id'] = request.metastore_id
-
-        self._api.do('DELETE',
-                     f'/api/2.1/unity-catalog/workspaces/{request.workspace_id}/metastore',
-                     query=query)
+        if metastore_id is not None: query['metastore_id'] = metastore_id
+        self._api.do('DELETE', f'/api/2.1/unity-catalog/workspaces/{workspace_id}/metastore', query=query)
 
     def update(self,
                id: str,
@@ -4325,8 +3858,7 @@ class MetastoresAPI:
                name: Optional[str] = None,
                owner: Optional[str] = None,
                privilege_model_version: Optional[str] = None,
-               storage_root_credential_id: Optional[str] = None,
-               **kwargs) -> MetastoreInfo:
+               storage_root_credential_id: Optional[str] = None) -> MetastoreInfo:
         """Update a metastore.
         
         Updates information for a specific metastore. The caller must be a metastore admin.
@@ -4351,28 +3883,27 @@ class MetastoresAPI:
         
         :returns: :class:`MetastoreInfo`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = UpdateMetastore(
-                delta_sharing_organization_name=delta_sharing_organization_name,
-                delta_sharing_recipient_token_lifetime_in_seconds=delta_sharing_recipient_token_lifetime_in_seconds,
-                delta_sharing_scope=delta_sharing_scope,
-                id=id,
-                name=name,
-                owner=owner,
-                privilege_model_version=privilege_model_version,
-                storage_root_credential_id=storage_root_credential_id)
-        body = request.as_dict()
+        body = {}
+        if delta_sharing_organization_name is not None:
+            body['delta_sharing_organization_name'] = delta_sharing_organization_name
+        if delta_sharing_recipient_token_lifetime_in_seconds is not None:
+            body[
+                'delta_sharing_recipient_token_lifetime_in_seconds'] = delta_sharing_recipient_token_lifetime_in_seconds
+        if delta_sharing_scope is not None: body['delta_sharing_scope'] = delta_sharing_scope.value
+        if name is not None: body['name'] = name
+        if owner is not None: body['owner'] = owner
+        if privilege_model_version is not None: body['privilege_model_version'] = privilege_model_version
+        if storage_root_credential_id is not None:
+            body['storage_root_credential_id'] = storage_root_credential_id
 
-        json = self._api.do('PATCH', f'/api/2.1/unity-catalog/metastores/{request.id}', body=body)
+        json = self._api.do('PATCH', f'/api/2.1/unity-catalog/metastores/{id}', body=body)
         return MetastoreInfo.from_dict(json)
 
     def update_assignment(self,
                           workspace_id: int,
                           *,
                           default_catalog_name: Optional[str] = None,
-                          metastore_id: Optional[str] = None,
-                          **kwargs):
+                          metastore_id: Optional[str] = None):
         """Update an assignment.
         
         Updates a metastore assignment. This operation can be used to update __metastore_id__ or
@@ -4389,15 +3920,10 @@ class MetastoresAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = UpdateMetastoreAssignment(default_catalog_name=default_catalog_name,
-                                                metastore_id=metastore_id,
-                                                workspace_id=workspace_id)
-        body = request.as_dict()
-        self._api.do('PATCH',
-                     f'/api/2.1/unity-catalog/workspaces/{request.workspace_id}/metastore',
-                     body=body)
+        body = {}
+        if default_catalog_name is not None: body['default_catalog_name'] = default_catalog_name
+        if metastore_id is not None: body['metastore_id'] = metastore_id
+        self._api.do('PATCH', f'/api/2.1/unity-catalog/workspaces/{workspace_id}/metastore', body=body)
 
 
 class SchemasAPI:
@@ -4415,8 +3941,7 @@ class SchemasAPI:
                *,
                comment: Optional[str] = None,
                properties: Optional[Dict[str, str]] = None,
-               storage_root: Optional[str] = None,
-               **kwargs) -> SchemaInfo:
+               storage_root: Optional[str] = None) -> SchemaInfo:
         """Create a schema.
         
         Creates a new schema for catalog in the Metatastore. The caller must be a metastore admin, or have the
@@ -4435,19 +3960,17 @@ class SchemasAPI:
         
         :returns: :class:`SchemaInfo`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = CreateSchema(catalog_name=catalog_name,
-                                   comment=comment,
-                                   name=name,
-                                   properties=properties,
-                                   storage_root=storage_root)
-        body = request.as_dict()
+        body = {}
+        if catalog_name is not None: body['catalog_name'] = catalog_name
+        if comment is not None: body['comment'] = comment
+        if name is not None: body['name'] = name
+        if properties is not None: body['properties'] = properties
+        if storage_root is not None: body['storage_root'] = storage_root
 
         json = self._api.do('POST', '/api/2.1/unity-catalog/schemas', body=body)
         return SchemaInfo.from_dict(json)
 
-    def delete(self, full_name: str, **kwargs):
+    def delete(self, full_name: str):
         """Delete a schema.
         
         Deletes the specified schema from the parent catalog. The caller must be the owner of the schema or an
@@ -4458,13 +3981,10 @@ class SchemasAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = DeleteSchemaRequest(full_name=full_name)
 
-        self._api.do('DELETE', f'/api/2.1/unity-catalog/schemas/{request.full_name}')
+        self._api.do('DELETE', f'/api/2.1/unity-catalog/schemas/{full_name}')
 
-    def get(self, full_name: str, **kwargs) -> SchemaInfo:
+    def get(self, full_name: str) -> SchemaInfo:
         """Get a schema.
         
         Gets the specified schema within the metastore. The caller must be a metastore admin, the owner of the
@@ -4475,14 +3995,11 @@ class SchemasAPI:
         
         :returns: :class:`SchemaInfo`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = GetSchemaRequest(full_name=full_name)
 
-        json = self._api.do('GET', f'/api/2.1/unity-catalog/schemas/{request.full_name}')
+        json = self._api.do('GET', f'/api/2.1/unity-catalog/schemas/{full_name}')
         return SchemaInfo.from_dict(json)
 
-    def list(self, catalog_name: str, **kwargs) -> Iterator[SchemaInfo]:
+    def list(self, catalog_name: str) -> Iterator[SchemaInfo]:
         """List schemas.
         
         Gets an array of schemas for a catalog in the metastore. If the caller is the metastore admin or the
@@ -4495,12 +4012,9 @@ class SchemasAPI:
         
         :returns: Iterator over :class:`SchemaInfo`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = ListSchemasRequest(catalog_name=catalog_name)
 
         query = {}
-        if catalog_name: query['catalog_name'] = request.catalog_name
+        if catalog_name is not None: query['catalog_name'] = catalog_name
 
         json = self._api.do('GET', '/api/2.1/unity-catalog/schemas', query=query)
         return [SchemaInfo.from_dict(v) for v in json.get('schemas', [])]
@@ -4511,8 +4025,7 @@ class SchemasAPI:
                comment: Optional[str] = None,
                name: Optional[str] = None,
                owner: Optional[str] = None,
-               properties: Optional[Dict[str, str]] = None,
-               **kwargs) -> SchemaInfo:
+               properties: Optional[Dict[str, str]] = None) -> SchemaInfo:
         """Update a schema.
         
         Updates a schema for a catalog. The caller must be the owner of the schema or a metastore admin. If
@@ -4533,16 +4046,13 @@ class SchemasAPI:
         
         :returns: :class:`SchemaInfo`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = UpdateSchema(comment=comment,
-                                   full_name=full_name,
-                                   name=name,
-                                   owner=owner,
-                                   properties=properties)
-        body = request.as_dict()
+        body = {}
+        if comment is not None: body['comment'] = comment
+        if name is not None: body['name'] = name
+        if owner is not None: body['owner'] = owner
+        if properties is not None: body['properties'] = properties
 
-        json = self._api.do('PATCH', f'/api/2.1/unity-catalog/schemas/{request.full_name}', body=body)
+        json = self._api.do('PATCH', f'/api/2.1/unity-catalog/schemas/{full_name}', body=body)
         return SchemaInfo.from_dict(json)
 
 
@@ -4570,8 +4080,7 @@ class StorageCredentialsAPI:
                comment: Optional[str] = None,
                databricks_gcp_service_account: Optional[Any] = None,
                read_only: Optional[bool] = None,
-               skip_validation: Optional[bool] = None,
-               **kwargs) -> StorageCredentialInfo:
+               skip_validation: Optional[bool] = None) -> StorageCredentialInfo:
         """Create a storage credential.
         
         Creates a new storage credential. The request object is specific to the cloud:
@@ -4602,22 +4111,23 @@ class StorageCredentialsAPI:
         
         :returns: :class:`StorageCredentialInfo`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = CreateStorageCredential(aws_iam_role=aws_iam_role,
-                                              azure_managed_identity=azure_managed_identity,
-                                              azure_service_principal=azure_service_principal,
-                                              comment=comment,
-                                              databricks_gcp_service_account=databricks_gcp_service_account,
-                                              name=name,
-                                              read_only=read_only,
-                                              skip_validation=skip_validation)
-        body = request.as_dict()
+        body = {}
+        if aws_iam_role is not None: body['aws_iam_role'] = aws_iam_role.as_dict()
+        if azure_managed_identity is not None:
+            body['azure_managed_identity'] = azure_managed_identity.as_dict()
+        if azure_service_principal is not None:
+            body['azure_service_principal'] = azure_service_principal.as_dict()
+        if comment is not None: body['comment'] = comment
+        if databricks_gcp_service_account is not None:
+            body['databricks_gcp_service_account'] = databricks_gcp_service_account
+        if name is not None: body['name'] = name
+        if read_only is not None: body['read_only'] = read_only
+        if skip_validation is not None: body['skip_validation'] = skip_validation
 
         json = self._api.do('POST', '/api/2.1/unity-catalog/storage-credentials', body=body)
         return StorageCredentialInfo.from_dict(json)
 
-    def delete(self, name: str, *, force: Optional[bool] = None, **kwargs):
+    def delete(self, name: str, *, force: Optional[bool] = None):
         """Delete a credential.
         
         Deletes a storage credential from the metastore. The caller must be an owner of the storage
@@ -4630,16 +4140,12 @@ class StorageCredentialsAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = DeleteStorageCredentialRequest(force=force, name=name)
 
         query = {}
-        if force: query['force'] = request.force
+        if force is not None: query['force'] = force
+        self._api.do('DELETE', f'/api/2.1/unity-catalog/storage-credentials/{name}', query=query)
 
-        self._api.do('DELETE', f'/api/2.1/unity-catalog/storage-credentials/{request.name}', query=query)
-
-    def get(self, name: str, **kwargs) -> StorageCredentialInfo:
+    def get(self, name: str) -> StorageCredentialInfo:
         """Get a credential.
         
         Gets a storage credential from the metastore. The caller must be a metastore admin, the owner of the
@@ -4650,11 +4156,8 @@ class StorageCredentialsAPI:
         
         :returns: :class:`StorageCredentialInfo`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = GetStorageCredentialRequest(name=name)
 
-        json = self._api.do('GET', f'/api/2.1/unity-catalog/storage-credentials/{request.name}')
+        json = self._api.do('GET', f'/api/2.1/unity-catalog/storage-credentials/{name}')
         return StorageCredentialInfo.from_dict(json)
 
     def list(self) -> Iterator[StorageCredentialInfo]:
@@ -4682,8 +4185,7 @@ class StorageCredentialsAPI:
                force: Optional[bool] = None,
                owner: Optional[str] = None,
                read_only: Optional[bool] = None,
-               skip_validation: Optional[bool] = None,
-               **kwargs) -> StorageCredentialInfo:
+               skip_validation: Optional[bool] = None) -> StorageCredentialInfo:
         """Update a credential.
         
         Updates a storage credential on the metastore. The caller must be the owner of the storage credential
@@ -4713,21 +4215,21 @@ class StorageCredentialsAPI:
         
         :returns: :class:`StorageCredentialInfo`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = UpdateStorageCredential(aws_iam_role=aws_iam_role,
-                                              azure_managed_identity=azure_managed_identity,
-                                              azure_service_principal=azure_service_principal,
-                                              comment=comment,
-                                              databricks_gcp_service_account=databricks_gcp_service_account,
-                                              force=force,
-                                              name=name,
-                                              owner=owner,
-                                              read_only=read_only,
-                                              skip_validation=skip_validation)
-        body = request.as_dict()
+        body = {}
+        if aws_iam_role is not None: body['aws_iam_role'] = aws_iam_role.as_dict()
+        if azure_managed_identity is not None:
+            body['azure_managed_identity'] = azure_managed_identity.as_dict()
+        if azure_service_principal is not None:
+            body['azure_service_principal'] = azure_service_principal.as_dict()
+        if comment is not None: body['comment'] = comment
+        if databricks_gcp_service_account is not None:
+            body['databricks_gcp_service_account'] = databricks_gcp_service_account
+        if force is not None: body['force'] = force
+        if owner is not None: body['owner'] = owner
+        if read_only is not None: body['read_only'] = read_only
+        if skip_validation is not None: body['skip_validation'] = skip_validation
 
-        json = self._api.do('PATCH', f'/api/2.1/unity-catalog/storage-credentials/{request.name}', body=body)
+        json = self._api.do('PATCH', f'/api/2.1/unity-catalog/storage-credentials/{name}', body=body)
         return StorageCredentialInfo.from_dict(json)
 
     def validate(self,
@@ -4739,8 +4241,7 @@ class StorageCredentialsAPI:
                  external_location_name: Optional[str] = None,
                  read_only: Optional[bool] = None,
                  storage_credential_name: Optional[Any] = None,
-                 url: Optional[str] = None,
-                 **kwargs) -> ValidateStorageCredentialResponse:
+                 url: Optional[str] = None) -> ValidateStorageCredentialResponse:
         """Validate a storage credential.
         
         Validates a storage credential. At least one of __external_location_name__ and __url__ need to be
@@ -4772,17 +4273,18 @@ class StorageCredentialsAPI:
         
         :returns: :class:`ValidateStorageCredentialResponse`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = ValidateStorageCredential(aws_iam_role=aws_iam_role,
-                                                azure_managed_identity=azure_managed_identity,
-                                                azure_service_principal=azure_service_principal,
-                                                databricks_gcp_service_account=databricks_gcp_service_account,
-                                                external_location_name=external_location_name,
-                                                read_only=read_only,
-                                                storage_credential_name=storage_credential_name,
-                                                url=url)
-        body = request.as_dict()
+        body = {}
+        if aws_iam_role is not None: body['aws_iam_role'] = aws_iam_role.as_dict()
+        if azure_managed_identity is not None:
+            body['azure_managed_identity'] = azure_managed_identity.as_dict()
+        if azure_service_principal is not None:
+            body['azure_service_principal'] = azure_service_principal.as_dict()
+        if databricks_gcp_service_account is not None:
+            body['databricks_gcp_service_account'] = databricks_gcp_service_account
+        if external_location_name is not None: body['external_location_name'] = external_location_name
+        if read_only is not None: body['read_only'] = read_only
+        if storage_credential_name is not None: body['storage_credential_name'] = storage_credential_name
+        if url is not None: body['url'] = url
 
         json = self._api.do('POST', '/api/2.1/unity-catalog/validate-storage-credentials', body=body)
         return ValidateStorageCredentialResponse.from_dict(json)
@@ -4795,7 +4297,7 @@ class SystemSchemasAPI:
     def __init__(self, api_client):
         self._api = api_client
 
-    def disable(self, metastore_id: str, schema_name: DisableSchemaName, **kwargs):
+    def disable(self, metastore_id: str, schema_name: DisableSchemaName):
         """Disable a system schema.
         
         Disables the system schema and removes it from the system catalog. The caller must be an account admin
@@ -4808,16 +4310,11 @@ class SystemSchemasAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = DisableRequest(metastore_id=metastore_id, schema_name=schema_name)
 
-        self._api.do(
-            'DELETE',
-            f'/api/2.1/unity-catalog/metastores/{request.metastore_id}/systemschemas/{request.schema_name.value}'
-        )
+        self._api.do('DELETE',
+                     f'/api/2.1/unity-catalog/metastores/{metastore_id}/systemschemas/{schema_name.value}')
 
-    def enable(self, metastore_id: str, schema_name: EnableSchemaName, **kwargs):
+    def enable(self, metastore_id: str, schema_name: EnableSchemaName):
         """Enable a system schema.
         
         Enables the system schema and adds it to the system catalog. The caller must be an account admin or a
@@ -4830,16 +4327,11 @@ class SystemSchemasAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = EnableRequest(metastore_id=metastore_id, schema_name=schema_name)
 
-        self._api.do(
-            'PUT',
-            f'/api/2.1/unity-catalog/metastores/{request.metastore_id}/systemschemas/{request.schema_name.value}'
-        )
+        self._api.do('PUT',
+                     f'/api/2.1/unity-catalog/metastores/{metastore_id}/systemschemas/{schema_name.value}')
 
-    def list(self, metastore_id: str, **kwargs) -> Iterator[SystemSchemaInfo]:
+    def list(self, metastore_id: str) -> Iterator[SystemSchemaInfo]:
         """List system schemas.
         
         Gets an array of system schemas for a metastore. The caller must be an account admin or a metastore
@@ -4850,11 +4342,8 @@ class SystemSchemasAPI:
         
         :returns: Iterator over :class:`SystemSchemaInfo`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = ListSystemSchemasRequest(metastore_id=metastore_id)
 
-        json = self._api.do('GET', f'/api/2.1/unity-catalog/metastores/{request.metastore_id}/systemschemas')
+        json = self._api.do('GET', f'/api/2.1/unity-catalog/metastores/{metastore_id}/systemschemas')
         return [SystemSchemaInfo.from_dict(v) for v in json.get('schemas', [])]
 
 
@@ -4873,7 +4362,7 @@ class TableConstraintsAPI:
     def __init__(self, api_client):
         self._api = api_client
 
-    def create(self, full_name_arg: str, constraint: TableConstraint, **kwargs) -> TableConstraint:
+    def create(self, full_name_arg: str, constraint: TableConstraint) -> TableConstraint:
         """Create a table constraint.
         
         Creates a new table constraint.
@@ -4893,15 +4382,14 @@ class TableConstraintsAPI:
         
         :returns: :class:`TableConstraint`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = CreateTableConstraint(constraint=constraint, full_name_arg=full_name_arg)
-        body = request.as_dict()
+        body = {}
+        if constraint is not None: body['constraint'] = constraint.as_dict()
+        if full_name_arg is not None: body['full_name_arg'] = full_name_arg
 
         json = self._api.do('POST', '/api/2.1/unity-catalog/constraints', body=body)
         return TableConstraint.from_dict(json)
 
-    def delete(self, full_name: str, constraint_name: str, cascade: bool, **kwargs):
+    def delete(self, full_name: str, constraint_name: str, cascade: bool):
         """Delete a table constraint.
         
         Deletes a table constraint.
@@ -4923,17 +4411,11 @@ class TableConstraintsAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = DeleteTableConstraintRequest(cascade=cascade,
-                                                   constraint_name=constraint_name,
-                                                   full_name=full_name)
 
         query = {}
-        if cascade: query['cascade'] = request.cascade
-        if constraint_name: query['constraint_name'] = request.constraint_name
-
-        self._api.do('DELETE', f'/api/2.1/unity-catalog/constraints/{request.full_name}', query=query)
+        if cascade is not None: query['cascade'] = cascade
+        if constraint_name is not None: query['constraint_name'] = constraint_name
+        self._api.do('DELETE', f'/api/2.1/unity-catalog/constraints/{full_name}', query=query)
 
 
 class TablesAPI:
@@ -4949,7 +4431,7 @@ class TablesAPI:
     def __init__(self, api_client):
         self._api = api_client
 
-    def delete(self, full_name: str, **kwargs):
+    def delete(self, full_name: str):
         """Delete a table.
         
         Deletes a table from the specified parent catalog and schema. The caller must be the owner of the
@@ -4962,13 +4444,10 @@ class TablesAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = DeleteTableRequest(full_name=full_name)
 
-        self._api.do('DELETE', f'/api/2.1/unity-catalog/tables/{request.full_name}')
+        self._api.do('DELETE', f'/api/2.1/unity-catalog/tables/{full_name}')
 
-    def get(self, full_name: str, *, include_delta_metadata: Optional[bool] = None, **kwargs) -> TableInfo:
+    def get(self, full_name: str, *, include_delta_metadata: Optional[bool] = None) -> TableInfo:
         """Get a table.
         
         Gets a table from the metastore for a specific catalog and schema. The caller must be a metastore
@@ -4983,14 +4462,11 @@ class TablesAPI:
         
         :returns: :class:`TableInfo`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = GetTableRequest(full_name=full_name, include_delta_metadata=include_delta_metadata)
 
         query = {}
-        if include_delta_metadata: query['include_delta_metadata'] = request.include_delta_metadata
+        if include_delta_metadata is not None: query['include_delta_metadata'] = include_delta_metadata
 
-        json = self._api.do('GET', f'/api/2.1/unity-catalog/tables/{request.full_name}', query=query)
+        json = self._api.do('GET', f'/api/2.1/unity-catalog/tables/{full_name}', query=query)
         return TableInfo.from_dict(json)
 
     def list(self,
@@ -4999,8 +4475,7 @@ class TablesAPI:
              *,
              include_delta_metadata: Optional[bool] = None,
              max_results: Optional[int] = None,
-             page_token: Optional[str] = None,
-             **kwargs) -> Iterator[TableInfo]:
+             page_token: Optional[str] = None) -> Iterator[TableInfo]:
         """List tables.
         
         Gets an array of all tables for the current metastore under the parent catalog and schema. The caller
@@ -5026,20 +4501,13 @@ class TablesAPI:
         
         :returns: Iterator over :class:`TableInfo`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = ListTablesRequest(catalog_name=catalog_name,
-                                        include_delta_metadata=include_delta_metadata,
-                                        max_results=max_results,
-                                        page_token=page_token,
-                                        schema_name=schema_name)
 
         query = {}
-        if catalog_name: query['catalog_name'] = request.catalog_name
-        if include_delta_metadata: query['include_delta_metadata'] = request.include_delta_metadata
-        if max_results: query['max_results'] = request.max_results
-        if page_token: query['page_token'] = request.page_token
-        if schema_name: query['schema_name'] = request.schema_name
+        if catalog_name is not None: query['catalog_name'] = catalog_name
+        if include_delta_metadata is not None: query['include_delta_metadata'] = include_delta_metadata
+        if max_results is not None: query['max_results'] = max_results
+        if page_token is not None: query['page_token'] = page_token
+        if schema_name is not None: query['schema_name'] = schema_name
 
         while True:
             json = self._api.do('GET', '/api/2.1/unity-catalog/tables', query=query)
@@ -5057,8 +4525,7 @@ class TablesAPI:
                        max_results: Optional[int] = None,
                        page_token: Optional[str] = None,
                        schema_name_pattern: Optional[str] = None,
-                       table_name_pattern: Optional[str] = None,
-                       **kwargs) -> Iterator[TableSummary]:
+                       table_name_pattern: Optional[str] = None) -> Iterator[TableSummary]:
         """List table summaries.
         
         Gets an array of summaries for tables for a schema and catalog within the metastore. The table
@@ -5085,20 +4552,13 @@ class TablesAPI:
         
         :returns: Iterator over :class:`TableSummary`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = ListSummariesRequest(catalog_name=catalog_name,
-                                           max_results=max_results,
-                                           page_token=page_token,
-                                           schema_name_pattern=schema_name_pattern,
-                                           table_name_pattern=table_name_pattern)
 
         query = {}
-        if catalog_name: query['catalog_name'] = request.catalog_name
-        if max_results: query['max_results'] = request.max_results
-        if page_token: query['page_token'] = request.page_token
-        if schema_name_pattern: query['schema_name_pattern'] = request.schema_name_pattern
-        if table_name_pattern: query['table_name_pattern'] = request.table_name_pattern
+        if catalog_name is not None: query['catalog_name'] = catalog_name
+        if max_results is not None: query['max_results'] = max_results
+        if page_token is not None: query['page_token'] = page_token
+        if schema_name_pattern is not None: query['schema_name_pattern'] = schema_name_pattern
+        if table_name_pattern is not None: query['table_name_pattern'] = table_name_pattern
 
         while True:
             json = self._api.do('GET', '/api/2.1/unity-catalog/table-summaries', query=query)
@@ -5110,7 +4570,7 @@ class TablesAPI:
                 return
             query['page_token'] = json['next_page_token']
 
-    def update(self, full_name: str, *, owner: Optional[str] = None, **kwargs):
+    def update(self, full_name: str, *, owner: Optional[str] = None):
         """Update a table owner.
         
         Change the owner of the table. The caller must be the owner of the parent catalog, have the
@@ -5124,11 +4584,9 @@ class TablesAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = UpdateTableRequest(full_name=full_name, owner=owner)
-        body = request.as_dict()
-        self._api.do('PATCH', f'/api/2.1/unity-catalog/tables/{request.full_name}', body=body)
+        body = {}
+        if owner is not None: body['owner'] = owner
+        self._api.do('PATCH', f'/api/2.1/unity-catalog/tables/{full_name}', body=body)
 
 
 class VolumesAPI:
@@ -5149,8 +4607,7 @@ class VolumesAPI:
                volume_type: VolumeType,
                *,
                comment: Optional[str] = None,
-               storage_location: Optional[str] = None,
-               **kwargs) -> VolumeInfo:
+               storage_location: Optional[str] = None) -> VolumeInfo:
         """Create a Volume.
         
         Creates a new volume.
@@ -5183,20 +4640,18 @@ class VolumesAPI:
         
         :returns: :class:`VolumeInfo`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = CreateVolumeRequestContent(catalog_name=catalog_name,
-                                                 comment=comment,
-                                                 name=name,
-                                                 schema_name=schema_name,
-                                                 storage_location=storage_location,
-                                                 volume_type=volume_type)
-        body = request.as_dict()
+        body = {}
+        if catalog_name is not None: body['catalog_name'] = catalog_name
+        if comment is not None: body['comment'] = comment
+        if name is not None: body['name'] = name
+        if schema_name is not None: body['schema_name'] = schema_name
+        if storage_location is not None: body['storage_location'] = storage_location
+        if volume_type is not None: body['volume_type'] = volume_type.value
 
         json = self._api.do('POST', '/api/2.1/unity-catalog/volumes', body=body)
         return VolumeInfo.from_dict(json)
 
-    def delete(self, full_name_arg: str, **kwargs):
+    def delete(self, full_name_arg: str):
         """Delete a Volume.
         
         Deletes a volume from the specified parent catalog and schema.
@@ -5210,13 +4665,10 @@ class VolumesAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = DeleteVolumeRequest(full_name_arg=full_name_arg)
 
-        self._api.do('DELETE', f'/api/2.1/unity-catalog/volumes/{request.full_name_arg}')
+        self._api.do('DELETE', f'/api/2.1/unity-catalog/volumes/{full_name_arg}')
 
-    def list(self, catalog_name: str, schema_name: str, **kwargs) -> Iterator[VolumeInfo]:
+    def list(self, catalog_name: str, schema_name: str) -> Iterator[VolumeInfo]:
         """List Volumes.
         
         Gets an array of all volumes for the current metastore under the parent catalog and schema.
@@ -5236,18 +4688,15 @@ class VolumesAPI:
         
         :returns: Iterator over :class:`VolumeInfo`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = ListVolumesRequest(catalog_name=catalog_name, schema_name=schema_name)
 
         query = {}
-        if catalog_name: query['catalog_name'] = request.catalog_name
-        if schema_name: query['schema_name'] = request.schema_name
+        if catalog_name is not None: query['catalog_name'] = catalog_name
+        if schema_name is not None: query['schema_name'] = schema_name
 
         json = self._api.do('GET', '/api/2.1/unity-catalog/volumes', query=query)
         return [VolumeInfo.from_dict(v) for v in json.get('volumes', [])]
 
-    def read(self, full_name_arg: str, **kwargs) -> VolumeInfo:
+    def read(self, full_name_arg: str) -> VolumeInfo:
         """Get a Volume.
         
         Gets a volume from the metastore for a specific catalog and schema.
@@ -5261,11 +4710,8 @@ class VolumesAPI:
         
         :returns: :class:`VolumeInfo`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = ReadVolumeRequest(full_name_arg=full_name_arg)
 
-        json = self._api.do('GET', f'/api/2.1/unity-catalog/volumes/{request.full_name_arg}')
+        json = self._api.do('GET', f'/api/2.1/unity-catalog/volumes/{full_name_arg}')
         return VolumeInfo.from_dict(json)
 
     def update(self,
@@ -5273,8 +4719,7 @@ class VolumesAPI:
                *,
                comment: Optional[str] = None,
                name: Optional[str] = None,
-               owner: Optional[str] = None,
-               **kwargs) -> VolumeInfo:
+               owner: Optional[str] = None) -> VolumeInfo:
         """Update a Volume.
         
         Updates the specified volume under the specified parent catalog and schema.
@@ -5296,15 +4741,12 @@ class VolumesAPI:
         
         :returns: :class:`VolumeInfo`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = UpdateVolumeRequestContent(comment=comment,
-                                                 full_name_arg=full_name_arg,
-                                                 name=name,
-                                                 owner=owner)
-        body = request.as_dict()
+        body = {}
+        if comment is not None: body['comment'] = comment
+        if name is not None: body['name'] = name
+        if owner is not None: body['owner'] = owner
 
-        json = self._api.do('PATCH', f'/api/2.1/unity-catalog/volumes/{request.full_name_arg}', body=body)
+        json = self._api.do('PATCH', f'/api/2.1/unity-catalog/volumes/{full_name_arg}', body=body)
         return VolumeInfo.from_dict(json)
 
 
@@ -5317,7 +4759,7 @@ class WorkspaceBindingsAPI:
     def __init__(self, api_client):
         self._api = api_client
 
-    def get(self, name: str, **kwargs) -> CurrentWorkspaceBindings:
+    def get(self, name: str) -> CurrentWorkspaceBindings:
         """Get catalog workspace bindings.
         
         Gets workspace bindings of the catalog. The caller must be a metastore admin or an owner of the
@@ -5328,19 +4770,15 @@ class WorkspaceBindingsAPI:
         
         :returns: :class:`CurrentWorkspaceBindings`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = GetWorkspaceBindingRequest(name=name)
 
-        json = self._api.do('GET', f'/api/2.1/unity-catalog/workspace-bindings/catalogs/{request.name}')
+        json = self._api.do('GET', f'/api/2.1/unity-catalog/workspace-bindings/catalogs/{name}')
         return CurrentWorkspaceBindings.from_dict(json)
 
     def update(self,
                name: str,
                *,
                assign_workspaces: Optional[List[int]] = None,
-               unassign_workspaces: Optional[List[int]] = None,
-               **kwargs) -> CurrentWorkspaceBindings:
+               unassign_workspaces: Optional[List[int]] = None) -> CurrentWorkspaceBindings:
         """Update catalog workspace bindings.
         
         Updates workspace bindings of the catalog. The caller must be a metastore admin or an owner of the
@@ -5355,14 +4793,9 @@ class WorkspaceBindingsAPI:
         
         :returns: :class:`CurrentWorkspaceBindings`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = UpdateWorkspaceBindings(assign_workspaces=assign_workspaces,
-                                              name=name,
-                                              unassign_workspaces=unassign_workspaces)
-        body = request.as_dict()
+        body = {}
+        if assign_workspaces is not None: body['assign_workspaces'] = [v for v in assign_workspaces]
+        if unassign_workspaces is not None: body['unassign_workspaces'] = [v for v in unassign_workspaces]
 
-        json = self._api.do('PATCH',
-                            f'/api/2.1/unity-catalog/workspace-bindings/catalogs/{request.name}',
-                            body=body)
+        json = self._api.do('PATCH', f'/api/2.1/unity-catalog/workspace-bindings/catalogs/{name}', body=body)
         return CurrentWorkspaceBindings.from_dict(json)

--- a/databricks/sdk/service/compute.py
+++ b/databricks/sdk/service/compute.py
@@ -633,13 +633,6 @@ class ClusterSpec:
 
 
 @dataclass
-class ClusterStatusRequest:
-    """Get status"""
-
-    cluster_id: str
-
-
-@dataclass
 class Command:
     cluster_id: Optional[str] = None
     command: Optional[str] = None
@@ -670,15 +663,6 @@ class CommandStatus(Enum):
     FINISHED = 'Finished'
     QUEUED = 'Queued'
     RUNNING = 'Running'
-
-
-@dataclass
-class CommandStatusRequest:
-    """Get command info"""
-
-    cluster_id: str
-    context_id: str
-    command_id: str
 
 
 @dataclass
@@ -726,14 +710,6 @@ class ContextStatus(Enum):
     ERROR = 'Error'
     PENDING = 'Pending'
     RUNNING = 'Running'
-
-
-@dataclass
-class ContextStatusRequest:
-    """Get status"""
-
-    cluster_id: str
-    context_id: str
 
 
 @dataclass
@@ -1083,13 +1059,6 @@ class DeleteCluster:
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'DeleteCluster':
         return cls(cluster_id=d.get('cluster_id', None))
-
-
-@dataclass
-class DeleteGlobalInitScriptRequest:
-    """Delete init script"""
-
-    script_id: str
 
 
 @dataclass
@@ -1652,20 +1621,6 @@ class GcpAvailability(Enum):
 
 
 @dataclass
-class GetClusterPolicyRequest:
-    """Get entity"""
-
-    policy_id: str
-
-
-@dataclass
-class GetClusterRequest:
-    """Get cluster info"""
-
-    cluster_id: str
-
-
-@dataclass
 class GetEvents:
     cluster_id: str
     end_time: Optional[int] = None
@@ -1722,13 +1677,6 @@ class GetEventsResponse:
         return cls(events=_repeated(d, 'events', ClusterEvent),
                    next_page=_from_dict(d, 'next_page', GetEvents),
                    total_count=d.get('total_count', None))
-
-
-@dataclass
-class GetGlobalInitScriptRequest:
-    """Get an init script"""
-
-    script_id: str
 
 
 @dataclass
@@ -1802,20 +1750,6 @@ class GetInstancePool:
                    state=_enum(d, 'state', InstancePoolState),
                    stats=_from_dict(d, 'stats', InstancePoolStats),
                    status=_from_dict(d, 'status', InstancePoolStatus))
-
-
-@dataclass
-class GetInstancePoolRequest:
-    """Get instance pool information"""
-
-    instance_pool_id: str
-
-
-@dataclass
-class GetPolicyFamilyRequest:
-    """Get policy family information"""
-
-    policy_family_id: str
 
 
 @dataclass
@@ -2330,21 +2264,6 @@ class ListAvailableZonesResponse:
 
 
 @dataclass
-class ListClusterPoliciesRequest:
-    """Get a cluster policy"""
-
-    sort_column: Optional['ListSortColumn'] = None
-    sort_order: Optional['ListSortOrder'] = None
-
-
-@dataclass
-class ListClustersRequest:
-    """List all clusters"""
-
-    can_use_client: Optional[str] = None
-
-
-@dataclass
 class ListClustersResponse:
     clusters: Optional['List[ClusterDetails]'] = None
 
@@ -2426,14 +2345,6 @@ class ListPoliciesResponse:
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'ListPoliciesResponse':
         return cls(policies=_repeated(d, 'policies', Policy))
-
-
-@dataclass
-class ListPolicyFamiliesRequest:
-    """List policy families"""
-
-    max_results: Optional[int] = None
-    page_token: Optional[str] = None
 
 
 @dataclass
@@ -3192,8 +3103,7 @@ class ClusterPoliciesAPI:
                description: Optional[str] = None,
                max_clusters_per_user: Optional[int] = None,
                policy_family_definition_overrides: Optional[str] = None,
-               policy_family_id: Optional[str] = None,
-               **kwargs) -> CreatePolicyResponse:
+               policy_family_id: Optional[str] = None) -> CreatePolicyResponse:
         """Create a new policy.
         
         Creates a new policy with prescribed settings.
@@ -3223,20 +3133,19 @@ class ClusterPoliciesAPI:
         
         :returns: :class:`CreatePolicyResponse`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = CreatePolicy(definition=definition,
-                                   description=description,
-                                   max_clusters_per_user=max_clusters_per_user,
-                                   name=name,
-                                   policy_family_definition_overrides=policy_family_definition_overrides,
-                                   policy_family_id=policy_family_id)
-        body = request.as_dict()
+        body = {}
+        if definition is not None: body['definition'] = definition
+        if description is not None: body['description'] = description
+        if max_clusters_per_user is not None: body['max_clusters_per_user'] = max_clusters_per_user
+        if name is not None: body['name'] = name
+        if policy_family_definition_overrides is not None:
+            body['policy_family_definition_overrides'] = policy_family_definition_overrides
+        if policy_family_id is not None: body['policy_family_id'] = policy_family_id
 
         json = self._api.do('POST', '/api/2.0/policies/clusters/create', body=body)
         return CreatePolicyResponse.from_dict(json)
 
-    def delete(self, policy_id: str, **kwargs):
+    def delete(self, policy_id: str):
         """Delete a cluster policy.
         
         Delete a policy for a cluster. Clusters governed by this policy can still run, but cannot be edited.
@@ -3246,10 +3155,8 @@ class ClusterPoliciesAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = DeletePolicy(policy_id=policy_id)
-        body = request.as_dict()
+        body = {}
+        if policy_id is not None: body['policy_id'] = policy_id
         self._api.do('POST', '/api/2.0/policies/clusters/delete', body=body)
 
     def edit(self,
@@ -3260,8 +3167,7 @@ class ClusterPoliciesAPI:
              description: Optional[str] = None,
              max_clusters_per_user: Optional[int] = None,
              policy_family_definition_overrides: Optional[str] = None,
-             policy_family_id: Optional[str] = None,
-             **kwargs):
+             policy_family_id: Optional[str] = None):
         """Update a cluster policy.
         
         Update an existing policy for cluster. This operation may make some clusters governed by the previous
@@ -3294,19 +3200,18 @@ class ClusterPoliciesAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = EditPolicy(definition=definition,
-                                 description=description,
-                                 max_clusters_per_user=max_clusters_per_user,
-                                 name=name,
-                                 policy_family_definition_overrides=policy_family_definition_overrides,
-                                 policy_family_id=policy_family_id,
-                                 policy_id=policy_id)
-        body = request.as_dict()
+        body = {}
+        if definition is not None: body['definition'] = definition
+        if description is not None: body['description'] = description
+        if max_clusters_per_user is not None: body['max_clusters_per_user'] = max_clusters_per_user
+        if name is not None: body['name'] = name
+        if policy_family_definition_overrides is not None:
+            body['policy_family_definition_overrides'] = policy_family_definition_overrides
+        if policy_family_id is not None: body['policy_family_id'] = policy_family_id
+        if policy_id is not None: body['policy_id'] = policy_id
         self._api.do('POST', '/api/2.0/policies/clusters/edit', body=body)
 
-    def get(self, policy_id: str, **kwargs) -> Policy:
+    def get(self, policy_id: str) -> Policy:
         """Get entity.
         
         Get a cluster policy entity. Creation and editing is available to admins only.
@@ -3316,12 +3221,9 @@ class ClusterPoliciesAPI:
         
         :returns: :class:`Policy`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = GetClusterPolicyRequest(policy_id=policy_id)
 
         query = {}
-        if policy_id: query['policy_id'] = request.policy_id
+        if policy_id is not None: query['policy_id'] = policy_id
 
         json = self._api.do('GET', '/api/2.0/policies/clusters/get', query=query)
         return Policy.from_dict(json)
@@ -3329,8 +3231,7 @@ class ClusterPoliciesAPI:
     def list(self,
              *,
              sort_column: Optional[ListSortColumn] = None,
-             sort_order: Optional[ListSortOrder] = None,
-             **kwargs) -> Iterator[Policy]:
+             sort_order: Optional[ListSortOrder] = None) -> Iterator[Policy]:
         """Get a cluster policy.
         
         Returns a list of policies accessible by the requesting user.
@@ -3344,13 +3245,10 @@ class ClusterPoliciesAPI:
         
         :returns: Iterator over :class:`Policy`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = ListClusterPoliciesRequest(sort_column=sort_column, sort_order=sort_order)
 
         query = {}
-        if sort_column: query['sort_column'] = request.sort_column.value
-        if sort_order: query['sort_order'] = request.sort_order.value
+        if sort_column is not None: query['sort_column'] = sort_column.value
+        if sort_order is not None: query['sort_order'] = sort_order.value
 
         json = self._api.do('GET', '/api/2.0/policies/clusters/list', query=query)
         return [Policy.from_dict(v) for v in json.get('policies', [])]
@@ -3444,7 +3342,7 @@ class ClustersAPI:
             attempt += 1
         raise TimeoutError(f'timed out after {timeout}: {status_message}')
 
-    def change_owner(self, cluster_id: str, owner_username: str, **kwargs):
+    def change_owner(self, cluster_id: str, owner_username: str):
         """Change cluster owner.
         
         Change the owner of the cluster. You must be an admin to perform this operation.
@@ -3456,10 +3354,9 @@ class ClustersAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = ChangeClusterOwner(cluster_id=cluster_id, owner_username=owner_username)
-        body = request.as_dict()
+        body = {}
+        if cluster_id is not None: body['cluster_id'] = cluster_id
+        if owner_username is not None: body['owner_username'] = owner_username
         self._api.do('POST', '/api/2.0/clusters/change-owner', body=body)
 
     def create(self,
@@ -3488,8 +3385,7 @@ class ClustersAPI:
                spark_conf: Optional[Dict[str, str]] = None,
                spark_env_vars: Optional[Dict[str, str]] = None,
                ssh_public_keys: Optional[List[str]] = None,
-               workload_type: Optional[WorkloadType] = None,
-               **kwargs) -> Wait[ClusterDetails]:
+               workload_type: Optional[WorkloadType] = None) -> Wait[ClusterDetails]:
         """Create new cluster.
         
         Creates a new Spark cluster. This method will acquire new instances from the cloud provider if
@@ -3602,34 +3498,34 @@ class ClustersAPI:
           Long-running operation waiter for :class:`ClusterDetails`.
           See :method:wait_get_cluster_running for more details.
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = CreateCluster(apply_policy_default_values=apply_policy_default_values,
-                                    autoscale=autoscale,
-                                    autotermination_minutes=autotermination_minutes,
-                                    aws_attributes=aws_attributes,
-                                    azure_attributes=azure_attributes,
-                                    cluster_log_conf=cluster_log_conf,
-                                    cluster_name=cluster_name,
-                                    cluster_source=cluster_source,
-                                    custom_tags=custom_tags,
-                                    driver_instance_pool_id=driver_instance_pool_id,
-                                    driver_node_type_id=driver_node_type_id,
-                                    enable_elastic_disk=enable_elastic_disk,
-                                    enable_local_disk_encryption=enable_local_disk_encryption,
-                                    gcp_attributes=gcp_attributes,
-                                    init_scripts=init_scripts,
-                                    instance_pool_id=instance_pool_id,
-                                    node_type_id=node_type_id,
-                                    num_workers=num_workers,
-                                    policy_id=policy_id,
-                                    runtime_engine=runtime_engine,
-                                    spark_conf=spark_conf,
-                                    spark_env_vars=spark_env_vars,
-                                    spark_version=spark_version,
-                                    ssh_public_keys=ssh_public_keys,
-                                    workload_type=workload_type)
-        body = request.as_dict()
+        body = {}
+        if apply_policy_default_values is not None:
+            body['apply_policy_default_values'] = apply_policy_default_values
+        if autoscale is not None: body['autoscale'] = autoscale.as_dict()
+        if autotermination_minutes is not None: body['autotermination_minutes'] = autotermination_minutes
+        if aws_attributes is not None: body['aws_attributes'] = aws_attributes.as_dict()
+        if azure_attributes is not None: body['azure_attributes'] = azure_attributes.as_dict()
+        if cluster_log_conf is not None: body['cluster_log_conf'] = cluster_log_conf.as_dict()
+        if cluster_name is not None: body['cluster_name'] = cluster_name
+        if cluster_source is not None: body['cluster_source'] = cluster_source.value
+        if custom_tags is not None: body['custom_tags'] = custom_tags
+        if driver_instance_pool_id is not None: body['driver_instance_pool_id'] = driver_instance_pool_id
+        if driver_node_type_id is not None: body['driver_node_type_id'] = driver_node_type_id
+        if enable_elastic_disk is not None: body['enable_elastic_disk'] = enable_elastic_disk
+        if enable_local_disk_encryption is not None:
+            body['enable_local_disk_encryption'] = enable_local_disk_encryption
+        if gcp_attributes is not None: body['gcp_attributes'] = gcp_attributes.as_dict()
+        if init_scripts is not None: body['init_scripts'] = [v.as_dict() for v in init_scripts]
+        if instance_pool_id is not None: body['instance_pool_id'] = instance_pool_id
+        if node_type_id is not None: body['node_type_id'] = node_type_id
+        if num_workers is not None: body['num_workers'] = num_workers
+        if policy_id is not None: body['policy_id'] = policy_id
+        if runtime_engine is not None: body['runtime_engine'] = runtime_engine.value
+        if spark_conf is not None: body['spark_conf'] = spark_conf
+        if spark_env_vars is not None: body['spark_env_vars'] = spark_env_vars
+        if spark_version is not None: body['spark_version'] = spark_version
+        if ssh_public_keys is not None: body['ssh_public_keys'] = [v for v in ssh_public_keys]
+        if workload_type is not None: body['workload_type'] = workload_type.as_dict()
         op_response = self._api.do('POST', '/api/2.0/clusters/create', body=body)
         return Wait(self.wait_get_cluster_running,
                     response=CreateClusterResponse.from_dict(op_response),
@@ -3690,7 +3586,7 @@ class ClustersAPI:
                            ssh_public_keys=ssh_public_keys,
                            workload_type=workload_type).result(timeout=timeout)
 
-    def delete(self, cluster_id: str, **kwargs) -> Wait[ClusterDetails]:
+    def delete(self, cluster_id: str) -> Wait[ClusterDetails]:
         """Terminate cluster.
         
         Terminates the Spark cluster with the specified ID. The cluster is removed asynchronously. Once the
@@ -3704,12 +3600,10 @@ class ClustersAPI:
           Long-running operation waiter for :class:`ClusterDetails`.
           See :method:wait_get_cluster_terminated for more details.
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = DeleteCluster(cluster_id=cluster_id)
-        body = request.as_dict()
+        body = {}
+        if cluster_id is not None: body['cluster_id'] = cluster_id
         self._api.do('POST', '/api/2.0/clusters/delete', body=body)
-        return Wait(self.wait_get_cluster_terminated, cluster_id=request.cluster_id)
+        return Wait(self.wait_get_cluster_terminated, cluster_id=cluster_id)
 
     def delete_and_wait(self, cluster_id: str, timeout=timedelta(minutes=20)) -> ClusterDetails:
         return self.delete(cluster_id=cluster_id).result(timeout=timeout)
@@ -3744,8 +3638,7 @@ class ClustersAPI:
              spark_conf: Optional[Dict[str, str]] = None,
              spark_env_vars: Optional[Dict[str, str]] = None,
              ssh_public_keys: Optional[List[str]] = None,
-             workload_type: Optional[WorkloadType] = None,
-             **kwargs) -> Wait[ClusterDetails]:
+             workload_type: Optional[WorkloadType] = None) -> Wait[ClusterDetails]:
         """Update cluster configuration.
         
         Updates the configuration of a cluster to match the provided attributes and size. A cluster can be
@@ -3870,40 +3763,40 @@ class ClustersAPI:
           Long-running operation waiter for :class:`ClusterDetails`.
           See :method:wait_get_cluster_running for more details.
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = EditCluster(apply_policy_default_values=apply_policy_default_values,
-                                  autoscale=autoscale,
-                                  autotermination_minutes=autotermination_minutes,
-                                  aws_attributes=aws_attributes,
-                                  azure_attributes=azure_attributes,
-                                  cluster_id=cluster_id,
-                                  cluster_log_conf=cluster_log_conf,
-                                  cluster_name=cluster_name,
-                                  cluster_source=cluster_source,
-                                  custom_tags=custom_tags,
-                                  data_security_mode=data_security_mode,
-                                  docker_image=docker_image,
-                                  driver_instance_pool_id=driver_instance_pool_id,
-                                  driver_node_type_id=driver_node_type_id,
-                                  enable_elastic_disk=enable_elastic_disk,
-                                  enable_local_disk_encryption=enable_local_disk_encryption,
-                                  gcp_attributes=gcp_attributes,
-                                  init_scripts=init_scripts,
-                                  instance_pool_id=instance_pool_id,
-                                  node_type_id=node_type_id,
-                                  num_workers=num_workers,
-                                  policy_id=policy_id,
-                                  runtime_engine=runtime_engine,
-                                  single_user_name=single_user_name,
-                                  spark_conf=spark_conf,
-                                  spark_env_vars=spark_env_vars,
-                                  spark_version=spark_version,
-                                  ssh_public_keys=ssh_public_keys,
-                                  workload_type=workload_type)
-        body = request.as_dict()
+        body = {}
+        if apply_policy_default_values is not None:
+            body['apply_policy_default_values'] = apply_policy_default_values
+        if autoscale is not None: body['autoscale'] = autoscale.as_dict()
+        if autotermination_minutes is not None: body['autotermination_minutes'] = autotermination_minutes
+        if aws_attributes is not None: body['aws_attributes'] = aws_attributes.as_dict()
+        if azure_attributes is not None: body['azure_attributes'] = azure_attributes.as_dict()
+        if cluster_id is not None: body['cluster_id'] = cluster_id
+        if cluster_log_conf is not None: body['cluster_log_conf'] = cluster_log_conf.as_dict()
+        if cluster_name is not None: body['cluster_name'] = cluster_name
+        if cluster_source is not None: body['cluster_source'] = cluster_source.value
+        if custom_tags is not None: body['custom_tags'] = custom_tags
+        if data_security_mode is not None: body['data_security_mode'] = data_security_mode.value
+        if docker_image is not None: body['docker_image'] = docker_image.as_dict()
+        if driver_instance_pool_id is not None: body['driver_instance_pool_id'] = driver_instance_pool_id
+        if driver_node_type_id is not None: body['driver_node_type_id'] = driver_node_type_id
+        if enable_elastic_disk is not None: body['enable_elastic_disk'] = enable_elastic_disk
+        if enable_local_disk_encryption is not None:
+            body['enable_local_disk_encryption'] = enable_local_disk_encryption
+        if gcp_attributes is not None: body['gcp_attributes'] = gcp_attributes.as_dict()
+        if init_scripts is not None: body['init_scripts'] = [v.as_dict() for v in init_scripts]
+        if instance_pool_id is not None: body['instance_pool_id'] = instance_pool_id
+        if node_type_id is not None: body['node_type_id'] = node_type_id
+        if num_workers is not None: body['num_workers'] = num_workers
+        if policy_id is not None: body['policy_id'] = policy_id
+        if runtime_engine is not None: body['runtime_engine'] = runtime_engine.value
+        if single_user_name is not None: body['single_user_name'] = single_user_name
+        if spark_conf is not None: body['spark_conf'] = spark_conf
+        if spark_env_vars is not None: body['spark_env_vars'] = spark_env_vars
+        if spark_version is not None: body['spark_version'] = spark_version
+        if ssh_public_keys is not None: body['ssh_public_keys'] = [v for v in ssh_public_keys]
+        if workload_type is not None: body['workload_type'] = workload_type.as_dict()
         self._api.do('POST', '/api/2.0/clusters/edit', body=body)
-        return Wait(self.wait_get_cluster_running, cluster_id=request.cluster_id)
+        return Wait(self.wait_get_cluster_running, cluster_id=cluster_id)
 
     def edit_and_wait(
         self,
@@ -3976,8 +3869,7 @@ class ClustersAPI:
                limit: Optional[int] = None,
                offset: Optional[int] = None,
                order: Optional[GetEventsOrder] = None,
-               start_time: Optional[int] = None,
-               **kwargs) -> Iterator[ClusterEvent]:
+               start_time: Optional[int] = None) -> Iterator[ClusterEvent]:
         """List cluster activity events.
         
         Retrieves a list of events about the activity of a cluster. This API is paginated. If there are more
@@ -4003,16 +3895,14 @@ class ClustersAPI:
         
         :returns: Iterator over :class:`ClusterEvent`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = GetEvents(cluster_id=cluster_id,
-                                end_time=end_time,
-                                event_types=event_types,
-                                limit=limit,
-                                offset=offset,
-                                order=order,
-                                start_time=start_time)
-        body = request.as_dict()
+        body = {}
+        if cluster_id is not None: body['cluster_id'] = cluster_id
+        if end_time is not None: body['end_time'] = end_time
+        if event_types is not None: body['event_types'] = [v for v in event_types]
+        if limit is not None: body['limit'] = limit
+        if offset is not None: body['offset'] = offset
+        if order is not None: body['order'] = order.value
+        if start_time is not None: body['start_time'] = start_time
 
         while True:
             json = self._api.do('POST', '/api/2.0/clusters/events', body=body)
@@ -4024,7 +3914,7 @@ class ClustersAPI:
                 return
             body = json['next_page']
 
-    def get(self, cluster_id: str, **kwargs) -> ClusterDetails:
+    def get(self, cluster_id: str) -> ClusterDetails:
         """Get cluster info.
         
         Retrieves the information for a cluster given its identifier. Clusters can be described while they are
@@ -4035,17 +3925,14 @@ class ClustersAPI:
         
         :returns: :class:`ClusterDetails`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = GetClusterRequest(cluster_id=cluster_id)
 
         query = {}
-        if cluster_id: query['cluster_id'] = request.cluster_id
+        if cluster_id is not None: query['cluster_id'] = cluster_id
 
         json = self._api.do('GET', '/api/2.0/clusters/get', query=query)
         return ClusterDetails.from_dict(json)
 
-    def list(self, *, can_use_client: Optional[str] = None, **kwargs) -> Iterator[ClusterDetails]:
+    def list(self, *, can_use_client: Optional[str] = None) -> Iterator[ClusterDetails]:
         """List all clusters.
         
         Return information about all pinned clusters, active clusters, up to 200 of the most recently
@@ -4064,12 +3951,9 @@ class ClustersAPI:
         
         :returns: Iterator over :class:`ClusterDetails`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = ListClustersRequest(can_use_client=can_use_client)
 
         query = {}
-        if can_use_client: query['can_use_client'] = request.can_use_client
+        if can_use_client is not None: query['can_use_client'] = can_use_client
 
         json = self._api.do('GET', '/api/2.0/clusters/list', query=query)
         return [ClusterDetails.from_dict(v) for v in json.get('clusters', [])]
@@ -4097,7 +3981,7 @@ class ClustersAPI:
         json = self._api.do('GET', '/api/2.0/clusters/list-zones')
         return ListAvailableZonesResponse.from_dict(json)
 
-    def permanent_delete(self, cluster_id: str, **kwargs):
+    def permanent_delete(self, cluster_id: str):
         """Permanently delete cluster.
         
         Permanently deletes a Spark cluster. This cluster is terminated and resources are asynchronously
@@ -4111,13 +3995,11 @@ class ClustersAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = PermanentDeleteCluster(cluster_id=cluster_id)
-        body = request.as_dict()
+        body = {}
+        if cluster_id is not None: body['cluster_id'] = cluster_id
         self._api.do('POST', '/api/2.0/clusters/permanent-delete', body=body)
 
-    def pin(self, cluster_id: str, **kwargs):
+    def pin(self, cluster_id: str):
         """Pin cluster.
         
         Pinning a cluster ensures that the cluster will always be returned by the ListClusters API. Pinning a
@@ -4128,18 +4010,15 @@ class ClustersAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = PinCluster(cluster_id=cluster_id)
-        body = request.as_dict()
+        body = {}
+        if cluster_id is not None: body['cluster_id'] = cluster_id
         self._api.do('POST', '/api/2.0/clusters/pin', body=body)
 
     def resize(self,
                cluster_id: str,
                *,
                autoscale: Optional[AutoScale] = None,
-               num_workers: Optional[int] = None,
-               **kwargs) -> Wait[ClusterDetails]:
+               num_workers: Optional[int] = None) -> Wait[ClusterDetails]:
         """Resize cluster.
         
         Resizes a cluster to have a desired number of workers. This will fail unless the cluster is in a
@@ -4164,12 +4043,12 @@ class ClustersAPI:
           Long-running operation waiter for :class:`ClusterDetails`.
           See :method:wait_get_cluster_running for more details.
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = ResizeCluster(autoscale=autoscale, cluster_id=cluster_id, num_workers=num_workers)
-        body = request.as_dict()
+        body = {}
+        if autoscale is not None: body['autoscale'] = autoscale.as_dict()
+        if cluster_id is not None: body['cluster_id'] = cluster_id
+        if num_workers is not None: body['num_workers'] = num_workers
         self._api.do('POST', '/api/2.0/clusters/resize', body=body)
-        return Wait(self.wait_get_cluster_running, cluster_id=request.cluster_id)
+        return Wait(self.wait_get_cluster_running, cluster_id=cluster_id)
 
     def resize_and_wait(self,
                         cluster_id: str,
@@ -4180,11 +4059,7 @@ class ClustersAPI:
         return self.resize(autoscale=autoscale, cluster_id=cluster_id,
                            num_workers=num_workers).result(timeout=timeout)
 
-    def restart(self,
-                cluster_id: str,
-                *,
-                restart_user: Optional[str] = None,
-                **kwargs) -> Wait[ClusterDetails]:
+    def restart(self, cluster_id: str, *, restart_user: Optional[str] = None) -> Wait[ClusterDetails]:
         """Restart cluster.
         
         Restarts a Spark cluster with the supplied ID. If the cluster is not currently in a `RUNNING` state,
@@ -4199,12 +4074,11 @@ class ClustersAPI:
           Long-running operation waiter for :class:`ClusterDetails`.
           See :method:wait_get_cluster_running for more details.
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = RestartCluster(cluster_id=cluster_id, restart_user=restart_user)
-        body = request.as_dict()
+        body = {}
+        if cluster_id is not None: body['cluster_id'] = cluster_id
+        if restart_user is not None: body['restart_user'] = restart_user
         self._api.do('POST', '/api/2.0/clusters/restart', body=body)
-        return Wait(self.wait_get_cluster_running, cluster_id=request.cluster_id)
+        return Wait(self.wait_get_cluster_running, cluster_id=cluster_id)
 
     def restart_and_wait(self,
                          cluster_id: str,
@@ -4224,7 +4098,7 @@ class ClustersAPI:
         json = self._api.do('GET', '/api/2.0/clusters/spark-versions')
         return GetSparkVersionsResponse.from_dict(json)
 
-    def start(self, cluster_id: str, **kwargs) -> Wait[ClusterDetails]:
+    def start(self, cluster_id: str) -> Wait[ClusterDetails]:
         """Start terminated cluster.
         
         Starts a terminated Spark cluster with the supplied ID. This works similar to `createCluster` except:
@@ -4241,17 +4115,15 @@ class ClustersAPI:
           Long-running operation waiter for :class:`ClusterDetails`.
           See :method:wait_get_cluster_running for more details.
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = StartCluster(cluster_id=cluster_id)
-        body = request.as_dict()
+        body = {}
+        if cluster_id is not None: body['cluster_id'] = cluster_id
         self._api.do('POST', '/api/2.0/clusters/start', body=body)
-        return Wait(self.wait_get_cluster_running, cluster_id=request.cluster_id)
+        return Wait(self.wait_get_cluster_running, cluster_id=cluster_id)
 
     def start_and_wait(self, cluster_id: str, timeout=timedelta(minutes=20)) -> ClusterDetails:
         return self.start(cluster_id=cluster_id).result(timeout=timeout)
 
-    def unpin(self, cluster_id: str, **kwargs):
+    def unpin(self, cluster_id: str):
         """Unpin cluster.
         
         Unpinning a cluster will allow the cluster to eventually be removed from the ListClusters API.
@@ -4263,10 +4135,8 @@ class ClustersAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = UnpinCluster(cluster_id=cluster_id)
-        body = request.as_dict()
+        body = {}
+        if cluster_id is not None: body['cluster_id'] = cluster_id
         self._api.do('POST', '/api/2.0/clusters/unpin', body=body)
 
 
@@ -4380,8 +4250,7 @@ class CommandExecutionAPI:
                *,
                cluster_id: Optional[str] = None,
                command_id: Optional[str] = None,
-               context_id: Optional[str] = None,
-               **kwargs) -> Wait[CommandStatusResponse]:
+               context_id: Optional[str] = None) -> Wait[CommandStatusResponse]:
         """Cancel a command.
         
         Cancels a currently running command within an execution context.
@@ -4396,15 +4265,15 @@ class CommandExecutionAPI:
           Long-running operation waiter for :class:`CommandStatusResponse`.
           See :method:wait_command_status_command_execution_cancelled for more details.
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = CancelCommand(cluster_id=cluster_id, command_id=command_id, context_id=context_id)
-        body = request.as_dict()
+        body = {}
+        if cluster_id is not None: body['clusterId'] = cluster_id
+        if command_id is not None: body['commandId'] = command_id
+        if context_id is not None: body['contextId'] = context_id
         self._api.do('POST', '/api/1.2/commands/cancel', body=body)
         return Wait(self.wait_command_status_command_execution_cancelled,
-                    cluster_id=request.cluster_id,
-                    command_id=request.command_id,
-                    context_id=request.context_id)
+                    cluster_id=cluster_id,
+                    command_id=command_id,
+                    context_id=context_id)
 
     def cancel_and_wait(
         self,
@@ -4416,8 +4285,7 @@ class CommandExecutionAPI:
         return self.cancel(cluster_id=cluster_id, command_id=command_id,
                            context_id=context_id).result(timeout=timeout)
 
-    def command_status(self, cluster_id: str, context_id: str, command_id: str,
-                       **kwargs) -> CommandStatusResponse:
+    def command_status(self, cluster_id: str, context_id: str, command_id: str) -> CommandStatusResponse:
         """Get command info.
         
         Gets the status of and, if available, the results from a currently executing command.
@@ -4430,21 +4298,16 @@ class CommandExecutionAPI:
         
         :returns: :class:`CommandStatusResponse`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = CommandStatusRequest(cluster_id=cluster_id,
-                                           command_id=command_id,
-                                           context_id=context_id)
 
         query = {}
-        if cluster_id: query['clusterId'] = request.cluster_id
-        if command_id: query['commandId'] = request.command_id
-        if context_id: query['contextId'] = request.context_id
+        if cluster_id is not None: query['clusterId'] = cluster_id
+        if command_id is not None: query['commandId'] = command_id
+        if context_id is not None: query['contextId'] = context_id
 
         json = self._api.do('GET', '/api/1.2/commands/status', query=query)
         return CommandStatusResponse.from_dict(json)
 
-    def context_status(self, cluster_id: str, context_id: str, **kwargs) -> ContextStatusResponse:
+    def context_status(self, cluster_id: str, context_id: str) -> ContextStatusResponse:
         """Get status.
         
         Gets the status for an execution context.
@@ -4454,13 +4317,10 @@ class CommandExecutionAPI:
         
         :returns: :class:`ContextStatusResponse`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = ContextStatusRequest(cluster_id=cluster_id, context_id=context_id)
 
         query = {}
-        if cluster_id: query['clusterId'] = request.cluster_id
-        if context_id: query['contextId'] = request.context_id
+        if cluster_id is not None: query['clusterId'] = cluster_id
+        if context_id is not None: query['contextId'] = context_id
 
         json = self._api.do('GET', '/api/1.2/contexts/status', query=query)
         return ContextStatusResponse.from_dict(json)
@@ -4468,8 +4328,7 @@ class CommandExecutionAPI:
     def create(self,
                *,
                cluster_id: Optional[str] = None,
-               language: Optional[Language] = None,
-               **kwargs) -> Wait[ContextStatusResponse]:
+               language: Optional[Language] = None) -> Wait[ContextStatusResponse]:
         """Create an execution context.
         
         Creates an execution context for running cluster commands.
@@ -4484,14 +4343,13 @@ class CommandExecutionAPI:
           Long-running operation waiter for :class:`ContextStatusResponse`.
           See :method:wait_context_status_command_execution_running for more details.
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = CreateContext(cluster_id=cluster_id, language=language)
-        body = request.as_dict()
+        body = {}
+        if cluster_id is not None: body['clusterId'] = cluster_id
+        if language is not None: body['language'] = language.value
         op_response = self._api.do('POST', '/api/1.2/contexts/create', body=body)
         return Wait(self.wait_context_status_command_execution_running,
                     response=Created.from_dict(op_response),
-                    cluster_id=request.cluster_id,
+                    cluster_id=cluster_id,
                     context_id=op_response['id'])
 
     def create_and_wait(
@@ -4502,7 +4360,7 @@ class CommandExecutionAPI:
         timeout=timedelta(minutes=20)) -> ContextStatusResponse:
         return self.create(cluster_id=cluster_id, language=language).result(timeout=timeout)
 
-    def destroy(self, cluster_id: str, context_id: str, **kwargs):
+    def destroy(self, cluster_id: str, context_id: str):
         """Delete an execution context.
         
         Deletes an execution context.
@@ -4512,10 +4370,9 @@ class CommandExecutionAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = DestroyContext(cluster_id=cluster_id, context_id=context_id)
-        body = request.as_dict()
+        body = {}
+        if cluster_id is not None: body['clusterId'] = cluster_id
+        if context_id is not None: body['contextId'] = context_id
         self._api.do('POST', '/api/1.2/contexts/destroy', body=body)
 
     def execute(self,
@@ -4523,8 +4380,7 @@ class CommandExecutionAPI:
                 cluster_id: Optional[str] = None,
                 command: Optional[str] = None,
                 context_id: Optional[str] = None,
-                language: Optional[Language] = None,
-                **kwargs) -> Wait[CommandStatusResponse]:
+                language: Optional[Language] = None) -> Wait[CommandStatusResponse]:
         """Run a command.
         
         Runs a cluster command in the given execution context, using the provided language.
@@ -4543,19 +4399,17 @@ class CommandExecutionAPI:
           Long-running operation waiter for :class:`CommandStatusResponse`.
           See :method:wait_command_status_command_execution_finished_or_error for more details.
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = Command(cluster_id=cluster_id,
-                              command=command,
-                              context_id=context_id,
-                              language=language)
-        body = request.as_dict()
+        body = {}
+        if cluster_id is not None: body['clusterId'] = cluster_id
+        if command is not None: body['command'] = command
+        if context_id is not None: body['contextId'] = context_id
+        if language is not None: body['language'] = language.value
         op_response = self._api.do('POST', '/api/1.2/commands/execute', body=body)
         return Wait(self.wait_command_status_command_execution_finished_or_error,
                     response=Created.from_dict(op_response),
-                    cluster_id=request.cluster_id,
+                    cluster_id=cluster_id,
                     command_id=op_response['id'],
-                    context_id=request.context_id)
+                    context_id=context_id)
 
     def execute_and_wait(
         self,
@@ -4586,8 +4440,7 @@ class GlobalInitScriptsAPI:
                script: str,
                *,
                enabled: Optional[bool] = None,
-               position: Optional[int] = None,
-               **kwargs) -> CreateResponse:
+               position: Optional[int] = None) -> CreateResponse:
         """Create init script.
         
         Creates a new global init script in this workspace.
@@ -4611,18 +4464,16 @@ class GlobalInitScriptsAPI:
         
         :returns: :class:`CreateResponse`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = GlobalInitScriptCreateRequest(enabled=enabled,
-                                                    name=name,
-                                                    position=position,
-                                                    script=script)
-        body = request.as_dict()
+        body = {}
+        if enabled is not None: body['enabled'] = enabled
+        if name is not None: body['name'] = name
+        if position is not None: body['position'] = position
+        if script is not None: body['script'] = script
 
         json = self._api.do('POST', '/api/2.0/global-init-scripts', body=body)
         return CreateResponse.from_dict(json)
 
-    def delete(self, script_id: str, **kwargs):
+    def delete(self, script_id: str):
         """Delete init script.
         
         Deletes a global init script.
@@ -4632,13 +4483,10 @@ class GlobalInitScriptsAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = DeleteGlobalInitScriptRequest(script_id=script_id)
 
-        self._api.do('DELETE', f'/api/2.0/global-init-scripts/{request.script_id}')
+        self._api.do('DELETE', f'/api/2.0/global-init-scripts/{script_id}')
 
-    def get(self, script_id: str, **kwargs) -> GlobalInitScriptDetailsWithContent:
+    def get(self, script_id: str) -> GlobalInitScriptDetailsWithContent:
         """Get an init script.
         
         Gets all the details of a script, including its Base64-encoded contents.
@@ -4648,11 +4496,8 @@ class GlobalInitScriptsAPI:
         
         :returns: :class:`GlobalInitScriptDetailsWithContent`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = GetGlobalInitScriptRequest(script_id=script_id)
 
-        json = self._api.do('GET', f'/api/2.0/global-init-scripts/{request.script_id}')
+        json = self._api.do('GET', f'/api/2.0/global-init-scripts/{script_id}')
         return GlobalInitScriptDetailsWithContent.from_dict(json)
 
     def list(self) -> Iterator[GlobalInitScriptDetails]:
@@ -4674,8 +4519,7 @@ class GlobalInitScriptsAPI:
                script_id: str,
                *,
                enabled: Optional[bool] = None,
-               position: Optional[int] = None,
-               **kwargs):
+               position: Optional[int] = None):
         """Update init script.
         
         Updates a global init script, specifying only the fields to change. All fields are optional.
@@ -4702,15 +4546,12 @@ class GlobalInitScriptsAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = GlobalInitScriptUpdateRequest(enabled=enabled,
-                                                    name=name,
-                                                    position=position,
-                                                    script=script,
-                                                    script_id=script_id)
-        body = request.as_dict()
-        self._api.do('PATCH', f'/api/2.0/global-init-scripts/{request.script_id}', body=body)
+        body = {}
+        if enabled is not None: body['enabled'] = enabled
+        if name is not None: body['name'] = name
+        if position is not None: body['position'] = position
+        if script is not None: body['script'] = script
+        self._api.do('PATCH', f'/api/2.0/global-init-scripts/{script_id}', body=body)
 
 
 class InstancePoolsAPI:
@@ -4747,8 +4588,7 @@ class InstancePoolsAPI:
                max_capacity: Optional[int] = None,
                min_idle_instances: Optional[int] = None,
                preloaded_docker_images: Optional[List[DockerImage]] = None,
-               preloaded_spark_versions: Optional[List[str]] = None,
-               **kwargs) -> CreateInstancePoolResponse:
+               preloaded_spark_versions: Optional[List[str]] = None) -> CreateInstancePoolResponse:
         """Create a new instance pool.
         
         Creates a new instance pool using idle and ready-to-use cloud instances.
@@ -4804,29 +4644,30 @@ class InstancePoolsAPI:
         
         :returns: :class:`CreateInstancePoolResponse`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = CreateInstancePool(
-                aws_attributes=aws_attributes,
-                azure_attributes=azure_attributes,
-                custom_tags=custom_tags,
-                disk_spec=disk_spec,
-                enable_elastic_disk=enable_elastic_disk,
-                gcp_attributes=gcp_attributes,
-                idle_instance_autotermination_minutes=idle_instance_autotermination_minutes,
-                instance_pool_fleet_attributes=instance_pool_fleet_attributes,
-                instance_pool_name=instance_pool_name,
-                max_capacity=max_capacity,
-                min_idle_instances=min_idle_instances,
-                node_type_id=node_type_id,
-                preloaded_docker_images=preloaded_docker_images,
-                preloaded_spark_versions=preloaded_spark_versions)
-        body = request.as_dict()
+        body = {}
+        if aws_attributes is not None: body['aws_attributes'] = aws_attributes.as_dict()
+        if azure_attributes is not None: body['azure_attributes'] = azure_attributes.as_dict()
+        if custom_tags is not None: body['custom_tags'] = custom_tags
+        if disk_spec is not None: body['disk_spec'] = disk_spec.as_dict()
+        if enable_elastic_disk is not None: body['enable_elastic_disk'] = enable_elastic_disk
+        if gcp_attributes is not None: body['gcp_attributes'] = gcp_attributes.as_dict()
+        if idle_instance_autotermination_minutes is not None:
+            body['idle_instance_autotermination_minutes'] = idle_instance_autotermination_minutes
+        if instance_pool_fleet_attributes is not None:
+            body['instance_pool_fleet_attributes'] = instance_pool_fleet_attributes.as_dict()
+        if instance_pool_name is not None: body['instance_pool_name'] = instance_pool_name
+        if max_capacity is not None: body['max_capacity'] = max_capacity
+        if min_idle_instances is not None: body['min_idle_instances'] = min_idle_instances
+        if node_type_id is not None: body['node_type_id'] = node_type_id
+        if preloaded_docker_images is not None:
+            body['preloaded_docker_images'] = [v.as_dict() for v in preloaded_docker_images]
+        if preloaded_spark_versions is not None:
+            body['preloaded_spark_versions'] = [v for v in preloaded_spark_versions]
 
         json = self._api.do('POST', '/api/2.0/instance-pools/create', body=body)
         return CreateInstancePoolResponse.from_dict(json)
 
-    def delete(self, instance_pool_id: str, **kwargs):
+    def delete(self, instance_pool_id: str):
         """Delete an instance pool.
         
         Deletes the instance pool permanently. The idle instances in the pool are terminated asynchronously.
@@ -4836,10 +4677,8 @@ class InstancePoolsAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = DeleteInstancePool(instance_pool_id=instance_pool_id)
-        body = request.as_dict()
+        body = {}
+        if instance_pool_id is not None: body['instance_pool_id'] = instance_pool_id
         self._api.do('POST', '/api/2.0/instance-pools/delete', body=body)
 
     def edit(self,
@@ -4858,8 +4697,7 @@ class InstancePoolsAPI:
              max_capacity: Optional[int] = None,
              min_idle_instances: Optional[int] = None,
              preloaded_docker_images: Optional[List[DockerImage]] = None,
-             preloaded_spark_versions: Optional[List[str]] = None,
-             **kwargs):
+             preloaded_spark_versions: Optional[List[str]] = None):
         """Edit an existing instance pool.
         
         Modifies the configuration of an existing instance pool.
@@ -4917,28 +4755,29 @@ class InstancePoolsAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = EditInstancePool(
-                aws_attributes=aws_attributes,
-                azure_attributes=azure_attributes,
-                custom_tags=custom_tags,
-                disk_spec=disk_spec,
-                enable_elastic_disk=enable_elastic_disk,
-                gcp_attributes=gcp_attributes,
-                idle_instance_autotermination_minutes=idle_instance_autotermination_minutes,
-                instance_pool_fleet_attributes=instance_pool_fleet_attributes,
-                instance_pool_id=instance_pool_id,
-                instance_pool_name=instance_pool_name,
-                max_capacity=max_capacity,
-                min_idle_instances=min_idle_instances,
-                node_type_id=node_type_id,
-                preloaded_docker_images=preloaded_docker_images,
-                preloaded_spark_versions=preloaded_spark_versions)
-        body = request.as_dict()
+        body = {}
+        if aws_attributes is not None: body['aws_attributes'] = aws_attributes.as_dict()
+        if azure_attributes is not None: body['azure_attributes'] = azure_attributes.as_dict()
+        if custom_tags is not None: body['custom_tags'] = custom_tags
+        if disk_spec is not None: body['disk_spec'] = disk_spec.as_dict()
+        if enable_elastic_disk is not None: body['enable_elastic_disk'] = enable_elastic_disk
+        if gcp_attributes is not None: body['gcp_attributes'] = gcp_attributes.as_dict()
+        if idle_instance_autotermination_minutes is not None:
+            body['idle_instance_autotermination_minutes'] = idle_instance_autotermination_minutes
+        if instance_pool_fleet_attributes is not None:
+            body['instance_pool_fleet_attributes'] = instance_pool_fleet_attributes.as_dict()
+        if instance_pool_id is not None: body['instance_pool_id'] = instance_pool_id
+        if instance_pool_name is not None: body['instance_pool_name'] = instance_pool_name
+        if max_capacity is not None: body['max_capacity'] = max_capacity
+        if min_idle_instances is not None: body['min_idle_instances'] = min_idle_instances
+        if node_type_id is not None: body['node_type_id'] = node_type_id
+        if preloaded_docker_images is not None:
+            body['preloaded_docker_images'] = [v.as_dict() for v in preloaded_docker_images]
+        if preloaded_spark_versions is not None:
+            body['preloaded_spark_versions'] = [v for v in preloaded_spark_versions]
         self._api.do('POST', '/api/2.0/instance-pools/edit', body=body)
 
-    def get(self, instance_pool_id: str, **kwargs) -> GetInstancePool:
+    def get(self, instance_pool_id: str) -> GetInstancePool:
         """Get instance pool information.
         
         Retrieve the information for an instance pool based on its identifier.
@@ -4948,12 +4787,9 @@ class InstancePoolsAPI:
         
         :returns: :class:`GetInstancePool`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = GetInstancePoolRequest(instance_pool_id=instance_pool_id)
 
         query = {}
-        if instance_pool_id: query['instance_pool_id'] = request.instance_pool_id
+        if instance_pool_id is not None: query['instance_pool_id'] = instance_pool_id
 
         json = self._api.do('GET', '/api/2.0/instance-pools/get', query=query)
         return GetInstancePool.from_dict(json)
@@ -4985,8 +4821,7 @@ class InstanceProfilesAPI:
             *,
             iam_role_arn: Optional[str] = None,
             is_meta_instance_profile: Optional[bool] = None,
-            skip_validation: Optional[bool] = None,
-            **kwargs):
+            skip_validation: Optional[bool] = None):
         """Register an instance profile.
         
         In the UI, you can select the instance profile when launching clusters. This API is only available to
@@ -5016,21 +4851,18 @@ class InstanceProfilesAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = AddInstanceProfile(iam_role_arn=iam_role_arn,
-                                         instance_profile_arn=instance_profile_arn,
-                                         is_meta_instance_profile=is_meta_instance_profile,
-                                         skip_validation=skip_validation)
-        body = request.as_dict()
+        body = {}
+        if iam_role_arn is not None: body['iam_role_arn'] = iam_role_arn
+        if instance_profile_arn is not None: body['instance_profile_arn'] = instance_profile_arn
+        if is_meta_instance_profile is not None: body['is_meta_instance_profile'] = is_meta_instance_profile
+        if skip_validation is not None: body['skip_validation'] = skip_validation
         self._api.do('POST', '/api/2.0/instance-profiles/add', body=body)
 
     def edit(self,
              instance_profile_arn: str,
              *,
              iam_role_arn: Optional[str] = None,
-             is_meta_instance_profile: Optional[bool] = None,
-             **kwargs):
+             is_meta_instance_profile: Optional[bool] = None):
         """Edit an instance profile.
         
         The only supported field to change is the optional IAM role ARN associated with the instance profile.
@@ -5064,12 +4896,10 @@ class InstanceProfilesAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = InstanceProfile(iam_role_arn=iam_role_arn,
-                                      instance_profile_arn=instance_profile_arn,
-                                      is_meta_instance_profile=is_meta_instance_profile)
-        body = request.as_dict()
+        body = {}
+        if iam_role_arn is not None: body['iam_role_arn'] = iam_role_arn
+        if instance_profile_arn is not None: body['instance_profile_arn'] = instance_profile_arn
+        if is_meta_instance_profile is not None: body['is_meta_instance_profile'] = is_meta_instance_profile
         self._api.do('POST', '/api/2.0/instance-profiles/edit', body=body)
 
     def list(self) -> Iterator[InstanceProfile]:
@@ -5085,7 +4915,7 @@ class InstanceProfilesAPI:
         json = self._api.do('GET', '/api/2.0/instance-profiles/list')
         return [InstanceProfile.from_dict(v) for v in json.get('instance_profiles', [])]
 
-    def remove(self, instance_profile_arn: str, **kwargs):
+    def remove(self, instance_profile_arn: str):
         """Remove the instance profile.
         
         Remove the instance profile with the provided ARN. Existing clusters with this instance profile will
@@ -5098,10 +4928,8 @@ class InstanceProfilesAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = RemoveInstanceProfile(instance_profile_arn=instance_profile_arn)
-        body = request.as_dict()
+        body = {}
+        if instance_profile_arn is not None: body['instance_profile_arn'] = instance_profile_arn
         self._api.do('POST', '/api/2.0/instance-profiles/remove', body=body)
 
 
@@ -5139,7 +4967,7 @@ class LibrariesAPI:
         json = self._api.do('GET', '/api/2.0/libraries/all-cluster-statuses')
         return ListAllClusterLibraryStatusesResponse.from_dict(json)
 
-    def cluster_status(self, cluster_id: str, **kwargs) -> ClusterLibraryStatuses:
+    def cluster_status(self, cluster_id: str) -> ClusterLibraryStatuses:
         """Get status.
         
         Get the status of libraries on a cluster. A status will be available for all libraries installed on
@@ -5160,17 +4988,14 @@ class LibrariesAPI:
         
         :returns: :class:`ClusterLibraryStatuses`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = ClusterStatusRequest(cluster_id=cluster_id)
 
         query = {}
-        if cluster_id: query['cluster_id'] = request.cluster_id
+        if cluster_id is not None: query['cluster_id'] = cluster_id
 
         json = self._api.do('GET', '/api/2.0/libraries/cluster-status', query=query)
         return ClusterLibraryStatuses.from_dict(json)
 
-    def install(self, cluster_id: str, libraries: List[Library], **kwargs):
+    def install(self, cluster_id: str, libraries: List[Library]):
         """Add a library.
         
         Add libraries to be installed on a cluster. The installation is asynchronous; it happens in the
@@ -5186,13 +5011,12 @@ class LibrariesAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = InstallLibraries(cluster_id=cluster_id, libraries=libraries)
-        body = request.as_dict()
+        body = {}
+        if cluster_id is not None: body['cluster_id'] = cluster_id
+        if libraries is not None: body['libraries'] = [v.as_dict() for v in libraries]
         self._api.do('POST', '/api/2.0/libraries/install', body=body)
 
-    def uninstall(self, cluster_id: str, libraries: List[Library], **kwargs):
+    def uninstall(self, cluster_id: str, libraries: List[Library]):
         """Uninstall libraries.
         
         Set libraries to be uninstalled on a cluster. The libraries won't be uninstalled until the cluster is
@@ -5206,10 +5030,9 @@ class LibrariesAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = UninstallLibraries(cluster_id=cluster_id, libraries=libraries)
-        body = request.as_dict()
+        body = {}
+        if cluster_id is not None: body['cluster_id'] = cluster_id
+        if libraries is not None: body['libraries'] = [v.as_dict() for v in libraries]
         self._api.do('POST', '/api/2.0/libraries/uninstall', body=body)
 
 
@@ -5227,7 +5050,7 @@ class PolicyFamiliesAPI:
     def __init__(self, api_client):
         self._api = api_client
 
-    def get(self, policy_family_id: str, **kwargs) -> PolicyFamily:
+    def get(self, policy_family_id: str) -> PolicyFamily:
         """Get policy family information.
         
         Retrieve the information for an policy family based on its identifier.
@@ -5236,18 +5059,14 @@ class PolicyFamiliesAPI:
         
         :returns: :class:`PolicyFamily`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = GetPolicyFamilyRequest(policy_family_id=policy_family_id)
 
-        json = self._api.do('GET', f'/api/2.0/policy-families/{request.policy_family_id}')
+        json = self._api.do('GET', f'/api/2.0/policy-families/{policy_family_id}')
         return PolicyFamily.from_dict(json)
 
     def list(self,
              *,
              max_results: Optional[int] = None,
-             page_token: Optional[str] = None,
-             **kwargs) -> Iterator[PolicyFamily]:
+             page_token: Optional[str] = None) -> Iterator[PolicyFamily]:
         """List policy families.
         
         Retrieve a list of policy families. This API is paginated.
@@ -5259,13 +5078,10 @@ class PolicyFamiliesAPI:
         
         :returns: Iterator over :class:`PolicyFamily`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = ListPolicyFamiliesRequest(max_results=max_results, page_token=page_token)
 
         query = {}
-        if max_results: query['max_results'] = request.max_results
-        if page_token: query['page_token'] = request.page_token
+        if max_results is not None: query['max_results'] = max_results
+        if page_token is not None: query['page_token'] = page_token
 
         while True:
             json = self._api.do('GET', '/api/2.0/policy-families', query=query)

--- a/databricks/sdk/service/compute.py
+++ b/databricks/sdk/service/compute.py
@@ -3898,7 +3898,7 @@ class ClustersAPI:
         body = {}
         if cluster_id is not None: body['cluster_id'] = cluster_id
         if end_time is not None: body['end_time'] = end_time
-        if event_types is not None: body['event_types'] = [v for v in event_types]
+        if event_types is not None: body['event_types'] = [v.value for v in event_types]
         if limit is not None: body['limit'] = limit
         if offset is not None: body['offset'] = offset
         if order is not None: body['order'] = order.value

--- a/databricks/sdk/service/files.py
+++ b/databricks/sdk/service/files.py
@@ -111,20 +111,6 @@ class FileInfo:
 
 
 @dataclass
-class GetStatusRequest:
-    """Get the information of a file or directory"""
-
-    path: str
-
-
-@dataclass
-class ListDbfsRequest:
-    """List directory contents or file details"""
-
-    path: str
-
-
-@dataclass
 class ListStatusResponse:
     files: Optional['List[FileInfo]'] = None
 
@@ -189,15 +175,6 @@ class Put:
 
 
 @dataclass
-class ReadDbfsRequest:
-    """Get the contents of a file"""
-
-    path: str
-    length: Optional[int] = None
-    offset: Optional[int] = None
-
-
-@dataclass
 class ReadResponse:
     bytes_read: Optional[int] = None
     data: Optional[str] = None
@@ -220,7 +197,7 @@ class DbfsAPI:
     def __init__(self, api_client):
         self._api = api_client
 
-    def add_block(self, handle: int, data: str, **kwargs):
+    def add_block(self, handle: int, data: str):
         """Append data block.
         
         Appends a block of data to the stream specified by the input handle. If the handle does not exist,
@@ -235,13 +212,12 @@ class DbfsAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = AddBlock(data=data, handle=handle)
-        body = request.as_dict()
+        body = {}
+        if data is not None: body['data'] = data
+        if handle is not None: body['handle'] = handle
         self._api.do('POST', '/api/2.0/dbfs/add-block', body=body)
 
-    def close(self, handle: int, **kwargs):
+    def close(self, handle: int):
         """Close the stream.
         
         Closes the stream specified by the input handle. If the handle does not exist, this call throws an
@@ -252,13 +228,11 @@ class DbfsAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = Close(handle=handle)
-        body = request.as_dict()
+        body = {}
+        if handle is not None: body['handle'] = handle
         self._api.do('POST', '/api/2.0/dbfs/close', body=body)
 
-    def create(self, path: str, *, overwrite: Optional[bool] = None, **kwargs) -> CreateResponse:
+    def create(self, path: str, *, overwrite: Optional[bool] = None) -> CreateResponse:
         """Open a stream.
         
         Opens a stream to write to a file and returns a handle to this stream. There is a 10 minute idle
@@ -277,15 +251,14 @@ class DbfsAPI:
         
         :returns: :class:`CreateResponse`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = Create(overwrite=overwrite, path=path)
-        body = request.as_dict()
+        body = {}
+        if overwrite is not None: body['overwrite'] = overwrite
+        if path is not None: body['path'] = path
 
         json = self._api.do('POST', '/api/2.0/dbfs/create', body=body)
         return CreateResponse.from_dict(json)
 
-    def delete(self, path: str, *, recursive: Optional[bool] = None, **kwargs):
+    def delete(self, path: str, *, recursive: Optional[bool] = None):
         """Delete a file/directory.
         
         Delete the file or directory (optionally recursively delete all files in the directory). This call
@@ -311,13 +284,12 @@ class DbfsAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = Delete(path=path, recursive=recursive)
-        body = request.as_dict()
+        body = {}
+        if path is not None: body['path'] = path
+        if recursive is not None: body['recursive'] = recursive
         self._api.do('POST', '/api/2.0/dbfs/delete', body=body)
 
-    def get_status(self, path: str, **kwargs) -> FileInfo:
+    def get_status(self, path: str) -> FileInfo:
         """Get the information of a file or directory.
         
         Gets the file information for a file or directory. If the file or directory does not exist, this call
@@ -328,17 +300,14 @@ class DbfsAPI:
         
         :returns: :class:`FileInfo`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = GetStatusRequest(path=path)
 
         query = {}
-        if path: query['path'] = request.path
+        if path is not None: query['path'] = path
 
         json = self._api.do('GET', '/api/2.0/dbfs/get-status', query=query)
         return FileInfo.from_dict(json)
 
-    def list(self, path: str, **kwargs) -> Iterator[FileInfo]:
+    def list(self, path: str) -> Iterator[FileInfo]:
         """List directory contents or file details.
         
         List the contents of a directory, or details of the file. If the file or directory does not exist,
@@ -356,17 +325,14 @@ class DbfsAPI:
         
         :returns: Iterator over :class:`FileInfo`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = ListDbfsRequest(path=path)
 
         query = {}
-        if path: query['path'] = request.path
+        if path is not None: query['path'] = path
 
         json = self._api.do('GET', '/api/2.0/dbfs/list', query=query)
         return [FileInfo.from_dict(v) for v in json.get('files', [])]
 
-    def mkdirs(self, path: str, **kwargs):
+    def mkdirs(self, path: str):
         """Create a directory.
         
         Creates the given directory and necessary parent directories if they do not exist. If a file (not a
@@ -379,13 +345,11 @@ class DbfsAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = MkDirs(path=path)
-        body = request.as_dict()
+        body = {}
+        if path is not None: body['path'] = path
         self._api.do('POST', '/api/2.0/dbfs/mkdirs', body=body)
 
-    def move(self, source_path: str, destination_path: str, **kwargs):
+    def move(self, source_path: str, destination_path: str):
         """Move a file.
         
         Moves a file from one location to another location within DBFS. If the source file does not exist,
@@ -400,13 +364,12 @@ class DbfsAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = Move(destination_path=destination_path, source_path=source_path)
-        body = request.as_dict()
+        body = {}
+        if destination_path is not None: body['destination_path'] = destination_path
+        if source_path is not None: body['source_path'] = source_path
         self._api.do('POST', '/api/2.0/dbfs/move', body=body)
 
-    def put(self, path: str, *, contents: Optional[str] = None, overwrite: Optional[bool] = None, **kwargs):
+    def put(self, path: str, *, contents: Optional[str] = None, overwrite: Optional[bool] = None):
         """Upload a file.
         
         Uploads a file through the use of multipart form post. It is mainly used for streaming uploads, but
@@ -429,18 +392,13 @@ class DbfsAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = Put(contents=contents, overwrite=overwrite, path=path)
-        body = request.as_dict()
+        body = {}
+        if contents is not None: body['contents'] = contents
+        if overwrite is not None: body['overwrite'] = overwrite
+        if path is not None: body['path'] = path
         self._api.do('POST', '/api/2.0/dbfs/put', body=body)
 
-    def read(self,
-             path: str,
-             *,
-             length: Optional[int] = None,
-             offset: Optional[int] = None,
-             **kwargs) -> ReadResponse:
+    def read(self, path: str, *, length: Optional[int] = None, offset: Optional[int] = None) -> ReadResponse:
         """Get the contents of a file.
         
         Returns the contents of a file. If the file does not exist, this call throws an exception with
@@ -461,14 +419,11 @@ class DbfsAPI:
         
         :returns: :class:`ReadResponse`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = ReadDbfsRequest(length=length, offset=offset, path=path)
 
         query = {}
-        if length: query['length'] = request.length
-        if offset: query['offset'] = request.offset
-        if path: query['path'] = request.path
+        if length is not None: query['length'] = length
+        if offset is not None: query['offset'] = offset
+        if path is not None: query['path'] = path
 
         json = self._api.do('GET', '/api/2.0/dbfs/read', query=query)
         return ReadResponse.from_dict(json)

--- a/databricks/sdk/service/iam.py
+++ b/databricks/sdk/service/iam.py
@@ -84,84 +84,6 @@ class ComplexValue:
 
 
 @dataclass
-class DeleteAccountGroupRequest:
-    """Delete a group"""
-
-    id: str
-
-
-@dataclass
-class DeleteAccountServicePrincipalRequest:
-    """Delete a service principal"""
-
-    id: str
-
-
-@dataclass
-class DeleteAccountUserRequest:
-    """Delete a user"""
-
-    id: str
-
-
-@dataclass
-class DeleteGroupRequest:
-    """Delete a group"""
-
-    id: str
-
-
-@dataclass
-class DeleteServicePrincipalRequest:
-    """Delete a service principal"""
-
-    id: str
-
-
-@dataclass
-class DeleteUserRequest:
-    """Delete a user"""
-
-    id: str
-
-
-@dataclass
-class DeleteWorkspaceAssignmentRequest:
-    """Delete permissions assignment"""
-
-    workspace_id: int
-    principal_id: int
-
-
-@dataclass
-class GetAccountGroupRequest:
-    """Get group details"""
-
-    id: str
-
-
-@dataclass
-class GetAccountServicePrincipalRequest:
-    """Get service principal details"""
-
-    id: str
-
-
-@dataclass
-class GetAccountUserRequest:
-    """Get user details"""
-
-    id: str
-
-
-@dataclass
-class GetAssignableRolesForResourceRequest:
-    """Get assignable roles for a resource"""
-
-    resource: str
-
-
-@dataclass
 class GetAssignableRolesForResourceResponse:
     roles: Optional['List[str]'] = None
 
@@ -176,21 +98,6 @@ class GetAssignableRolesForResourceResponse:
 
 
 @dataclass
-class GetGroupRequest:
-    """Get group details"""
-
-    id: str
-
-
-@dataclass
-class GetPermissionLevelsRequest:
-    """Get permission levels"""
-
-    request_object_type: str
-    request_object_id: str
-
-
-@dataclass
 class GetPermissionLevelsResponse:
     permission_levels: Optional['List[PermissionsDescription]'] = None
 
@@ -202,43 +109,6 @@ class GetPermissionLevelsResponse:
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'GetPermissionLevelsResponse':
         return cls(permission_levels=_repeated(d, 'permission_levels', PermissionsDescription))
-
-
-@dataclass
-class GetPermissionRequest:
-    """Get object permissions"""
-
-    request_object_type: str
-    request_object_id: str
-
-
-@dataclass
-class GetRuleSetRequest:
-    """Get a rule set"""
-
-    name: str
-    etag: str
-
-
-@dataclass
-class GetServicePrincipalRequest:
-    """Get service principal details"""
-
-    id: str
-
-
-@dataclass
-class GetUserRequest:
-    """Get user details"""
-
-    id: str
-
-
-@dataclass
-class GetWorkspaceAssignmentRequest:
-    """List workspace permissions"""
-
-    workspace_id: int
 
 
 @dataclass
@@ -293,58 +163,6 @@ class Group:
 
 
 @dataclass
-class ListAccountGroupsRequest:
-    """List group details"""
-
-    attributes: Optional[str] = None
-    count: Optional[int] = None
-    excluded_attributes: Optional[str] = None
-    filter: Optional[str] = None
-    sort_by: Optional[str] = None
-    sort_order: Optional['ListSortOrder'] = None
-    start_index: Optional[int] = None
-
-
-@dataclass
-class ListAccountServicePrincipalsRequest:
-    """List service principals"""
-
-    attributes: Optional[str] = None
-    count: Optional[int] = None
-    excluded_attributes: Optional[str] = None
-    filter: Optional[str] = None
-    sort_by: Optional[str] = None
-    sort_order: Optional['ListSortOrder'] = None
-    start_index: Optional[int] = None
-
-
-@dataclass
-class ListAccountUsersRequest:
-    """List users"""
-
-    attributes: Optional[str] = None
-    count: Optional[int] = None
-    excluded_attributes: Optional[str] = None
-    filter: Optional[str] = None
-    sort_by: Optional[str] = None
-    sort_order: Optional['ListSortOrder'] = None
-    start_index: Optional[int] = None
-
-
-@dataclass
-class ListGroupsRequest:
-    """List group details"""
-
-    attributes: Optional[str] = None
-    count: Optional[int] = None
-    excluded_attributes: Optional[str] = None
-    filter: Optional[str] = None
-    sort_by: Optional[str] = None
-    sort_order: Optional['ListSortOrder'] = None
-    start_index: Optional[int] = None
-
-
-@dataclass
 class ListGroupsResponse:
     items_per_page: Optional[int] = None
     resources: Optional['List[Group]'] = None
@@ -390,36 +208,10 @@ class ListServicePrincipalResponse:
                    total_results=d.get('totalResults', None))
 
 
-@dataclass
-class ListServicePrincipalsRequest:
-    """List service principals"""
-
-    attributes: Optional[str] = None
-    count: Optional[int] = None
-    excluded_attributes: Optional[str] = None
-    filter: Optional[str] = None
-    sort_by: Optional[str] = None
-    sort_order: Optional['ListSortOrder'] = None
-    start_index: Optional[int] = None
-
-
 class ListSortOrder(Enum):
 
     ASCENDING = 'ascending'
     DESCENDING = 'descending'
-
-
-@dataclass
-class ListUsersRequest:
-    """List users"""
-
-    attributes: Optional[str] = None
-    count: Optional[int] = None
-    excluded_attributes: Optional[str] = None
-    filter: Optional[str] = None
-    sort_by: Optional[str] = None
-    sort_order: Optional['ListSortOrder'] = None
-    start_index: Optional[int] = None
 
 
 @dataclass
@@ -443,13 +235,6 @@ class ListUsersResponse:
                    resources=_repeated(d, 'Resources', User),
                    start_index=d.get('startIndex', None),
                    total_results=d.get('totalResults', None))
-
-
-@dataclass
-class ListWorkspaceAssignmentRequest:
-    """Get permission assignments"""
-
-    workspace_id: int
 
 
 @dataclass
@@ -892,8 +677,7 @@ class AccountAccessControlAPI:
     def __init__(self, api_client):
         self._api = api_client
 
-    def get_assignable_roles_for_resource(self, resource: str,
-                                          **kwargs) -> GetAssignableRolesForResourceResponse:
+    def get_assignable_roles_for_resource(self, resource: str) -> GetAssignableRolesForResourceResponse:
         """Get assignable roles for a resource.
         
         Gets all the roles that can be granted on an account level resource. A role is grantable if the rule
@@ -904,12 +688,9 @@ class AccountAccessControlAPI:
         
         :returns: :class:`GetAssignableRolesForResourceResponse`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = GetAssignableRolesForResourceRequest(resource=resource)
 
         query = {}
-        if resource: query['resource'] = request.resource
+        if resource is not None: query['resource'] = resource
 
         json = self._api.do(
             'GET',
@@ -917,7 +698,7 @@ class AccountAccessControlAPI:
             query=query)
         return GetAssignableRolesForResourceResponse.from_dict(json)
 
-    def get_rule_set(self, name: str, etag: str, **kwargs) -> RuleSetResponse:
+    def get_rule_set(self, name: str, etag: str) -> RuleSetResponse:
         """Get a rule set.
         
         Get a rule set by its name. A rule set is always attached to a resource and contains a list of access
@@ -935,20 +716,17 @@ class AccountAccessControlAPI:
         
         :returns: :class:`RuleSetResponse`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = GetRuleSetRequest(etag=etag, name=name)
 
         query = {}
-        if etag: query['etag'] = request.etag
-        if name: query['name'] = request.name
+        if etag is not None: query['etag'] = etag
+        if name is not None: query['name'] = name
 
         json = self._api.do('GET',
                             f'/api/2.0/preview/accounts/{self._api.account_id}/access-control/rule-sets',
                             query=query)
         return RuleSetResponse.from_dict(json)
 
-    def update_rule_set(self, name: str, rule_set: RuleSetUpdateRequest, **kwargs) -> RuleSetResponse:
+    def update_rule_set(self, name: str, rule_set: RuleSetUpdateRequest) -> RuleSetResponse:
         """Update a rule set.
         
         Replace the rules of a rule set. First, use get to read the current version of the rule set before
@@ -960,10 +738,9 @@ class AccountAccessControlAPI:
         
         :returns: :class:`RuleSetResponse`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = UpdateRuleSetRequest(name=name, rule_set=rule_set)
-        body = request.as_dict()
+        body = {}
+        if name is not None: body['name'] = name
+        if rule_set is not None: body['rule_set'] = rule_set.as_dict()
 
         json = self._api.do('PUT',
                             f'/api/2.0/preview/accounts/{self._api.account_id}/access-control/rule-sets',
@@ -979,8 +756,7 @@ class AccountAccessControlProxyAPI:
     def __init__(self, api_client):
         self._api = api_client
 
-    def get_assignable_roles_for_resource(self, resource: str,
-                                          **kwargs) -> GetAssignableRolesForResourceResponse:
+    def get_assignable_roles_for_resource(self, resource: str) -> GetAssignableRolesForResourceResponse:
         """Get assignable roles for a resource.
         
         Gets all the roles that can be granted on an account-level resource. A role is grantable if the rule
@@ -991,17 +767,14 @@ class AccountAccessControlProxyAPI:
         
         :returns: :class:`GetAssignableRolesForResourceResponse`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = GetAssignableRolesForResourceRequest(resource=resource)
 
         query = {}
-        if resource: query['resource'] = request.resource
+        if resource is not None: query['resource'] = resource
 
         json = self._api.do('GET', '/api/2.0/preview/accounts/access-control/assignable-roles', query=query)
         return GetAssignableRolesForResourceResponse.from_dict(json)
 
-    def get_rule_set(self, name: str, etag: str, **kwargs) -> RuleSetResponse:
+    def get_rule_set(self, name: str, etag: str) -> RuleSetResponse:
         """Get a rule set.
         
         Get a rule set by its name. A rule set is always attached to a resource and contains a list of access
@@ -1019,18 +792,15 @@ class AccountAccessControlProxyAPI:
         
         :returns: :class:`RuleSetResponse`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = GetRuleSetRequest(etag=etag, name=name)
 
         query = {}
-        if etag: query['etag'] = request.etag
-        if name: query['name'] = request.name
+        if etag is not None: query['etag'] = etag
+        if name is not None: query['name'] = name
 
         json = self._api.do('GET', '/api/2.0/preview/accounts/access-control/rule-sets', query=query)
         return RuleSetResponse.from_dict(json)
 
-    def update_rule_set(self, name: str, rule_set: RuleSetUpdateRequest, **kwargs) -> RuleSetResponse:
+    def update_rule_set(self, name: str, rule_set: RuleSetUpdateRequest) -> RuleSetResponse:
         """Update a rule set.
         
         Replace the rules of a rule set. First, use a GET rule set request to read the current version of the
@@ -1042,10 +812,9 @@ class AccountAccessControlProxyAPI:
         
         :returns: :class:`RuleSetResponse`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = UpdateRuleSetRequest(name=name, rule_set=rule_set)
-        body = request.as_dict()
+        body = {}
+        if name is not None: body['name'] = name
+        if rule_set is not None: body['rule_set'] = rule_set.as_dict()
 
         json = self._api.do('PUT', '/api/2.0/preview/accounts/access-control/rule-sets', body=body)
         return RuleSetResponse.from_dict(json)
@@ -1071,8 +840,7 @@ class AccountGroupsAPI:
                id: Optional[str] = None,
                members: Optional[List[ComplexValue]] = None,
                meta: Optional[ResourceMeta] = None,
-               roles: Optional[List[ComplexValue]] = None,
-               **kwargs) -> Group:
+               roles: Optional[List[ComplexValue]] = None) -> Group:
         """Create a new group.
         
         Creates a group in the Databricks account with a unique name, using the supplied group details.
@@ -1091,22 +859,20 @@ class AccountGroupsAPI:
         
         :returns: :class:`Group`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = Group(display_name=display_name,
-                            entitlements=entitlements,
-                            external_id=external_id,
-                            groups=groups,
-                            id=id,
-                            members=members,
-                            meta=meta,
-                            roles=roles)
-        body = request.as_dict()
+        body = {}
+        if display_name is not None: body['displayName'] = display_name
+        if entitlements is not None: body['entitlements'] = [v.as_dict() for v in entitlements]
+        if external_id is not None: body['externalId'] = external_id
+        if groups is not None: body['groups'] = [v.as_dict() for v in groups]
+        if id is not None: body['id'] = id
+        if members is not None: body['members'] = [v.as_dict() for v in members]
+        if meta is not None: body['meta'] = meta.as_dict()
+        if roles is not None: body['roles'] = [v.as_dict() for v in roles]
 
         json = self._api.do('POST', f'/api/2.0/accounts/{self._api.account_id}/scim/v2/Groups', body=body)
         return Group.from_dict(json)
 
-    def delete(self, id: str, **kwargs):
+    def delete(self, id: str):
         """Delete a group.
         
         Deletes a group from the Databricks account.
@@ -1116,13 +882,10 @@ class AccountGroupsAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = DeleteAccountGroupRequest(id=id)
 
-        self._api.do('DELETE', f'/api/2.0/accounts/{self._api.account_id}/scim/v2/Groups/{request.id}')
+        self._api.do('DELETE', f'/api/2.0/accounts/{self._api.account_id}/scim/v2/Groups/{id}')
 
-    def get(self, id: str, **kwargs) -> Group:
+    def get(self, id: str) -> Group:
         """Get group details.
         
         Gets the information for a specific group in the Databricks account.
@@ -1132,11 +895,8 @@ class AccountGroupsAPI:
         
         :returns: :class:`Group`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = GetAccountGroupRequest(id=id)
 
-        json = self._api.do('GET', f'/api/2.0/accounts/{self._api.account_id}/scim/v2/Groups/{request.id}')
+        json = self._api.do('GET', f'/api/2.0/accounts/{self._api.account_id}/scim/v2/Groups/{id}')
         return Group.from_dict(json)
 
     def list(self,
@@ -1147,8 +907,7 @@ class AccountGroupsAPI:
              filter: Optional[str] = None,
              sort_by: Optional[str] = None,
              sort_order: Optional[ListSortOrder] = None,
-             start_index: Optional[int] = None,
-             **kwargs) -> Iterator[Group]:
+             start_index: Optional[int] = None) -> Iterator[Group]:
         """List group details.
         
         Gets all details of the groups associated with the Databricks account.
@@ -1175,24 +934,15 @@ class AccountGroupsAPI:
         
         :returns: Iterator over :class:`Group`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = ListAccountGroupsRequest(attributes=attributes,
-                                               count=count,
-                                               excluded_attributes=excluded_attributes,
-                                               filter=filter,
-                                               sort_by=sort_by,
-                                               sort_order=sort_order,
-                                               start_index=start_index)
 
         query = {}
-        if attributes: query['attributes'] = request.attributes
-        if count: query['count'] = request.count
-        if excluded_attributes: query['excludedAttributes'] = request.excluded_attributes
-        if filter: query['filter'] = request.filter
-        if sort_by: query['sortBy'] = request.sort_by
-        if sort_order: query['sortOrder'] = request.sort_order.value
-        if start_index: query['startIndex'] = request.start_index
+        if attributes is not None: query['attributes'] = attributes
+        if count is not None: query['count'] = count
+        if excluded_attributes is not None: query['excludedAttributes'] = excluded_attributes
+        if filter is not None: query['filter'] = filter
+        if sort_by is not None: query['sortBy'] = sort_by
+        if sort_order is not None: query['sortOrder'] = sort_order.value
+        if start_index is not None: query['startIndex'] = start_index
 
         json = self._api.do('GET', f'/api/2.0/accounts/{self._api.account_id}/scim/v2/Groups', query=query)
         return [Group.from_dict(v) for v in json.get('Resources', [])]
@@ -1201,8 +951,7 @@ class AccountGroupsAPI:
               id: str,
               *,
               operations: Optional[List[Patch]] = None,
-              schema: Optional[List[PatchSchema]] = None,
-              **kwargs):
+              schema: Optional[List[PatchSchema]] = None):
         """Update group details.
         
         Partially updates the details of a group.
@@ -1215,13 +964,10 @@ class AccountGroupsAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = PartialUpdate(id=id, operations=operations, schema=schema)
-        body = request.as_dict()
-        self._api.do('PATCH',
-                     f'/api/2.0/accounts/{self._api.account_id}/scim/v2/Groups/{request.id}',
-                     body=body)
+        body = {}
+        if operations is not None: body['Operations'] = [v.as_dict() for v in operations]
+        if schema is not None: body['schema'] = [v for v in schema]
+        self._api.do('PATCH', f'/api/2.0/accounts/{self._api.account_id}/scim/v2/Groups/{id}', body=body)
 
     def update(self,
                id: str,
@@ -1232,8 +978,7 @@ class AccountGroupsAPI:
                groups: Optional[List[ComplexValue]] = None,
                members: Optional[List[ComplexValue]] = None,
                meta: Optional[ResourceMeta] = None,
-               roles: Optional[List[ComplexValue]] = None,
-               **kwargs):
+               roles: Optional[List[ComplexValue]] = None):
         """Replace a group.
         
         Updates the details of a group by replacing the entire group entity.
@@ -1252,20 +997,15 @@ class AccountGroupsAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = Group(display_name=display_name,
-                            entitlements=entitlements,
-                            external_id=external_id,
-                            groups=groups,
-                            id=id,
-                            members=members,
-                            meta=meta,
-                            roles=roles)
-        body = request.as_dict()
-        self._api.do('PUT',
-                     f'/api/2.0/accounts/{self._api.account_id}/scim/v2/Groups/{request.id}',
-                     body=body)
+        body = {}
+        if display_name is not None: body['displayName'] = display_name
+        if entitlements is not None: body['entitlements'] = [v.as_dict() for v in entitlements]
+        if external_id is not None: body['externalId'] = external_id
+        if groups is not None: body['groups'] = [v.as_dict() for v in groups]
+        if members is not None: body['members'] = [v.as_dict() for v in members]
+        if meta is not None: body['meta'] = meta.as_dict()
+        if roles is not None: body['roles'] = [v.as_dict() for v in roles]
+        self._api.do('PUT', f'/api/2.0/accounts/{self._api.account_id}/scim/v2/Groups/{id}', body=body)
 
 
 class AccountServicePrincipalsAPI:
@@ -1287,8 +1027,7 @@ class AccountServicePrincipalsAPI:
                external_id: Optional[str] = None,
                groups: Optional[List[ComplexValue]] = None,
                id: Optional[str] = None,
-               roles: Optional[List[ComplexValue]] = None,
-               **kwargs) -> ServicePrincipal:
+               roles: Optional[List[ComplexValue]] = None) -> ServicePrincipal:
         """Create a service principal.
         
         Creates a new service principal in the Databricks account.
@@ -1308,24 +1047,22 @@ class AccountServicePrincipalsAPI:
         
         :returns: :class:`ServicePrincipal`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = ServicePrincipal(active=active,
-                                       application_id=application_id,
-                                       display_name=display_name,
-                                       entitlements=entitlements,
-                                       external_id=external_id,
-                                       groups=groups,
-                                       id=id,
-                                       roles=roles)
-        body = request.as_dict()
+        body = {}
+        if active is not None: body['active'] = active
+        if application_id is not None: body['applicationId'] = application_id
+        if display_name is not None: body['displayName'] = display_name
+        if entitlements is not None: body['entitlements'] = [v.as_dict() for v in entitlements]
+        if external_id is not None: body['externalId'] = external_id
+        if groups is not None: body['groups'] = [v.as_dict() for v in groups]
+        if id is not None: body['id'] = id
+        if roles is not None: body['roles'] = [v.as_dict() for v in roles]
 
         json = self._api.do('POST',
                             f'/api/2.0/accounts/{self._api.account_id}/scim/v2/ServicePrincipals',
                             body=body)
         return ServicePrincipal.from_dict(json)
 
-    def delete(self, id: str, **kwargs):
+    def delete(self, id: str):
         """Delete a service principal.
         
         Delete a single service principal in the Databricks account.
@@ -1335,14 +1072,10 @@ class AccountServicePrincipalsAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = DeleteAccountServicePrincipalRequest(id=id)
 
-        self._api.do('DELETE',
-                     f'/api/2.0/accounts/{self._api.account_id}/scim/v2/ServicePrincipals/{request.id}')
+        self._api.do('DELETE', f'/api/2.0/accounts/{self._api.account_id}/scim/v2/ServicePrincipals/{id}')
 
-    def get(self, id: str, **kwargs) -> ServicePrincipal:
+    def get(self, id: str) -> ServicePrincipal:
         """Get service principal details.
         
         Gets the details for a single service principal define in the Databricks account.
@@ -1352,12 +1085,8 @@ class AccountServicePrincipalsAPI:
         
         :returns: :class:`ServicePrincipal`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = GetAccountServicePrincipalRequest(id=id)
 
-        json = self._api.do(
-            'GET', f'/api/2.0/accounts/{self._api.account_id}/scim/v2/ServicePrincipals/{request.id}')
+        json = self._api.do('GET', f'/api/2.0/accounts/{self._api.account_id}/scim/v2/ServicePrincipals/{id}')
         return ServicePrincipal.from_dict(json)
 
     def list(self,
@@ -1368,8 +1097,7 @@ class AccountServicePrincipalsAPI:
              filter: Optional[str] = None,
              sort_by: Optional[str] = None,
              sort_order: Optional[ListSortOrder] = None,
-             start_index: Optional[int] = None,
-             **kwargs) -> Iterator[ServicePrincipal]:
+             start_index: Optional[int] = None) -> Iterator[ServicePrincipal]:
         """List service principals.
         
         Gets the set of service principals associated with a Databricks account.
@@ -1396,24 +1124,15 @@ class AccountServicePrincipalsAPI:
         
         :returns: Iterator over :class:`ServicePrincipal`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = ListAccountServicePrincipalsRequest(attributes=attributes,
-                                                          count=count,
-                                                          excluded_attributes=excluded_attributes,
-                                                          filter=filter,
-                                                          sort_by=sort_by,
-                                                          sort_order=sort_order,
-                                                          start_index=start_index)
 
         query = {}
-        if attributes: query['attributes'] = request.attributes
-        if count: query['count'] = request.count
-        if excluded_attributes: query['excludedAttributes'] = request.excluded_attributes
-        if filter: query['filter'] = request.filter
-        if sort_by: query['sortBy'] = request.sort_by
-        if sort_order: query['sortOrder'] = request.sort_order.value
-        if start_index: query['startIndex'] = request.start_index
+        if attributes is not None: query['attributes'] = attributes
+        if count is not None: query['count'] = count
+        if excluded_attributes is not None: query['excludedAttributes'] = excluded_attributes
+        if filter is not None: query['filter'] = filter
+        if sort_by is not None: query['sortBy'] = sort_by
+        if sort_order is not None: query['sortOrder'] = sort_order.value
+        if start_index is not None: query['startIndex'] = start_index
 
         json = self._api.do('GET',
                             f'/api/2.0/accounts/{self._api.account_id}/scim/v2/ServicePrincipals',
@@ -1424,8 +1143,7 @@ class AccountServicePrincipalsAPI:
               id: str,
               *,
               operations: Optional[List[Patch]] = None,
-              schema: Optional[List[PatchSchema]] = None,
-              **kwargs):
+              schema: Optional[List[PatchSchema]] = None):
         """Update service principal details.
         
         Partially updates the details of a single service principal in the Databricks account.
@@ -1438,12 +1156,11 @@ class AccountServicePrincipalsAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = PartialUpdate(id=id, operations=operations, schema=schema)
-        body = request.as_dict()
+        body = {}
+        if operations is not None: body['Operations'] = [v.as_dict() for v in operations]
+        if schema is not None: body['schema'] = [v for v in schema]
         self._api.do('PATCH',
-                     f'/api/2.0/accounts/{self._api.account_id}/scim/v2/ServicePrincipals/{request.id}',
+                     f'/api/2.0/accounts/{self._api.account_id}/scim/v2/ServicePrincipals/{id}',
                      body=body)
 
     def update(self,
@@ -1455,8 +1172,7 @@ class AccountServicePrincipalsAPI:
                entitlements: Optional[List[ComplexValue]] = None,
                external_id: Optional[str] = None,
                groups: Optional[List[ComplexValue]] = None,
-               roles: Optional[List[ComplexValue]] = None,
-               **kwargs):
+               roles: Optional[List[ComplexValue]] = None):
         """Replace service principal.
         
         Updates the details of a single service principal.
@@ -1478,19 +1194,16 @@ class AccountServicePrincipalsAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = ServicePrincipal(active=active,
-                                       application_id=application_id,
-                                       display_name=display_name,
-                                       entitlements=entitlements,
-                                       external_id=external_id,
-                                       groups=groups,
-                                       id=id,
-                                       roles=roles)
-        body = request.as_dict()
+        body = {}
+        if active is not None: body['active'] = active
+        if application_id is not None: body['applicationId'] = application_id
+        if display_name is not None: body['displayName'] = display_name
+        if entitlements is not None: body['entitlements'] = [v.as_dict() for v in entitlements]
+        if external_id is not None: body['externalId'] = external_id
+        if groups is not None: body['groups'] = [v.as_dict() for v in groups]
+        if roles is not None: body['roles'] = [v.as_dict() for v in roles]
         self._api.do('PUT',
-                     f'/api/2.0/accounts/{self._api.account_id}/scim/v2/ServicePrincipals/{request.id}',
+                     f'/api/2.0/accounts/{self._api.account_id}/scim/v2/ServicePrincipals/{id}',
                      body=body)
 
 
@@ -1519,8 +1232,7 @@ class AccountUsersAPI:
                id: Optional[str] = None,
                name: Optional[Name] = None,
                roles: Optional[List[ComplexValue]] = None,
-               user_name: Optional[str] = None,
-               **kwargs) -> User:
+               user_name: Optional[str] = None) -> User:
         """Create a new user.
         
         Creates a new user in the Databricks account. This new user will also be added to the Databricks
@@ -1544,24 +1256,22 @@ class AccountUsersAPI:
         
         :returns: :class:`User`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = User(active=active,
-                           display_name=display_name,
-                           emails=emails,
-                           entitlements=entitlements,
-                           external_id=external_id,
-                           groups=groups,
-                           id=id,
-                           name=name,
-                           roles=roles,
-                           user_name=user_name)
-        body = request.as_dict()
+        body = {}
+        if active is not None: body['active'] = active
+        if display_name is not None: body['displayName'] = display_name
+        if emails is not None: body['emails'] = [v.as_dict() for v in emails]
+        if entitlements is not None: body['entitlements'] = [v.as_dict() for v in entitlements]
+        if external_id is not None: body['externalId'] = external_id
+        if groups is not None: body['groups'] = [v.as_dict() for v in groups]
+        if id is not None: body['id'] = id
+        if name is not None: body['name'] = name.as_dict()
+        if roles is not None: body['roles'] = [v.as_dict() for v in roles]
+        if user_name is not None: body['userName'] = user_name
 
         json = self._api.do('POST', f'/api/2.0/accounts/{self._api.account_id}/scim/v2/Users', body=body)
         return User.from_dict(json)
 
-    def delete(self, id: str, **kwargs):
+    def delete(self, id: str):
         """Delete a user.
         
         Deletes a user. Deleting a user from a Databricks account also removes objects associated with the
@@ -1572,13 +1282,10 @@ class AccountUsersAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = DeleteAccountUserRequest(id=id)
 
-        self._api.do('DELETE', f'/api/2.0/accounts/{self._api.account_id}/scim/v2/Users/{request.id}')
+        self._api.do('DELETE', f'/api/2.0/accounts/{self._api.account_id}/scim/v2/Users/{id}')
 
-    def get(self, id: str, **kwargs) -> User:
+    def get(self, id: str) -> User:
         """Get user details.
         
         Gets information for a specific user in Databricks account.
@@ -1588,11 +1295,8 @@ class AccountUsersAPI:
         
         :returns: :class:`User`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = GetAccountUserRequest(id=id)
 
-        json = self._api.do('GET', f'/api/2.0/accounts/{self._api.account_id}/scim/v2/Users/{request.id}')
+        json = self._api.do('GET', f'/api/2.0/accounts/{self._api.account_id}/scim/v2/Users/{id}')
         return User.from_dict(json)
 
     def list(self,
@@ -1603,8 +1307,7 @@ class AccountUsersAPI:
              filter: Optional[str] = None,
              sort_by: Optional[str] = None,
              sort_order: Optional[ListSortOrder] = None,
-             start_index: Optional[int] = None,
-             **kwargs) -> Iterator[User]:
+             start_index: Optional[int] = None) -> Iterator[User]:
         """List users.
         
         Gets details for all the users associated with a Databricks account.
@@ -1632,24 +1335,15 @@ class AccountUsersAPI:
         
         :returns: Iterator over :class:`User`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = ListAccountUsersRequest(attributes=attributes,
-                                              count=count,
-                                              excluded_attributes=excluded_attributes,
-                                              filter=filter,
-                                              sort_by=sort_by,
-                                              sort_order=sort_order,
-                                              start_index=start_index)
 
         query = {}
-        if attributes: query['attributes'] = request.attributes
-        if count: query['count'] = request.count
-        if excluded_attributes: query['excludedAttributes'] = request.excluded_attributes
-        if filter: query['filter'] = request.filter
-        if sort_by: query['sortBy'] = request.sort_by
-        if sort_order: query['sortOrder'] = request.sort_order.value
-        if start_index: query['startIndex'] = request.start_index
+        if attributes is not None: query['attributes'] = attributes
+        if count is not None: query['count'] = count
+        if excluded_attributes is not None: query['excludedAttributes'] = excluded_attributes
+        if filter is not None: query['filter'] = filter
+        if sort_by is not None: query['sortBy'] = sort_by
+        if sort_order is not None: query['sortOrder'] = sort_order.value
+        if start_index is not None: query['startIndex'] = start_index
 
         json = self._api.do('GET', f'/api/2.0/accounts/{self._api.account_id}/scim/v2/Users', query=query)
         return [User.from_dict(v) for v in json.get('Resources', [])]
@@ -1658,8 +1352,7 @@ class AccountUsersAPI:
               id: str,
               *,
               operations: Optional[List[Patch]] = None,
-              schema: Optional[List[PatchSchema]] = None,
-              **kwargs):
+              schema: Optional[List[PatchSchema]] = None):
         """Update user details.
         
         Partially updates a user resource by applying the supplied operations on specific user attributes.
@@ -1672,13 +1365,10 @@ class AccountUsersAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = PartialUpdate(id=id, operations=operations, schema=schema)
-        body = request.as_dict()
-        self._api.do('PATCH',
-                     f'/api/2.0/accounts/{self._api.account_id}/scim/v2/Users/{request.id}',
-                     body=body)
+        body = {}
+        if operations is not None: body['Operations'] = [v.as_dict() for v in operations]
+        if schema is not None: body['schema'] = [v for v in schema]
+        self._api.do('PATCH', f'/api/2.0/accounts/{self._api.account_id}/scim/v2/Users/{id}', body=body)
 
     def update(self,
                id: str,
@@ -1691,8 +1381,7 @@ class AccountUsersAPI:
                groups: Optional[List[ComplexValue]] = None,
                name: Optional[Name] = None,
                roles: Optional[List[ComplexValue]] = None,
-               user_name: Optional[str] = None,
-               **kwargs):
+               user_name: Optional[str] = None):
         """Replace a user.
         
         Replaces a user's information with the data supplied in request.
@@ -1715,20 +1404,17 @@ class AccountUsersAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = User(active=active,
-                           display_name=display_name,
-                           emails=emails,
-                           entitlements=entitlements,
-                           external_id=external_id,
-                           groups=groups,
-                           id=id,
-                           name=name,
-                           roles=roles,
-                           user_name=user_name)
-        body = request.as_dict()
-        self._api.do('PUT', f'/api/2.0/accounts/{self._api.account_id}/scim/v2/Users/{request.id}', body=body)
+        body = {}
+        if active is not None: body['active'] = active
+        if display_name is not None: body['displayName'] = display_name
+        if emails is not None: body['emails'] = [v.as_dict() for v in emails]
+        if entitlements is not None: body['entitlements'] = [v.as_dict() for v in entitlements]
+        if external_id is not None: body['externalId'] = external_id
+        if groups is not None: body['groups'] = [v.as_dict() for v in groups]
+        if name is not None: body['name'] = name.as_dict()
+        if roles is not None: body['roles'] = [v.as_dict() for v in roles]
+        if user_name is not None: body['userName'] = user_name
+        self._api.do('PUT', f'/api/2.0/accounts/{self._api.account_id}/scim/v2/Users/{id}', body=body)
 
 
 class CurrentUserAPI:
@@ -1769,8 +1455,7 @@ class GroupsAPI:
                id: Optional[str] = None,
                members: Optional[List[ComplexValue]] = None,
                meta: Optional[ResourceMeta] = None,
-               roles: Optional[List[ComplexValue]] = None,
-               **kwargs) -> Group:
+               roles: Optional[List[ComplexValue]] = None) -> Group:
         """Create a new group.
         
         Creates a group in the Databricks workspace with a unique name, using the supplied group details.
@@ -1789,22 +1474,20 @@ class GroupsAPI:
         
         :returns: :class:`Group`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = Group(display_name=display_name,
-                            entitlements=entitlements,
-                            external_id=external_id,
-                            groups=groups,
-                            id=id,
-                            members=members,
-                            meta=meta,
-                            roles=roles)
-        body = request.as_dict()
+        body = {}
+        if display_name is not None: body['displayName'] = display_name
+        if entitlements is not None: body['entitlements'] = [v.as_dict() for v in entitlements]
+        if external_id is not None: body['externalId'] = external_id
+        if groups is not None: body['groups'] = [v.as_dict() for v in groups]
+        if id is not None: body['id'] = id
+        if members is not None: body['members'] = [v.as_dict() for v in members]
+        if meta is not None: body['meta'] = meta.as_dict()
+        if roles is not None: body['roles'] = [v.as_dict() for v in roles]
 
         json = self._api.do('POST', '/api/2.0/preview/scim/v2/Groups', body=body)
         return Group.from_dict(json)
 
-    def delete(self, id: str, **kwargs):
+    def delete(self, id: str):
         """Delete a group.
         
         Deletes a group from the Databricks workspace.
@@ -1814,13 +1497,10 @@ class GroupsAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = DeleteGroupRequest(id=id)
 
-        self._api.do('DELETE', f'/api/2.0/preview/scim/v2/Groups/{request.id}')
+        self._api.do('DELETE', f'/api/2.0/preview/scim/v2/Groups/{id}')
 
-    def get(self, id: str, **kwargs) -> Group:
+    def get(self, id: str) -> Group:
         """Get group details.
         
         Gets the information for a specific group in the Databricks workspace.
@@ -1830,11 +1510,8 @@ class GroupsAPI:
         
         :returns: :class:`Group`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = GetGroupRequest(id=id)
 
-        json = self._api.do('GET', f'/api/2.0/preview/scim/v2/Groups/{request.id}')
+        json = self._api.do('GET', f'/api/2.0/preview/scim/v2/Groups/{id}')
         return Group.from_dict(json)
 
     def list(self,
@@ -1845,8 +1522,7 @@ class GroupsAPI:
              filter: Optional[str] = None,
              sort_by: Optional[str] = None,
              sort_order: Optional[ListSortOrder] = None,
-             start_index: Optional[int] = None,
-             **kwargs) -> Iterator[Group]:
+             start_index: Optional[int] = None) -> Iterator[Group]:
         """List group details.
         
         Gets all details of the groups associated with the Databricks workspace.
@@ -1873,24 +1549,15 @@ class GroupsAPI:
         
         :returns: Iterator over :class:`Group`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = ListGroupsRequest(attributes=attributes,
-                                        count=count,
-                                        excluded_attributes=excluded_attributes,
-                                        filter=filter,
-                                        sort_by=sort_by,
-                                        sort_order=sort_order,
-                                        start_index=start_index)
 
         query = {}
-        if attributes: query['attributes'] = request.attributes
-        if count: query['count'] = request.count
-        if excluded_attributes: query['excludedAttributes'] = request.excluded_attributes
-        if filter: query['filter'] = request.filter
-        if sort_by: query['sortBy'] = request.sort_by
-        if sort_order: query['sortOrder'] = request.sort_order.value
-        if start_index: query['startIndex'] = request.start_index
+        if attributes is not None: query['attributes'] = attributes
+        if count is not None: query['count'] = count
+        if excluded_attributes is not None: query['excludedAttributes'] = excluded_attributes
+        if filter is not None: query['filter'] = filter
+        if sort_by is not None: query['sortBy'] = sort_by
+        if sort_order is not None: query['sortOrder'] = sort_order.value
+        if start_index is not None: query['startIndex'] = start_index
 
         json = self._api.do('GET', '/api/2.0/preview/scim/v2/Groups', query=query)
         return [Group.from_dict(v) for v in json.get('Resources', [])]
@@ -1899,8 +1566,7 @@ class GroupsAPI:
               id: str,
               *,
               operations: Optional[List[Patch]] = None,
-              schema: Optional[List[PatchSchema]] = None,
-              **kwargs):
+              schema: Optional[List[PatchSchema]] = None):
         """Update group details.
         
         Partially updates the details of a group.
@@ -1913,11 +1579,10 @@ class GroupsAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = PartialUpdate(id=id, operations=operations, schema=schema)
-        body = request.as_dict()
-        self._api.do('PATCH', f'/api/2.0/preview/scim/v2/Groups/{request.id}', body=body)
+        body = {}
+        if operations is not None: body['Operations'] = [v.as_dict() for v in operations]
+        if schema is not None: body['schema'] = [v for v in schema]
+        self._api.do('PATCH', f'/api/2.0/preview/scim/v2/Groups/{id}', body=body)
 
     def update(self,
                id: str,
@@ -1928,8 +1593,7 @@ class GroupsAPI:
                groups: Optional[List[ComplexValue]] = None,
                members: Optional[List[ComplexValue]] = None,
                meta: Optional[ResourceMeta] = None,
-               roles: Optional[List[ComplexValue]] = None,
-               **kwargs):
+               roles: Optional[List[ComplexValue]] = None):
         """Replace a group.
         
         Updates the details of a group by replacing the entire group entity.
@@ -1948,18 +1612,15 @@ class GroupsAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = Group(display_name=display_name,
-                            entitlements=entitlements,
-                            external_id=external_id,
-                            groups=groups,
-                            id=id,
-                            members=members,
-                            meta=meta,
-                            roles=roles)
-        body = request.as_dict()
-        self._api.do('PUT', f'/api/2.0/preview/scim/v2/Groups/{request.id}', body=body)
+        body = {}
+        if display_name is not None: body['displayName'] = display_name
+        if entitlements is not None: body['entitlements'] = [v.as_dict() for v in entitlements]
+        if external_id is not None: body['externalId'] = external_id
+        if groups is not None: body['groups'] = [v.as_dict() for v in groups]
+        if members is not None: body['members'] = [v.as_dict() for v in members]
+        if meta is not None: body['meta'] = meta.as_dict()
+        if roles is not None: body['roles'] = [v.as_dict() for v in roles]
+        self._api.do('PUT', f'/api/2.0/preview/scim/v2/Groups/{id}', body=body)
 
 
 class PermissionsAPI:
@@ -1969,7 +1630,7 @@ class PermissionsAPI:
     def __init__(self, api_client):
         self._api = api_client
 
-    def get(self, request_object_type: str, request_object_id: str, **kwargs) -> ObjectPermissions:
+    def get(self, request_object_type: str, request_object_id: str) -> ObjectPermissions:
         """Get object permissions.
         
         Gets the permission of an object. Objects can inherit permissions from their parent objects or root
@@ -1981,17 +1642,12 @@ class PermissionsAPI:
         
         :returns: :class:`ObjectPermissions`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = GetPermissionRequest(request_object_id=request_object_id,
-                                           request_object_type=request_object_type)
 
-        json = self._api.do(
-            'GET', f'/api/2.0/permissions/{request.request_object_type}/{request.request_object_id}')
+        json = self._api.do('GET', f'/api/2.0/permissions/{request_object_type}/{request_object_id}')
         return ObjectPermissions.from_dict(json)
 
-    def get_permission_levels(self, request_object_type: str, request_object_id: str,
-                              **kwargs) -> GetPermissionLevelsResponse:
+    def get_permission_levels(self, request_object_type: str,
+                              request_object_id: str) -> GetPermissionLevelsResponse:
         """Get permission levels.
         
         Gets the permission levels that a user can have on an object.
@@ -2003,23 +1659,16 @@ class PermissionsAPI:
         
         :returns: :class:`GetPermissionLevelsResponse`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = GetPermissionLevelsRequest(request_object_id=request_object_id,
-                                                 request_object_type=request_object_type)
 
         json = self._api.do(
-            'GET',
-            f'/api/2.0/permissions/{request.request_object_type}/{request.request_object_id}/permissionLevels'
-        )
+            'GET', f'/api/2.0/permissions/{request_object_type}/{request_object_id}/permissionLevels')
         return GetPermissionLevelsResponse.from_dict(json)
 
     def set(self,
             request_object_type: str,
             request_object_id: str,
             *,
-            access_control_list: Optional[List[AccessControlRequest]] = None,
-            **kwargs):
+            access_control_list: Optional[List[AccessControlRequest]] = None):
         """Set permissions.
         
         Sets permissions on object. Objects can inherit permissions from their parent objects and root
@@ -2032,22 +1681,16 @@ class PermissionsAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = PermissionsRequest(access_control_list=access_control_list,
-                                         request_object_id=request_object_id,
-                                         request_object_type=request_object_type)
-        body = request.as_dict()
-        self._api.do('PUT',
-                     f'/api/2.0/permissions/{request.request_object_type}/{request.request_object_id}',
-                     body=body)
+        body = {}
+        if access_control_list is not None:
+            body['access_control_list'] = [v.as_dict() for v in access_control_list]
+        self._api.do('PUT', f'/api/2.0/permissions/{request_object_type}/{request_object_id}', body=body)
 
     def update(self,
                request_object_type: str,
                request_object_id: str,
                *,
-               access_control_list: Optional[List[AccessControlRequest]] = None,
-               **kwargs):
+               access_control_list: Optional[List[AccessControlRequest]] = None):
         """Update permission.
         
         Updates the permissions on an object.
@@ -2059,15 +1702,10 @@ class PermissionsAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = PermissionsRequest(access_control_list=access_control_list,
-                                         request_object_id=request_object_id,
-                                         request_object_type=request_object_type)
-        body = request.as_dict()
-        self._api.do('PATCH',
-                     f'/api/2.0/permissions/{request.request_object_type}/{request.request_object_id}',
-                     body=body)
+        body = {}
+        if access_control_list is not None:
+            body['access_control_list'] = [v.as_dict() for v in access_control_list]
+        self._api.do('PATCH', f'/api/2.0/permissions/{request_object_type}/{request_object_id}', body=body)
 
 
 class ServicePrincipalsAPI:
@@ -2089,8 +1727,7 @@ class ServicePrincipalsAPI:
                external_id: Optional[str] = None,
                groups: Optional[List[ComplexValue]] = None,
                id: Optional[str] = None,
-               roles: Optional[List[ComplexValue]] = None,
-               **kwargs) -> ServicePrincipal:
+               roles: Optional[List[ComplexValue]] = None) -> ServicePrincipal:
         """Create a service principal.
         
         Creates a new service principal in the Databricks workspace.
@@ -2110,22 +1747,20 @@ class ServicePrincipalsAPI:
         
         :returns: :class:`ServicePrincipal`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = ServicePrincipal(active=active,
-                                       application_id=application_id,
-                                       display_name=display_name,
-                                       entitlements=entitlements,
-                                       external_id=external_id,
-                                       groups=groups,
-                                       id=id,
-                                       roles=roles)
-        body = request.as_dict()
+        body = {}
+        if active is not None: body['active'] = active
+        if application_id is not None: body['applicationId'] = application_id
+        if display_name is not None: body['displayName'] = display_name
+        if entitlements is not None: body['entitlements'] = [v.as_dict() for v in entitlements]
+        if external_id is not None: body['externalId'] = external_id
+        if groups is not None: body['groups'] = [v.as_dict() for v in groups]
+        if id is not None: body['id'] = id
+        if roles is not None: body['roles'] = [v.as_dict() for v in roles]
 
         json = self._api.do('POST', '/api/2.0/preview/scim/v2/ServicePrincipals', body=body)
         return ServicePrincipal.from_dict(json)
 
-    def delete(self, id: str, **kwargs):
+    def delete(self, id: str):
         """Delete a service principal.
         
         Delete a single service principal in the Databricks workspace.
@@ -2135,13 +1770,10 @@ class ServicePrincipalsAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = DeleteServicePrincipalRequest(id=id)
 
-        self._api.do('DELETE', f'/api/2.0/preview/scim/v2/ServicePrincipals/{request.id}')
+        self._api.do('DELETE', f'/api/2.0/preview/scim/v2/ServicePrincipals/{id}')
 
-    def get(self, id: str, **kwargs) -> ServicePrincipal:
+    def get(self, id: str) -> ServicePrincipal:
         """Get service principal details.
         
         Gets the details for a single service principal define in the Databricks workspace.
@@ -2151,11 +1783,8 @@ class ServicePrincipalsAPI:
         
         :returns: :class:`ServicePrincipal`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = GetServicePrincipalRequest(id=id)
 
-        json = self._api.do('GET', f'/api/2.0/preview/scim/v2/ServicePrincipals/{request.id}')
+        json = self._api.do('GET', f'/api/2.0/preview/scim/v2/ServicePrincipals/{id}')
         return ServicePrincipal.from_dict(json)
 
     def list(self,
@@ -2166,8 +1795,7 @@ class ServicePrincipalsAPI:
              filter: Optional[str] = None,
              sort_by: Optional[str] = None,
              sort_order: Optional[ListSortOrder] = None,
-             start_index: Optional[int] = None,
-             **kwargs) -> Iterator[ServicePrincipal]:
+             start_index: Optional[int] = None) -> Iterator[ServicePrincipal]:
         """List service principals.
         
         Gets the set of service principals associated with a Databricks workspace.
@@ -2194,24 +1822,15 @@ class ServicePrincipalsAPI:
         
         :returns: Iterator over :class:`ServicePrincipal`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = ListServicePrincipalsRequest(attributes=attributes,
-                                                   count=count,
-                                                   excluded_attributes=excluded_attributes,
-                                                   filter=filter,
-                                                   sort_by=sort_by,
-                                                   sort_order=sort_order,
-                                                   start_index=start_index)
 
         query = {}
-        if attributes: query['attributes'] = request.attributes
-        if count: query['count'] = request.count
-        if excluded_attributes: query['excludedAttributes'] = request.excluded_attributes
-        if filter: query['filter'] = request.filter
-        if sort_by: query['sortBy'] = request.sort_by
-        if sort_order: query['sortOrder'] = request.sort_order.value
-        if start_index: query['startIndex'] = request.start_index
+        if attributes is not None: query['attributes'] = attributes
+        if count is not None: query['count'] = count
+        if excluded_attributes is not None: query['excludedAttributes'] = excluded_attributes
+        if filter is not None: query['filter'] = filter
+        if sort_by is not None: query['sortBy'] = sort_by
+        if sort_order is not None: query['sortOrder'] = sort_order.value
+        if start_index is not None: query['startIndex'] = start_index
 
         json = self._api.do('GET', '/api/2.0/preview/scim/v2/ServicePrincipals', query=query)
         return [ServicePrincipal.from_dict(v) for v in json.get('Resources', [])]
@@ -2220,8 +1839,7 @@ class ServicePrincipalsAPI:
               id: str,
               *,
               operations: Optional[List[Patch]] = None,
-              schema: Optional[List[PatchSchema]] = None,
-              **kwargs):
+              schema: Optional[List[PatchSchema]] = None):
         """Update service principal details.
         
         Partially updates the details of a single service principal in the Databricks workspace.
@@ -2234,11 +1852,10 @@ class ServicePrincipalsAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = PartialUpdate(id=id, operations=operations, schema=schema)
-        body = request.as_dict()
-        self._api.do('PATCH', f'/api/2.0/preview/scim/v2/ServicePrincipals/{request.id}', body=body)
+        body = {}
+        if operations is not None: body['Operations'] = [v.as_dict() for v in operations]
+        if schema is not None: body['schema'] = [v for v in schema]
+        self._api.do('PATCH', f'/api/2.0/preview/scim/v2/ServicePrincipals/{id}', body=body)
 
     def update(self,
                id: str,
@@ -2249,8 +1866,7 @@ class ServicePrincipalsAPI:
                entitlements: Optional[List[ComplexValue]] = None,
                external_id: Optional[str] = None,
                groups: Optional[List[ComplexValue]] = None,
-               roles: Optional[List[ComplexValue]] = None,
-               **kwargs):
+               roles: Optional[List[ComplexValue]] = None):
         """Replace service principal.
         
         Updates the details of a single service principal.
@@ -2272,18 +1888,15 @@ class ServicePrincipalsAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = ServicePrincipal(active=active,
-                                       application_id=application_id,
-                                       display_name=display_name,
-                                       entitlements=entitlements,
-                                       external_id=external_id,
-                                       groups=groups,
-                                       id=id,
-                                       roles=roles)
-        body = request.as_dict()
-        self._api.do('PUT', f'/api/2.0/preview/scim/v2/ServicePrincipals/{request.id}', body=body)
+        body = {}
+        if active is not None: body['active'] = active
+        if application_id is not None: body['applicationId'] = application_id
+        if display_name is not None: body['displayName'] = display_name
+        if entitlements is not None: body['entitlements'] = [v.as_dict() for v in entitlements]
+        if external_id is not None: body['externalId'] = external_id
+        if groups is not None: body['groups'] = [v.as_dict() for v in groups]
+        if roles is not None: body['roles'] = [v.as_dict() for v in roles]
+        self._api.do('PUT', f'/api/2.0/preview/scim/v2/ServicePrincipals/{id}', body=body)
 
 
 class UsersAPI:
@@ -2311,8 +1924,7 @@ class UsersAPI:
                id: Optional[str] = None,
                name: Optional[Name] = None,
                roles: Optional[List[ComplexValue]] = None,
-               user_name: Optional[str] = None,
-               **kwargs) -> User:
+               user_name: Optional[str] = None) -> User:
         """Create a new user.
         
         Creates a new user in the Databricks workspace. This new user will also be added to the Databricks
@@ -2336,24 +1948,22 @@ class UsersAPI:
         
         :returns: :class:`User`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = User(active=active,
-                           display_name=display_name,
-                           emails=emails,
-                           entitlements=entitlements,
-                           external_id=external_id,
-                           groups=groups,
-                           id=id,
-                           name=name,
-                           roles=roles,
-                           user_name=user_name)
-        body = request.as_dict()
+        body = {}
+        if active is not None: body['active'] = active
+        if display_name is not None: body['displayName'] = display_name
+        if emails is not None: body['emails'] = [v.as_dict() for v in emails]
+        if entitlements is not None: body['entitlements'] = [v.as_dict() for v in entitlements]
+        if external_id is not None: body['externalId'] = external_id
+        if groups is not None: body['groups'] = [v.as_dict() for v in groups]
+        if id is not None: body['id'] = id
+        if name is not None: body['name'] = name.as_dict()
+        if roles is not None: body['roles'] = [v.as_dict() for v in roles]
+        if user_name is not None: body['userName'] = user_name
 
         json = self._api.do('POST', '/api/2.0/preview/scim/v2/Users', body=body)
         return User.from_dict(json)
 
-    def delete(self, id: str, **kwargs):
+    def delete(self, id: str):
         """Delete a user.
         
         Deletes a user. Deleting a user from a Databricks workspace also removes objects associated with the
@@ -2364,13 +1974,10 @@ class UsersAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = DeleteUserRequest(id=id)
 
-        self._api.do('DELETE', f'/api/2.0/preview/scim/v2/Users/{request.id}')
+        self._api.do('DELETE', f'/api/2.0/preview/scim/v2/Users/{id}')
 
-    def get(self, id: str, **kwargs) -> User:
+    def get(self, id: str) -> User:
         """Get user details.
         
         Gets information for a specific user in Databricks workspace.
@@ -2380,11 +1987,8 @@ class UsersAPI:
         
         :returns: :class:`User`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = GetUserRequest(id=id)
 
-        json = self._api.do('GET', f'/api/2.0/preview/scim/v2/Users/{request.id}')
+        json = self._api.do('GET', f'/api/2.0/preview/scim/v2/Users/{id}')
         return User.from_dict(json)
 
     def list(self,
@@ -2395,8 +1999,7 @@ class UsersAPI:
              filter: Optional[str] = None,
              sort_by: Optional[str] = None,
              sort_order: Optional[ListSortOrder] = None,
-             start_index: Optional[int] = None,
-             **kwargs) -> Iterator[User]:
+             start_index: Optional[int] = None) -> Iterator[User]:
         """List users.
         
         Gets details for all the users associated with a Databricks workspace.
@@ -2424,24 +2027,15 @@ class UsersAPI:
         
         :returns: Iterator over :class:`User`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = ListUsersRequest(attributes=attributes,
-                                       count=count,
-                                       excluded_attributes=excluded_attributes,
-                                       filter=filter,
-                                       sort_by=sort_by,
-                                       sort_order=sort_order,
-                                       start_index=start_index)
 
         query = {}
-        if attributes: query['attributes'] = request.attributes
-        if count: query['count'] = request.count
-        if excluded_attributes: query['excludedAttributes'] = request.excluded_attributes
-        if filter: query['filter'] = request.filter
-        if sort_by: query['sortBy'] = request.sort_by
-        if sort_order: query['sortOrder'] = request.sort_order.value
-        if start_index: query['startIndex'] = request.start_index
+        if attributes is not None: query['attributes'] = attributes
+        if count is not None: query['count'] = count
+        if excluded_attributes is not None: query['excludedAttributes'] = excluded_attributes
+        if filter is not None: query['filter'] = filter
+        if sort_by is not None: query['sortBy'] = sort_by
+        if sort_order is not None: query['sortOrder'] = sort_order.value
+        if start_index is not None: query['startIndex'] = start_index
 
         json = self._api.do('GET', '/api/2.0/preview/scim/v2/Users', query=query)
         return [User.from_dict(v) for v in json.get('Resources', [])]
@@ -2450,8 +2044,7 @@ class UsersAPI:
               id: str,
               *,
               operations: Optional[List[Patch]] = None,
-              schema: Optional[List[PatchSchema]] = None,
-              **kwargs):
+              schema: Optional[List[PatchSchema]] = None):
         """Update user details.
         
         Partially updates a user resource by applying the supplied operations on specific user attributes.
@@ -2464,11 +2057,10 @@ class UsersAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = PartialUpdate(id=id, operations=operations, schema=schema)
-        body = request.as_dict()
-        self._api.do('PATCH', f'/api/2.0/preview/scim/v2/Users/{request.id}', body=body)
+        body = {}
+        if operations is not None: body['Operations'] = [v.as_dict() for v in operations]
+        if schema is not None: body['schema'] = [v for v in schema]
+        self._api.do('PATCH', f'/api/2.0/preview/scim/v2/Users/{id}', body=body)
 
     def update(self,
                id: str,
@@ -2481,8 +2073,7 @@ class UsersAPI:
                groups: Optional[List[ComplexValue]] = None,
                name: Optional[Name] = None,
                roles: Optional[List[ComplexValue]] = None,
-               user_name: Optional[str] = None,
-               **kwargs):
+               user_name: Optional[str] = None):
         """Replace a user.
         
         Replaces a user's information with the data supplied in request.
@@ -2505,20 +2096,17 @@ class UsersAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = User(active=active,
-                           display_name=display_name,
-                           emails=emails,
-                           entitlements=entitlements,
-                           external_id=external_id,
-                           groups=groups,
-                           id=id,
-                           name=name,
-                           roles=roles,
-                           user_name=user_name)
-        body = request.as_dict()
-        self._api.do('PUT', f'/api/2.0/preview/scim/v2/Users/{request.id}', body=body)
+        body = {}
+        if active is not None: body['active'] = active
+        if display_name is not None: body['displayName'] = display_name
+        if emails is not None: body['emails'] = [v.as_dict() for v in emails]
+        if entitlements is not None: body['entitlements'] = [v.as_dict() for v in entitlements]
+        if external_id is not None: body['externalId'] = external_id
+        if groups is not None: body['groups'] = [v.as_dict() for v in groups]
+        if name is not None: body['name'] = name.as_dict()
+        if roles is not None: body['roles'] = [v.as_dict() for v in roles]
+        if user_name is not None: body['userName'] = user_name
+        self._api.do('PUT', f'/api/2.0/preview/scim/v2/Users/{id}', body=body)
 
 
 class WorkspaceAssignmentAPI:
@@ -2528,7 +2116,7 @@ class WorkspaceAssignmentAPI:
     def __init__(self, api_client):
         self._api = api_client
 
-    def delete(self, workspace_id: int, principal_id: int, **kwargs):
+    def delete(self, workspace_id: int, principal_id: int):
         """Delete permissions assignment.
         
         Deletes the workspace permissions assignment in a given account and workspace for the specified
@@ -2541,16 +2129,13 @@ class WorkspaceAssignmentAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = DeleteWorkspaceAssignmentRequest(principal_id=principal_id, workspace_id=workspace_id)
 
         self._api.do(
             'DELETE',
-            f'/api/2.0/accounts/{self._api.account_id}/workspaces/{request.workspace_id}/permissionassignments/principals/{request.principal_id}'
+            f'/api/2.0/accounts/{self._api.account_id}/workspaces/{workspace_id}/permissionassignments/principals/{principal_id}'
         )
 
-    def get(self, workspace_id: int, **kwargs) -> WorkspacePermissions:
+    def get(self, workspace_id: int) -> WorkspacePermissions:
         """List workspace permissions.
         
         Get an array of workspace permissions for the specified account and workspace.
@@ -2560,17 +2145,14 @@ class WorkspaceAssignmentAPI:
         
         :returns: :class:`WorkspacePermissions`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = GetWorkspaceAssignmentRequest(workspace_id=workspace_id)
 
         json = self._api.do(
             'GET',
-            f'/api/2.0/accounts/{self._api.account_id}/workspaces/{request.workspace_id}/permissionassignments/permissions'
+            f'/api/2.0/accounts/{self._api.account_id}/workspaces/{workspace_id}/permissionassignments/permissions'
         )
         return WorkspacePermissions.from_dict(json)
 
-    def list(self, workspace_id: int, **kwargs) -> Iterator[PermissionAssignment]:
+    def list(self, workspace_id: int) -> Iterator[PermissionAssignment]:
         """Get permission assignments.
         
         Get the permission assignments for the specified Databricks account and Databricks workspace.
@@ -2580,17 +2162,13 @@ class WorkspaceAssignmentAPI:
         
         :returns: Iterator over :class:`PermissionAssignment`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = ListWorkspaceAssignmentRequest(workspace_id=workspace_id)
 
         json = self._api.do(
             'GET',
-            f'/api/2.0/accounts/{self._api.account_id}/workspaces/{request.workspace_id}/permissionassignments'
-        )
+            f'/api/2.0/accounts/{self._api.account_id}/workspaces/{workspace_id}/permissionassignments')
         return [PermissionAssignment.from_dict(v) for v in json.get('permission_assignments', [])]
 
-    def update(self, permissions: List[WorkspacePermission], workspace_id: int, principal_id: int, **kwargs):
+    def update(self, permissions: List[WorkspacePermission], workspace_id: int, principal_id: int):
         """Create or update permissions assignment.
         
         Creates or updates the workspace permissions assignment in a given account and workspace for the
@@ -2605,13 +2183,9 @@ class WorkspaceAssignmentAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = UpdateWorkspaceAssignments(permissions=permissions,
-                                                 principal_id=principal_id,
-                                                 workspace_id=workspace_id)
-        body = request.as_dict()
+        body = {}
+        if permissions is not None: body['permissions'] = [v for v in permissions]
         self._api.do(
             'PUT',
-            f'/api/2.0/accounts/{self._api.account_id}/workspaces/{request.workspace_id}/permissionassignments/principals/{request.principal_id}',
+            f'/api/2.0/accounts/{self._api.account_id}/workspaces/{workspace_id}/permissionassignments/principals/{principal_id}',
             body=body)

--- a/databricks/sdk/service/jobs.py
+++ b/databricks/sdk/service/jobs.py
@@ -6,10 +6,10 @@ import time
 from dataclasses import dataclass
 from datetime import timedelta
 from enum import Enum
-from typing import Callable, Dict, Iterator, List, Optional
+from typing import Any, Callable, Dict, Iterator, List, Optional
 
 from ..errors import OperationFailed
-from ._internal import Wait, _enum, _from_dict, _repeated, _validated
+from ._internal import Wait, _enum, _from_dict, _repeated
 
 _LOG = logging.getLogger('databricks.sdk')
 
@@ -54,6 +54,7 @@ class BaseRun:
     git_source: Optional['GitSource'] = None
     job_clusters: Optional['List[JobCluster]'] = None
     job_id: Optional[int] = None
+    job_parameters: Optional['List[JobParameter]'] = None
     number_in_job: Optional[int] = None
     original_attempt_run_id: Optional[int] = None
     overriding_parameters: Optional['RunParameters'] = None
@@ -68,6 +69,7 @@ class BaseRun:
     state: Optional['RunState'] = None
     tasks: Optional['List[RunTask]'] = None
     trigger: Optional['TriggerType'] = None
+    trigger_info: Optional['TriggerInfo'] = None
 
     def as_dict(self) -> dict:
         body = {}
@@ -82,6 +84,7 @@ class BaseRun:
         if self.git_source: body['git_source'] = self.git_source.as_dict()
         if self.job_clusters: body['job_clusters'] = [v.as_dict() for v in self.job_clusters]
         if self.job_id is not None: body['job_id'] = self.job_id
+        if self.job_parameters: body['job_parameters'] = [v.as_dict() for v in self.job_parameters]
         if self.number_in_job is not None: body['number_in_job'] = self.number_in_job
         if self.original_attempt_run_id is not None:
             body['original_attempt_run_id'] = self.original_attempt_run_id
@@ -97,6 +100,7 @@ class BaseRun:
         if self.state: body['state'] = self.state.as_dict()
         if self.tasks: body['tasks'] = [v.as_dict() for v in self.tasks]
         if self.trigger is not None: body['trigger'] = self.trigger.value
+        if self.trigger_info: body['trigger_info'] = self.trigger_info.as_dict()
         return body
 
     @classmethod
@@ -112,6 +116,7 @@ class BaseRun:
                    git_source=_from_dict(d, 'git_source', GitSource),
                    job_clusters=_repeated(d, 'job_clusters', JobCluster),
                    job_id=d.get('job_id', None),
+                   job_parameters=_repeated(d, 'job_parameters', JobParameter),
                    number_in_job=d.get('number_in_job', None),
                    original_attempt_run_id=d.get('original_attempt_run_id', None),
                    overriding_parameters=_from_dict(d, 'overriding_parameters', RunParameters),
@@ -125,7 +130,8 @@ class BaseRun:
                    start_time=d.get('start_time', None),
                    state=_from_dict(d, 'state', RunState),
                    tasks=_repeated(d, 'tasks', RunTask),
-                   trigger=_enum(d, 'trigger', TriggerType))
+                   trigger=_enum(d, 'trigger', TriggerType),
+                   trigger_info=_from_dict(d, 'trigger_info', TriggerInfo))
 
 
 @dataclass
@@ -176,7 +182,7 @@ class ClusterInstance:
 class ClusterSpec:
     existing_cluster_id: Optional[str] = None
     libraries: Optional['List[compute.Library]'] = None
-    new_cluster: Optional['compute.BaseClusterInfo'] = None
+    new_cluster: Optional['compute.ClusterSpec'] = None
 
     def as_dict(self) -> dict:
         body = {}
@@ -189,12 +195,49 @@ class ClusterSpec:
     def from_dict(cls, d: Dict[str, any]) -> 'ClusterSpec':
         return cls(existing_cluster_id=d.get('existing_cluster_id', None),
                    libraries=_repeated(d, 'libraries', compute.Library),
-                   new_cluster=_from_dict(d, 'new_cluster', compute.BaseClusterInfo))
+                   new_cluster=_from_dict(d, 'new_cluster', compute.ClusterSpec))
+
+
+@dataclass
+class ConditionTask:
+    left: Optional[str] = None
+    op: Optional['ConditionTaskOp'] = None
+    right: Optional[str] = None
+
+    def as_dict(self) -> dict:
+        body = {}
+        if self.left is not None: body['left'] = self.left
+        if self.op is not None: body['op'] = self.op.value
+        if self.right is not None: body['right'] = self.right
+        return body
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, any]) -> 'ConditionTask':
+        return cls(left=d.get('left', None), op=_enum(d, 'op', ConditionTaskOp), right=d.get('right', None))
+
+
+class ConditionTaskOp(Enum):
+    """* `EQUAL_TO`, `NOT_EQUAL` operators perform string comparison of their operands. This means that
+    `“12.0” == “12”` will evaluate to `false`. * `GREATER_THAN`, `GREATER_THAN_OR_EQUAL`,
+    `LESS_THAN`, `LESS_THAN_OR_EQUAL` operators perform numeric comparison of their operands.
+    `“12.0” >= “12”` will evaluate to `true`, `“10.0” >= “12”` will evaluate to
+    `false`.
+    
+    The boolean comparison to task values can be implemented with operators `EQUAL_TO`, `NOT_EQUAL`.
+    If a task value was set to a boolean value, it will be serialized to `“true”` or
+    `“false”` for the comparison."""
+
+    EQUAL_TO = 'EQUAL_TO'
+    GREATER_THAN = 'GREATER_THAN'
+    GREATER_THAN_OR_EQUAL = 'GREATER_THAN_OR_EQUAL'
+    LESS_THAN = 'LESS_THAN'
+    LESS_THAN_OR_EQUAL = 'LESS_THAN_OR_EQUAL'
+    NOT_EQUAL = 'NOT_EQUAL'
 
 
 @dataclass
 class Continuous:
-    pause_status: Optional['ContinuousPauseStatus'] = None
+    pause_status: Optional['PauseStatus'] = None
 
     def as_dict(self) -> dict:
         body = {}
@@ -203,47 +246,46 @@ class Continuous:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'Continuous':
-        return cls(pause_status=_enum(d, 'pause_status', ContinuousPauseStatus))
-
-
-class ContinuousPauseStatus(Enum):
-    """Indicate whether the continuous execution of the job is paused or not. Defaults to UNPAUSED."""
-
-    PAUSED = 'PAUSED'
-    UNPAUSED = 'UNPAUSED'
+        return cls(pause_status=_enum(d, 'pause_status', PauseStatus))
 
 
 @dataclass
 class CreateJob:
     access_control_list: Optional['List[iam.AccessControlRequest]'] = None
+    compute: Optional['List[JobCompute]'] = None
     continuous: Optional['Continuous'] = None
     email_notifications: Optional['JobEmailNotifications'] = None
-    format: Optional['CreateJobFormat'] = None
+    format: Optional['Format'] = None
     git_source: Optional['GitSource'] = None
+    health: Optional['JobsHealthRules'] = None
     job_clusters: Optional['List[JobCluster]'] = None
     max_concurrent_runs: Optional[int] = None
     name: Optional[str] = None
     notification_settings: Optional['JobNotificationSettings'] = None
+    parameters: Optional['List[JobParameterDefinition]'] = None
     run_as: Optional['JobRunAs'] = None
     schedule: Optional['CronSchedule'] = None
     tags: Optional['Dict[str,str]'] = None
-    tasks: Optional['List[JobTaskSettings]'] = None
+    tasks: Optional['List[Task]'] = None
     timeout_seconds: Optional[int] = None
     trigger: Optional['TriggerSettings'] = None
-    webhook_notifications: Optional['JobWebhookNotifications'] = None
+    webhook_notifications: Optional['WebhookNotifications'] = None
 
     def as_dict(self) -> dict:
         body = {}
         if self.access_control_list:
             body['access_control_list'] = [v.as_dict() for v in self.access_control_list]
+        if self.compute: body['compute'] = [v.as_dict() for v in self.compute]
         if self.continuous: body['continuous'] = self.continuous.as_dict()
         if self.email_notifications: body['email_notifications'] = self.email_notifications.as_dict()
         if self.format is not None: body['format'] = self.format.value
         if self.git_source: body['git_source'] = self.git_source.as_dict()
+        if self.health: body['health'] = self.health.as_dict()
         if self.job_clusters: body['job_clusters'] = [v.as_dict() for v in self.job_clusters]
         if self.max_concurrent_runs is not None: body['max_concurrent_runs'] = self.max_concurrent_runs
         if self.name is not None: body['name'] = self.name
         if self.notification_settings: body['notification_settings'] = self.notification_settings.as_dict()
+        if self.parameters: body['parameters'] = [v.as_dict() for v in self.parameters]
         if self.run_as: body['run_as'] = self.run_as.as_dict()
         if self.schedule: body['schedule'] = self.schedule.as_dict()
         if self.tags: body['tags'] = self.tags
@@ -256,29 +298,24 @@ class CreateJob:
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'CreateJob':
         return cls(access_control_list=_repeated(d, 'access_control_list', iam.AccessControlRequest),
+                   compute=_repeated(d, 'compute', JobCompute),
                    continuous=_from_dict(d, 'continuous', Continuous),
                    email_notifications=_from_dict(d, 'email_notifications', JobEmailNotifications),
-                   format=_enum(d, 'format', CreateJobFormat),
+                   format=_enum(d, 'format', Format),
                    git_source=_from_dict(d, 'git_source', GitSource),
+                   health=_from_dict(d, 'health', JobsHealthRules),
                    job_clusters=_repeated(d, 'job_clusters', JobCluster),
                    max_concurrent_runs=d.get('max_concurrent_runs', None),
                    name=d.get('name', None),
                    notification_settings=_from_dict(d, 'notification_settings', JobNotificationSettings),
+                   parameters=_repeated(d, 'parameters', JobParameterDefinition),
                    run_as=_from_dict(d, 'run_as', JobRunAs),
                    schedule=_from_dict(d, 'schedule', CronSchedule),
                    tags=d.get('tags', None),
-                   tasks=_repeated(d, 'tasks', JobTaskSettings),
+                   tasks=_repeated(d, 'tasks', Task),
                    timeout_seconds=d.get('timeout_seconds', None),
                    trigger=_from_dict(d, 'trigger', TriggerSettings),
-                   webhook_notifications=_from_dict(d, 'webhook_notifications', JobWebhookNotifications))
-
-
-class CreateJobFormat(Enum):
-    """Used to tell what is the format of the job. This field is ignored in Create/Update/Reset calls.
-    When using the Jobs API 2.1 this value is always set to `"MULTI_TASK"`."""
-
-    MULTI_TASK = 'MULTI_TASK'
-    SINGLE_TASK = 'SINGLE_TASK'
+                   webhook_notifications=_from_dict(d, 'webhook_notifications', WebhookNotifications))
 
 
 @dataclass
@@ -299,7 +336,7 @@ class CreateResponse:
 class CronSchedule:
     quartz_cron_expression: str
     timezone_id: str
-    pause_status: Optional['CronSchedulePauseStatus'] = None
+    pause_status: Optional['PauseStatus'] = None
 
     def as_dict(self) -> dict:
         body = {}
@@ -311,16 +348,9 @@ class CronSchedule:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'CronSchedule':
-        return cls(pause_status=_enum(d, 'pause_status', CronSchedulePauseStatus),
+        return cls(pause_status=_enum(d, 'pause_status', PauseStatus),
                    quartz_cron_expression=d.get('quartz_cron_expression', None),
                    timezone_id=d.get('timezone_id', None))
-
-
-class CronSchedulePauseStatus(Enum):
-    """Indicate whether this schedule is paused or not."""
-
-    PAUSED = 'PAUSED'
-    UNPAUSED = 'UNPAUSED'
 
 
 @dataclass
@@ -412,25 +442,43 @@ class ExportRunOutput:
 
 
 @dataclass
-class FileArrivalTriggerSettings:
-    min_time_between_trigger_seconds: Optional[int] = None
+class FileArrivalTriggerConfiguration:
+    min_time_between_triggers_seconds: Optional[int] = None
     url: Optional[str] = None
     wait_after_last_change_seconds: Optional[int] = None
 
     def as_dict(self) -> dict:
         body = {}
-        if self.min_time_between_trigger_seconds is not None:
-            body['min_time_between_trigger_seconds'] = self.min_time_between_trigger_seconds
+        if self.min_time_between_triggers_seconds is not None:
+            body['min_time_between_triggers_seconds'] = self.min_time_between_triggers_seconds
         if self.url is not None: body['url'] = self.url
         if self.wait_after_last_change_seconds is not None:
             body['wait_after_last_change_seconds'] = self.wait_after_last_change_seconds
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> 'FileArrivalTriggerSettings':
-        return cls(min_time_between_trigger_seconds=d.get('min_time_between_trigger_seconds', None),
+    def from_dict(cls, d: Dict[str, any]) -> 'FileArrivalTriggerConfiguration':
+        return cls(min_time_between_triggers_seconds=d.get('min_time_between_triggers_seconds', None),
                    url=d.get('url', None),
                    wait_after_last_change_seconds=d.get('wait_after_last_change_seconds', None))
+
+
+class Format(Enum):
+
+    MULTI_TASK = 'MULTI_TASK'
+    SINGLE_TASK = 'SINGLE_TASK'
+
+
+class GitProvider(Enum):
+
+    AWS_CODE_COMMIT = 'awsCodeCommit'
+    AZURE_DEV_OPS_SERVICES = 'azureDevOpsServices'
+    BITBUCKET_CLOUD = 'bitbucketCloud'
+    BITBUCKET_SERVER = 'bitbucketServer'
+    GIT_HUB = 'gitHub'
+    GIT_HUB_ENTERPRISE = 'gitHubEnterprise'
+    GIT_LAB = 'gitLab'
+    GIT_LAB_ENTERPRISE_EDITION = 'gitLabEnterpriseEdition'
 
 
 @dataclass
@@ -456,11 +504,12 @@ class GitSource:
     notebook tasks."""
 
     git_url: str
-    git_provider: 'GitSourceGitProvider'
+    git_provider: 'GitProvider'
     git_branch: Optional[str] = None
     git_commit: Optional[str] = None
     git_snapshot: Optional['GitSnapshot'] = None
     git_tag: Optional[str] = None
+    job_source: Optional['JobSource'] = None
 
     def as_dict(self) -> dict:
         body = {}
@@ -470,29 +519,18 @@ class GitSource:
         if self.git_snapshot: body['git_snapshot'] = self.git_snapshot.as_dict()
         if self.git_tag is not None: body['git_tag'] = self.git_tag
         if self.git_url is not None: body['git_url'] = self.git_url
+        if self.job_source: body['job_source'] = self.job_source.as_dict()
         return body
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'GitSource':
         return cls(git_branch=d.get('git_branch', None),
                    git_commit=d.get('git_commit', None),
-                   git_provider=_enum(d, 'git_provider', GitSourceGitProvider),
+                   git_provider=_enum(d, 'git_provider', GitProvider),
                    git_snapshot=_from_dict(d, 'git_snapshot', GitSnapshot),
                    git_tag=d.get('git_tag', None),
-                   git_url=d.get('git_url', None))
-
-
-class GitSourceGitProvider(Enum):
-    """Unique identifier of the service used to host the Git repository. The value is case insensitive."""
-
-    AWS_CODE_COMMIT = 'awsCodeCommit'
-    AZURE_DEV_OPS_SERVICES = 'azureDevOpsServices'
-    BITBUCKET_CLOUD = 'bitbucketCloud'
-    BITBUCKET_SERVER = 'bitbucketServer'
-    GIT_HUB = 'gitHub'
-    GIT_HUB_ENTERPRISE = 'gitHubEnterprise'
-    GIT_LAB = 'gitLab'
-    GIT_LAB_ENTERPRISE_EDITION = 'gitLabEnterpriseEdition'
+                   git_url=d.get('git_url', None),
+                   job_source=_from_dict(d, 'job_source', JobSource))
 
 
 @dataclass
@@ -527,7 +565,7 @@ class Job:
 @dataclass
 class JobCluster:
     job_cluster_key: str
-    new_cluster: Optional['compute.BaseClusterInfo'] = None
+    new_cluster: Optional['compute.ClusterSpec'] = None
 
     def as_dict(self) -> dict:
         body = {}
@@ -538,12 +576,29 @@ class JobCluster:
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'JobCluster':
         return cls(job_cluster_key=d.get('job_cluster_key', None),
-                   new_cluster=_from_dict(d, 'new_cluster', compute.BaseClusterInfo))
+                   new_cluster=_from_dict(d, 'new_cluster', compute.ClusterSpec))
+
+
+@dataclass
+class JobCompute:
+    compute_key: str
+    spec: 'compute.ComputeSpec'
+
+    def as_dict(self) -> dict:
+        body = {}
+        if self.compute_key is not None: body['compute_key'] = self.compute_key
+        if self.spec: body['spec'] = self.spec.as_dict()
+        return body
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, any]) -> 'JobCompute':
+        return cls(compute_key=d.get('compute_key', None), spec=_from_dict(d, 'spec', compute.ComputeSpec))
 
 
 @dataclass
 class JobEmailNotifications:
     no_alert_for_skipped_runs: Optional[bool] = None
+    on_duration_warning_threshold_exceeded: Optional['List[str]'] = None
     on_failure: Optional['List[str]'] = None
     on_start: Optional['List[str]'] = None
     on_success: Optional['List[str]'] = None
@@ -552,6 +607,10 @@ class JobEmailNotifications:
         body = {}
         if self.no_alert_for_skipped_runs is not None:
             body['no_alert_for_skipped_runs'] = self.no_alert_for_skipped_runs
+        if self.on_duration_warning_threshold_exceeded:
+            body['on_duration_warning_threshold_exceeded'] = [
+                v for v in self.on_duration_warning_threshold_exceeded
+            ]
         if self.on_failure: body['on_failure'] = [v for v in self.on_failure]
         if self.on_start: body['on_start'] = [v for v in self.on_start]
         if self.on_success: body['on_success'] = [v for v in self.on_success]
@@ -560,6 +619,8 @@ class JobEmailNotifications:
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'JobEmailNotifications':
         return cls(no_alert_for_skipped_runs=d.get('no_alert_for_skipped_runs', None),
+                   on_duration_warning_threshold_exceeded=d.get('on_duration_warning_threshold_exceeded',
+                                                                None),
                    on_failure=d.get('on_failure', None),
                    on_start=d.get('on_start', None),
                    on_success=d.get('on_success', None))
@@ -582,6 +643,40 @@ class JobNotificationSettings:
     def from_dict(cls, d: Dict[str, any]) -> 'JobNotificationSettings':
         return cls(no_alert_for_canceled_runs=d.get('no_alert_for_canceled_runs', None),
                    no_alert_for_skipped_runs=d.get('no_alert_for_skipped_runs', None))
+
+
+@dataclass
+class JobParameter:
+    default: Optional[str] = None
+    name: Optional[str] = None
+    value: Optional[str] = None
+
+    def as_dict(self) -> dict:
+        body = {}
+        if self.default is not None: body['default'] = self.default
+        if self.name is not None: body['name'] = self.name
+        if self.value is not None: body['value'] = self.value
+        return body
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, any]) -> 'JobParameter':
+        return cls(default=d.get('default', None), name=d.get('name', None), value=d.get('value', None))
+
+
+@dataclass
+class JobParameterDefinition:
+    name: str
+    default: str
+
+    def as_dict(self) -> dict:
+        body = {}
+        if self.default is not None: body['default'] = self.default
+        if self.name is not None: body['name'] = self.name
+        return body
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, any]) -> 'JobParameterDefinition':
+        return cls(default=d.get('default', None), name=d.get('name', None))
 
 
 @dataclass
@@ -611,32 +706,38 @@ class JobRunAs:
 
 @dataclass
 class JobSettings:
+    compute: Optional['List[JobCompute]'] = None
     continuous: Optional['Continuous'] = None
     email_notifications: Optional['JobEmailNotifications'] = None
-    format: Optional['JobSettingsFormat'] = None
+    format: Optional['Format'] = None
     git_source: Optional['GitSource'] = None
+    health: Optional['JobsHealthRules'] = None
     job_clusters: Optional['List[JobCluster]'] = None
     max_concurrent_runs: Optional[int] = None
     name: Optional[str] = None
     notification_settings: Optional['JobNotificationSettings'] = None
+    parameters: Optional['List[JobParameterDefinition]'] = None
     run_as: Optional['JobRunAs'] = None
     schedule: Optional['CronSchedule'] = None
     tags: Optional['Dict[str,str]'] = None
-    tasks: Optional['List[JobTaskSettings]'] = None
+    tasks: Optional['List[Task]'] = None
     timeout_seconds: Optional[int] = None
     trigger: Optional['TriggerSettings'] = None
-    webhook_notifications: Optional['JobWebhookNotifications'] = None
+    webhook_notifications: Optional['WebhookNotifications'] = None
 
     def as_dict(self) -> dict:
         body = {}
+        if self.compute: body['compute'] = [v.as_dict() for v in self.compute]
         if self.continuous: body['continuous'] = self.continuous.as_dict()
         if self.email_notifications: body['email_notifications'] = self.email_notifications.as_dict()
         if self.format is not None: body['format'] = self.format.value
         if self.git_source: body['git_source'] = self.git_source.as_dict()
+        if self.health: body['health'] = self.health.as_dict()
         if self.job_clusters: body['job_clusters'] = [v.as_dict() for v in self.job_clusters]
         if self.max_concurrent_runs is not None: body['max_concurrent_runs'] = self.max_concurrent_runs
         if self.name is not None: body['name'] = self.name
         if self.notification_settings: body['notification_settings'] = self.notification_settings.as_dict()
+        if self.parameters: body['parameters'] = [v.as_dict() for v in self.parameters]
         if self.run_as: body['run_as'] = self.run_as.as_dict()
         if self.schedule: body['schedule'] = self.schedule.as_dict()
         if self.tags: body['tags'] = self.tags
@@ -648,166 +749,102 @@ class JobSettings:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'JobSettings':
-        return cls(continuous=_from_dict(d, 'continuous', Continuous),
+        return cls(compute=_repeated(d, 'compute', JobCompute),
+                   continuous=_from_dict(d, 'continuous', Continuous),
                    email_notifications=_from_dict(d, 'email_notifications', JobEmailNotifications),
-                   format=_enum(d, 'format', JobSettingsFormat),
+                   format=_enum(d, 'format', Format),
                    git_source=_from_dict(d, 'git_source', GitSource),
+                   health=_from_dict(d, 'health', JobsHealthRules),
                    job_clusters=_repeated(d, 'job_clusters', JobCluster),
                    max_concurrent_runs=d.get('max_concurrent_runs', None),
                    name=d.get('name', None),
                    notification_settings=_from_dict(d, 'notification_settings', JobNotificationSettings),
+                   parameters=_repeated(d, 'parameters', JobParameterDefinition),
                    run_as=_from_dict(d, 'run_as', JobRunAs),
                    schedule=_from_dict(d, 'schedule', CronSchedule),
                    tags=d.get('tags', None),
-                   tasks=_repeated(d, 'tasks', JobTaskSettings),
+                   tasks=_repeated(d, 'tasks', Task),
                    timeout_seconds=d.get('timeout_seconds', None),
                    trigger=_from_dict(d, 'trigger', TriggerSettings),
-                   webhook_notifications=_from_dict(d, 'webhook_notifications', JobWebhookNotifications))
-
-
-class JobSettingsFormat(Enum):
-    """Used to tell what is the format of the job. This field is ignored in Create/Update/Reset calls.
-    When using the Jobs API 2.1 this value is always set to `"MULTI_TASK"`."""
-
-    MULTI_TASK = 'MULTI_TASK'
-    SINGLE_TASK = 'SINGLE_TASK'
+                   webhook_notifications=_from_dict(d, 'webhook_notifications', WebhookNotifications))
 
 
 @dataclass
-class JobTaskSettings:
-    task_key: str
-    dbt_task: Optional['DbtTask'] = None
-    depends_on: Optional['List[TaskDependenciesItem]'] = None
-    description: Optional[str] = None
-    email_notifications: Optional['TaskEmailNotifications'] = None
-    existing_cluster_id: Optional[str] = None
-    job_cluster_key: Optional[str] = None
-    libraries: Optional['List[compute.Library]'] = None
-    max_retries: Optional[int] = None
-    min_retry_interval_millis: Optional[int] = None
-    new_cluster: Optional['compute.BaseClusterInfo'] = None
-    notebook_task: Optional['NotebookTask'] = None
-    notification_settings: Optional['TaskNotificationSettings'] = None
-    pipeline_task: Optional['PipelineTask'] = None
-    python_wheel_task: Optional['PythonWheelTask'] = None
-    retry_on_timeout: Optional[bool] = None
-    spark_jar_task: Optional['SparkJarTask'] = None
-    spark_python_task: Optional['SparkPythonTask'] = None
-    spark_submit_task: Optional['SparkSubmitTask'] = None
-    sql_task: Optional['SqlTask'] = None
-    timeout_seconds: Optional[int] = None
+class JobSource:
+    """The source of the job specification in the remote repository when the job is source controlled."""
+
+    job_config_path: str
+    import_from_git_branch: str
+    dirty_state: Optional['JobSourceDirtyState'] = None
 
     def as_dict(self) -> dict:
         body = {}
-        if self.dbt_task: body['dbt_task'] = self.dbt_task.as_dict()
-        if self.depends_on: body['depends_on'] = [v.as_dict() for v in self.depends_on]
-        if self.description is not None: body['description'] = self.description
-        if self.email_notifications: body['email_notifications'] = self.email_notifications.as_dict()
-        if self.existing_cluster_id is not None: body['existing_cluster_id'] = self.existing_cluster_id
-        if self.job_cluster_key is not None: body['job_cluster_key'] = self.job_cluster_key
-        if self.libraries: body['libraries'] = [v.as_dict() for v in self.libraries]
-        if self.max_retries is not None: body['max_retries'] = self.max_retries
-        if self.min_retry_interval_millis is not None:
-            body['min_retry_interval_millis'] = self.min_retry_interval_millis
-        if self.new_cluster: body['new_cluster'] = self.new_cluster.as_dict()
-        if self.notebook_task: body['notebook_task'] = self.notebook_task.as_dict()
-        if self.notification_settings: body['notification_settings'] = self.notification_settings.as_dict()
-        if self.pipeline_task: body['pipeline_task'] = self.pipeline_task.as_dict()
-        if self.python_wheel_task: body['python_wheel_task'] = self.python_wheel_task.as_dict()
-        if self.retry_on_timeout is not None: body['retry_on_timeout'] = self.retry_on_timeout
-        if self.spark_jar_task: body['spark_jar_task'] = self.spark_jar_task.as_dict()
-        if self.spark_python_task: body['spark_python_task'] = self.spark_python_task.as_dict()
-        if self.spark_submit_task: body['spark_submit_task'] = self.spark_submit_task.as_dict()
-        if self.sql_task: body['sql_task'] = self.sql_task.as_dict()
-        if self.task_key is not None: body['task_key'] = self.task_key
-        if self.timeout_seconds is not None: body['timeout_seconds'] = self.timeout_seconds
+        if self.dirty_state is not None: body['dirty_state'] = self.dirty_state.value
+        if self.import_from_git_branch is not None:
+            body['import_from_git_branch'] = self.import_from_git_branch
+        if self.job_config_path is not None: body['job_config_path'] = self.job_config_path
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> 'JobTaskSettings':
-        return cls(dbt_task=_from_dict(d, 'dbt_task', DbtTask),
-                   depends_on=_repeated(d, 'depends_on', TaskDependenciesItem),
-                   description=d.get('description', None),
-                   email_notifications=_from_dict(d, 'email_notifications', TaskEmailNotifications),
-                   existing_cluster_id=d.get('existing_cluster_id', None),
-                   job_cluster_key=d.get('job_cluster_key', None),
-                   libraries=_repeated(d, 'libraries', compute.Library),
-                   max_retries=d.get('max_retries', None),
-                   min_retry_interval_millis=d.get('min_retry_interval_millis', None),
-                   new_cluster=_from_dict(d, 'new_cluster', compute.BaseClusterInfo),
-                   notebook_task=_from_dict(d, 'notebook_task', NotebookTask),
-                   notification_settings=_from_dict(d, 'notification_settings', TaskNotificationSettings),
-                   pipeline_task=_from_dict(d, 'pipeline_task', PipelineTask),
-                   python_wheel_task=_from_dict(d, 'python_wheel_task', PythonWheelTask),
-                   retry_on_timeout=d.get('retry_on_timeout', None),
-                   spark_jar_task=_from_dict(d, 'spark_jar_task', SparkJarTask),
-                   spark_python_task=_from_dict(d, 'spark_python_task', SparkPythonTask),
-                   spark_submit_task=_from_dict(d, 'spark_submit_task', SparkSubmitTask),
-                   sql_task=_from_dict(d, 'sql_task', SqlTask),
-                   task_key=d.get('task_key', None),
-                   timeout_seconds=d.get('timeout_seconds', None))
+    def from_dict(cls, d: Dict[str, any]) -> 'JobSource':
+        return cls(dirty_state=_enum(d, 'dirty_state', JobSourceDirtyState),
+                   import_from_git_branch=d.get('import_from_git_branch', None),
+                   job_config_path=d.get('job_config_path', None))
+
+
+class JobSourceDirtyState(Enum):
+    """This describes an enum"""
+
+    DISCONNECTED = 'DISCONNECTED'
+    NOT_SYNCED = 'NOT_SYNCED'
+
+
+class JobsHealthMetric(Enum):
+    """Specifies the health metric that is being evaluated for a particular health rule."""
+
+    RUN_DURATION_SECONDS = 'RUN_DURATION_SECONDS'
+
+
+class JobsHealthOperator(Enum):
+    """Specifies the operator used to compare the health metric value with the specified threshold."""
+
+    GREATER_THAN = 'GREATER_THAN'
 
 
 @dataclass
-class JobWebhookNotifications:
-    on_failure: Optional['List[JobWebhookNotificationsOnFailureItem]'] = None
-    on_start: Optional['List[JobWebhookNotificationsOnStartItem]'] = None
-    on_success: Optional['List[JobWebhookNotificationsOnSuccessItem]'] = None
+class JobsHealthRule:
+    metric: Optional['JobsHealthMetric'] = None
+    op: Optional['JobsHealthOperator'] = None
+    value: Optional[int] = None
 
     def as_dict(self) -> dict:
         body = {}
-        if self.on_failure: body['on_failure'] = [v.as_dict() for v in self.on_failure]
-        if self.on_start: body['on_start'] = [v.as_dict() for v in self.on_start]
-        if self.on_success: body['on_success'] = [v.as_dict() for v in self.on_success]
+        if self.metric is not None: body['metric'] = self.metric.value
+        if self.op is not None: body['op'] = self.op.value
+        if self.value is not None: body['value'] = self.value
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> 'JobWebhookNotifications':
-        return cls(on_failure=_repeated(d, 'on_failure', JobWebhookNotificationsOnFailureItem),
-                   on_start=_repeated(d, 'on_start', JobWebhookNotificationsOnStartItem),
-                   on_success=_repeated(d, 'on_success', JobWebhookNotificationsOnSuccessItem))
+    def from_dict(cls, d: Dict[str, any]) -> 'JobsHealthRule':
+        return cls(metric=_enum(d, 'metric', JobsHealthMetric),
+                   op=_enum(d, 'op', JobsHealthOperator),
+                   value=d.get('value', None))
 
 
 @dataclass
-class JobWebhookNotificationsOnFailureItem:
-    id: Optional[str] = None
+class JobsHealthRules:
+    """An optional set of health rules that can be defined for this job."""
+
+    rules: Optional['List[JobsHealthRule]'] = None
 
     def as_dict(self) -> dict:
         body = {}
-        if self.id is not None: body['id'] = self.id
+        if self.rules: body['rules'] = [v.as_dict() for v in self.rules]
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> 'JobWebhookNotificationsOnFailureItem':
-        return cls(id=d.get('id', None))
-
-
-@dataclass
-class JobWebhookNotificationsOnStartItem:
-    id: Optional[str] = None
-
-    def as_dict(self) -> dict:
-        body = {}
-        if self.id is not None: body['id'] = self.id
-        return body
-
-    @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> 'JobWebhookNotificationsOnStartItem':
-        return cls(id=d.get('id', None))
-
-
-@dataclass
-class JobWebhookNotificationsOnSuccessItem:
-    id: Optional[str] = None
-
-    def as_dict(self) -> dict:
-        body = {}
-        if self.id is not None: body['id'] = self.id
-        return body
-
-    @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> 'JobWebhookNotificationsOnSuccessItem':
-        return cls(id=d.get('id', None))
+    def from_dict(cls, d: Dict[str, any]) -> 'JobsHealthRules':
+        return cls(rules=_repeated(d, 'rules', JobsHealthRule))
 
 
 @dataclass
@@ -884,7 +921,7 @@ class NotebookOutput:
 class NotebookTask:
     notebook_path: str
     base_parameters: Optional['Dict[str,str]'] = None
-    source: Optional['NotebookTaskSource'] = None
+    source: Optional['Source'] = None
 
     def as_dict(self) -> dict:
         body = {}
@@ -897,14 +934,16 @@ class NotebookTask:
     def from_dict(cls, d: Dict[str, any]) -> 'NotebookTask':
         return cls(base_parameters=d.get('base_parameters', None),
                    notebook_path=d.get('notebook_path', None),
-                   source=_enum(d, 'source', NotebookTaskSource))
+                   source=_enum(d, 'source', Source))
 
 
-class NotebookTaskSource(Enum):
-    """This describes an enum"""
+ParamPairs = Dict[str, str]
 
-    GIT = 'GIT'
-    WORKSPACE = 'WORKSPACE'
+
+class PauseStatus(Enum):
+
+    PAUSED = 'PAUSED'
+    UNPAUSED = 'UNPAUSED'
 
 
 @dataclass
@@ -1007,6 +1046,7 @@ class RepairRun:
     python_named_params: Optional['Dict[str,str]'] = None
     python_params: Optional['List[str]'] = None
     rerun_all_failed_tasks: Optional[bool] = None
+    rerun_dependent_tasks: Optional[bool] = None
     rerun_tasks: Optional['List[str]'] = None
     spark_submit_params: Optional['List[str]'] = None
     sql_params: Optional['Dict[str,str]'] = None
@@ -1022,6 +1062,7 @@ class RepairRun:
         if self.python_params: body['python_params'] = [v for v in self.python_params]
         if self.rerun_all_failed_tasks is not None:
             body['rerun_all_failed_tasks'] = self.rerun_all_failed_tasks
+        if self.rerun_dependent_tasks is not None: body['rerun_dependent_tasks'] = self.rerun_dependent_tasks
         if self.rerun_tasks: body['rerun_tasks'] = [v for v in self.rerun_tasks]
         if self.run_id is not None: body['run_id'] = self.run_id
         if self.spark_submit_params: body['spark_submit_params'] = [v for v in self.spark_submit_params]
@@ -1038,6 +1079,7 @@ class RepairRun:
                    python_named_params=d.get('python_named_params', None),
                    python_params=d.get('python_params', None),
                    rerun_all_failed_tasks=d.get('rerun_all_failed_tasks', None),
+                   rerun_dependent_tasks=d.get('rerun_dependent_tasks', None),
                    rerun_tasks=d.get('rerun_tasks', None),
                    run_id=d.get('run_id', None),
                    spark_submit_params=d.get('spark_submit_params', None),
@@ -1075,6 +1117,151 @@ class ResetJob:
 
 
 @dataclass
+class ResolvedConditionTaskValues:
+    left: Optional[str] = None
+    right: Optional[str] = None
+
+    def as_dict(self) -> dict:
+        body = {}
+        if self.left is not None: body['left'] = self.left
+        if self.right is not None: body['right'] = self.right
+        return body
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, any]) -> 'ResolvedConditionTaskValues':
+        return cls(left=d.get('left', None), right=d.get('right', None))
+
+
+@dataclass
+class ResolvedDbtTaskValues:
+    commands: Optional['List[str]'] = None
+
+    def as_dict(self) -> dict:
+        body = {}
+        if self.commands: body['commands'] = [v for v in self.commands]
+        return body
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, any]) -> 'ResolvedDbtTaskValues':
+        return cls(commands=d.get('commands', None))
+
+
+@dataclass
+class ResolvedNotebookTaskValues:
+    base_parameters: Optional['Dict[str,str]'] = None
+
+    def as_dict(self) -> dict:
+        body = {}
+        if self.base_parameters: body['base_parameters'] = self.base_parameters
+        return body
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, any]) -> 'ResolvedNotebookTaskValues':
+        return cls(base_parameters=d.get('base_parameters', None))
+
+
+@dataclass
+class ResolvedParamPairValues:
+    parameters: Optional['Dict[str,str]'] = None
+
+    def as_dict(self) -> dict:
+        body = {}
+        if self.parameters: body['parameters'] = self.parameters
+        return body
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, any]) -> 'ResolvedParamPairValues':
+        return cls(parameters=d.get('parameters', None))
+
+
+@dataclass
+class ResolvedPythonWheelTaskValues:
+    named_parameters: Optional['Dict[str,str]'] = None
+    parameters: Optional['List[str]'] = None
+
+    def as_dict(self) -> dict:
+        body = {}
+        if self.named_parameters: body['named_parameters'] = self.named_parameters
+        if self.parameters: body['parameters'] = [v for v in self.parameters]
+        return body
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, any]) -> 'ResolvedPythonWheelTaskValues':
+        return cls(named_parameters=d.get('named_parameters', None), parameters=d.get('parameters', None))
+
+
+@dataclass
+class ResolvedRunJobTaskValues:
+    named_parameters: Optional['Dict[str,str]'] = None
+    parameters: Optional['Dict[str,str]'] = None
+
+    def as_dict(self) -> dict:
+        body = {}
+        if self.named_parameters: body['named_parameters'] = self.named_parameters
+        if self.parameters: body['parameters'] = self.parameters
+        return body
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, any]) -> 'ResolvedRunJobTaskValues':
+        return cls(named_parameters=d.get('named_parameters', None), parameters=d.get('parameters', None))
+
+
+@dataclass
+class ResolvedStringParamsValues:
+    parameters: Optional['List[str]'] = None
+
+    def as_dict(self) -> dict:
+        body = {}
+        if self.parameters: body['parameters'] = [v for v in self.parameters]
+        return body
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, any]) -> 'ResolvedStringParamsValues':
+        return cls(parameters=d.get('parameters', None))
+
+
+@dataclass
+class ResolvedValues:
+    condition_task: Optional['ResolvedConditionTaskValues'] = None
+    dbt_task: Optional['ResolvedDbtTaskValues'] = None
+    notebook_task: Optional['ResolvedNotebookTaskValues'] = None
+    python_wheel_task: Optional['ResolvedPythonWheelTaskValues'] = None
+    run_job_task: Optional['ResolvedRunJobTaskValues'] = None
+    simulation_task: Optional['ResolvedParamPairValues'] = None
+    spark_jar_task: Optional['ResolvedStringParamsValues'] = None
+    spark_python_task: Optional['ResolvedStringParamsValues'] = None
+    spark_submit_task: Optional['ResolvedStringParamsValues'] = None
+    sql_task: Optional['ResolvedParamPairValues'] = None
+
+    def as_dict(self) -> dict:
+        body = {}
+        if self.condition_task: body['condition_task'] = self.condition_task.as_dict()
+        if self.dbt_task: body['dbt_task'] = self.dbt_task.as_dict()
+        if self.notebook_task: body['notebook_task'] = self.notebook_task.as_dict()
+        if self.python_wheel_task: body['python_wheel_task'] = self.python_wheel_task.as_dict()
+        if self.run_job_task: body['run_job_task'] = self.run_job_task.as_dict()
+        if self.simulation_task: body['simulation_task'] = self.simulation_task.as_dict()
+        if self.spark_jar_task: body['spark_jar_task'] = self.spark_jar_task.as_dict()
+        if self.spark_python_task: body['spark_python_task'] = self.spark_python_task.as_dict()
+        if self.spark_submit_task: body['spark_submit_task'] = self.spark_submit_task.as_dict()
+        if self.sql_task: body['sql_task'] = self.sql_task.as_dict()
+        return body
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, any]) -> 'ResolvedValues':
+        return cls(condition_task=_from_dict(d, 'condition_task', ResolvedConditionTaskValues),
+                   dbt_task=_from_dict(d, 'dbt_task', ResolvedDbtTaskValues),
+                   notebook_task=_from_dict(d, 'notebook_task', ResolvedNotebookTaskValues),
+                   python_wheel_task=_from_dict(d, 'python_wheel_task', ResolvedPythonWheelTaskValues),
+                   run_job_task=_from_dict(d, 'run_job_task', ResolvedRunJobTaskValues),
+                   simulation_task=_from_dict(d, 'simulation_task', ResolvedParamPairValues),
+                   spark_jar_task=_from_dict(d, 'spark_jar_task', ResolvedStringParamsValues),
+                   spark_python_task=_from_dict(d, 'spark_python_task', ResolvedStringParamsValues),
+                   spark_submit_task=_from_dict(d, 'spark_submit_task', ResolvedStringParamsValues),
+                   sql_task=_from_dict(d, 'sql_task', ResolvedParamPairValues))
+
+
+@dataclass
 class Run:
     attempt_number: Optional[int] = None
     cleanup_duration: Optional[int] = None
@@ -1087,6 +1274,7 @@ class Run:
     git_source: Optional['GitSource'] = None
     job_clusters: Optional['List[JobCluster]'] = None
     job_id: Optional[int] = None
+    job_parameters: Optional['List[JobParameter]'] = None
     number_in_job: Optional[int] = None
     original_attempt_run_id: Optional[int] = None
     overriding_parameters: Optional['RunParameters'] = None
@@ -1102,6 +1290,7 @@ class Run:
     state: Optional['RunState'] = None
     tasks: Optional['List[RunTask]'] = None
     trigger: Optional['TriggerType'] = None
+    trigger_info: Optional['TriggerInfo'] = None
 
     def as_dict(self) -> dict:
         body = {}
@@ -1116,6 +1305,7 @@ class Run:
         if self.git_source: body['git_source'] = self.git_source.as_dict()
         if self.job_clusters: body['job_clusters'] = [v.as_dict() for v in self.job_clusters]
         if self.job_id is not None: body['job_id'] = self.job_id
+        if self.job_parameters: body['job_parameters'] = [v.as_dict() for v in self.job_parameters]
         if self.number_in_job is not None: body['number_in_job'] = self.number_in_job
         if self.original_attempt_run_id is not None:
             body['original_attempt_run_id'] = self.original_attempt_run_id
@@ -1132,6 +1322,7 @@ class Run:
         if self.state: body['state'] = self.state.as_dict()
         if self.tasks: body['tasks'] = [v.as_dict() for v in self.tasks]
         if self.trigger is not None: body['trigger'] = self.trigger.value
+        if self.trigger_info: body['trigger_info'] = self.trigger_info.as_dict()
         return body
 
     @classmethod
@@ -1147,6 +1338,7 @@ class Run:
                    git_source=_from_dict(d, 'git_source', GitSource),
                    job_clusters=_repeated(d, 'job_clusters', JobCluster),
                    job_id=d.get('job_id', None),
+                   job_parameters=_repeated(d, 'job_parameters', JobParameter),
                    number_in_job=d.get('number_in_job', None),
                    original_attempt_run_id=d.get('original_attempt_run_id', None),
                    overriding_parameters=_from_dict(d, 'overriding_parameters', RunParameters),
@@ -1161,7 +1353,83 @@ class Run:
                    start_time=d.get('start_time', None),
                    state=_from_dict(d, 'state', RunState),
                    tasks=_repeated(d, 'tasks', RunTask),
-                   trigger=_enum(d, 'trigger', TriggerType))
+                   trigger=_enum(d, 'trigger', TriggerType),
+                   trigger_info=_from_dict(d, 'trigger_info', TriggerInfo))
+
+
+@dataclass
+class RunConditionTask:
+    left: str
+    right: str
+    op: 'RunConditionTaskOp'
+    outcome: Optional[str] = None
+
+    def as_dict(self) -> dict:
+        body = {}
+        if self.left is not None: body['left'] = self.left
+        if self.op is not None: body['op'] = self.op.value
+        if self.outcome is not None: body['outcome'] = self.outcome
+        if self.right is not None: body['right'] = self.right
+        return body
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, any]) -> 'RunConditionTask':
+        return cls(left=d.get('left', None),
+                   op=_enum(d, 'op', RunConditionTaskOp),
+                   outcome=d.get('outcome', None),
+                   right=d.get('right', None))
+
+
+class RunConditionTaskOp(Enum):
+    """The condtion task operator."""
+
+    EQUAL_TO = 'EQUAL_TO'
+    GREATER_THAN = 'GREATER_THAN'
+    GREATER_THAN_OR_EQUAL = 'GREATER_THAN_OR_EQUAL'
+    LESS_THAN = 'LESS_THAN'
+    LESS_THAN_OR_EQUAL = 'LESS_THAN_OR_EQUAL'
+    NOT_EQUAL = 'NOT_EQUAL'
+
+
+class RunIf(Enum):
+    """This describes an enum"""
+
+    ALL_DONE = 'ALL_DONE'
+    ALL_FAILED = 'ALL_FAILED'
+    ALL_SUCCESS = 'ALL_SUCCESS'
+    AT_LEAST_ONE_FAILED = 'AT_LEAST_ONE_FAILED'
+    AT_LEAST_ONE_SUCCESS = 'AT_LEAST_ONE_SUCCESS'
+    NONE_FAILED = 'NONE_FAILED'
+
+
+@dataclass
+class RunJobOutput:
+    run_id: Optional[int] = None
+
+    def as_dict(self) -> dict:
+        body = {}
+        if self.run_id is not None: body['run_id'] = self.run_id
+        return body
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, any]) -> 'RunJobOutput':
+        return cls(run_id=d.get('run_id', None))
+
+
+@dataclass
+class RunJobTask:
+    job_id: int
+    job_parameters: Optional[Any] = None
+
+    def as_dict(self) -> dict:
+        body = {}
+        if self.job_id is not None: body['job_id'] = self.job_id
+        if self.job_parameters: body['job_parameters'] = self.job_parameters
+        return body
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, any]) -> 'RunJobTask':
+        return cls(job_id=d.get('job_id', None), job_parameters=d.get('job_parameters', None))
 
 
 class RunLifeCycleState(Enum):
@@ -1183,6 +1451,7 @@ class RunNow:
     dbt_commands: Optional['List[str]'] = None
     idempotency_token: Optional[str] = None
     jar_params: Optional['List[str]'] = None
+    job_parameters: Optional['List[Dict[str,str]]'] = None
     notebook_params: Optional['Dict[str,str]'] = None
     pipeline_params: Optional['PipelineParams'] = None
     python_named_params: Optional['Dict[str,str]'] = None
@@ -1196,6 +1465,7 @@ class RunNow:
         if self.idempotency_token is not None: body['idempotency_token'] = self.idempotency_token
         if self.jar_params: body['jar_params'] = [v for v in self.jar_params]
         if self.job_id is not None: body['job_id'] = self.job_id
+        if self.job_parameters: body['job_parameters'] = [v for v in self.job_parameters]
         if self.notebook_params: body['notebook_params'] = self.notebook_params
         if self.pipeline_params: body['pipeline_params'] = self.pipeline_params.as_dict()
         if self.python_named_params: body['python_named_params'] = self.python_named_params
@@ -1210,6 +1480,7 @@ class RunNow:
                    idempotency_token=d.get('idempotency_token', None),
                    jar_params=d.get('jar_params', None),
                    job_id=d.get('job_id', None),
+                   job_parameters=d.get('job_parameters', None),
                    notebook_params=d.get('notebook_params', None),
                    pipeline_params=_from_dict(d, 'pipeline_params', PipelineParams),
                    python_named_params=d.get('python_named_params', None),
@@ -1236,6 +1507,7 @@ class RunNowResponse:
 
 @dataclass
 class RunOutput:
+    condition_task: Optional[Any] = None
     dbt_output: Optional['DbtOutput'] = None
     error: Optional[str] = None
     error_trace: Optional[str] = None
@@ -1243,10 +1515,12 @@ class RunOutput:
     logs_truncated: Optional[bool] = None
     metadata: Optional['Run'] = None
     notebook_output: Optional['NotebookOutput'] = None
+    run_job_output: Optional['RunJobOutput'] = None
     sql_output: Optional['SqlOutput'] = None
 
     def as_dict(self) -> dict:
         body = {}
+        if self.condition_task: body['condition_task'] = self.condition_task
         if self.dbt_output: body['dbt_output'] = self.dbt_output.as_dict()
         if self.error is not None: body['error'] = self.error
         if self.error_trace is not None: body['error_trace'] = self.error_trace
@@ -1254,18 +1528,21 @@ class RunOutput:
         if self.logs_truncated is not None: body['logs_truncated'] = self.logs_truncated
         if self.metadata: body['metadata'] = self.metadata.as_dict()
         if self.notebook_output: body['notebook_output'] = self.notebook_output.as_dict()
+        if self.run_job_output: body['run_job_output'] = self.run_job_output.as_dict()
         if self.sql_output: body['sql_output'] = self.sql_output.as_dict()
         return body
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'RunOutput':
-        return cls(dbt_output=_from_dict(d, 'dbt_output', DbtOutput),
+        return cls(condition_task=d.get('condition_task', None),
+                   dbt_output=_from_dict(d, 'dbt_output', DbtOutput),
                    error=d.get('error', None),
                    error_trace=d.get('error_trace', None),
                    logs=d.get('logs', None),
                    logs_truncated=d.get('logs_truncated', None),
                    metadata=_from_dict(d, 'metadata', Run),
                    notebook_output=_from_dict(d, 'notebook_output', NotebookOutput),
+                   run_job_output=_from_dict(d, 'run_job_output', RunJobOutput),
                    sql_output=_from_dict(d, 'sql_output', SqlOutput))
 
 
@@ -1308,14 +1585,19 @@ class RunResultState(Enum):
     """This describes an enum"""
 
     CANCELED = 'CANCELED'
+    EXCLUDED = 'EXCLUDED'
     FAILED = 'FAILED'
+    MAXIMUM_CONCURRENT_RUNS_REACHED = 'MAXIMUM_CONCURRENT_RUNS_REACHED'
     SUCCESS = 'SUCCESS'
+    SUCCESS_WITH_FAILURES = 'SUCCESS_WITH_FAILURES'
     TIMEDOUT = 'TIMEDOUT'
+    UPSTREAM_CANCELED = 'UPSTREAM_CANCELED'
+    UPSTREAM_FAILED = 'UPSTREAM_FAILED'
 
 
 @dataclass
 class RunState:
-    """The result and lifecycle state of the run."""
+    """The current state of the run."""
 
     life_cycle_state: Optional['RunLifeCycleState'] = None
     result_state: Optional['RunResultState'] = None
@@ -1340,73 +1622,27 @@ class RunState:
 
 
 @dataclass
-class RunSubmitTaskSettings:
-    task_key: str
-    depends_on: Optional['List[TaskDependenciesItem]'] = None
-    existing_cluster_id: Optional[str] = None
-    libraries: Optional['List[compute.Library]'] = None
-    new_cluster: Optional['compute.BaseClusterInfo'] = None
-    notebook_task: Optional['NotebookTask'] = None
-    pipeline_task: Optional['PipelineTask'] = None
-    python_wheel_task: Optional['PythonWheelTask'] = None
-    spark_jar_task: Optional['SparkJarTask'] = None
-    spark_python_task: Optional['SparkPythonTask'] = None
-    spark_submit_task: Optional['SparkSubmitTask'] = None
-    sql_task: Optional['SqlTask'] = None
-    timeout_seconds: Optional[int] = None
-
-    def as_dict(self) -> dict:
-        body = {}
-        if self.depends_on: body['depends_on'] = [v.as_dict() for v in self.depends_on]
-        if self.existing_cluster_id is not None: body['existing_cluster_id'] = self.existing_cluster_id
-        if self.libraries: body['libraries'] = [v.as_dict() for v in self.libraries]
-        if self.new_cluster: body['new_cluster'] = self.new_cluster.as_dict()
-        if self.notebook_task: body['notebook_task'] = self.notebook_task.as_dict()
-        if self.pipeline_task: body['pipeline_task'] = self.pipeline_task.as_dict()
-        if self.python_wheel_task: body['python_wheel_task'] = self.python_wheel_task.as_dict()
-        if self.spark_jar_task: body['spark_jar_task'] = self.spark_jar_task.as_dict()
-        if self.spark_python_task: body['spark_python_task'] = self.spark_python_task.as_dict()
-        if self.spark_submit_task: body['spark_submit_task'] = self.spark_submit_task.as_dict()
-        if self.sql_task: body['sql_task'] = self.sql_task.as_dict()
-        if self.task_key is not None: body['task_key'] = self.task_key
-        if self.timeout_seconds is not None: body['timeout_seconds'] = self.timeout_seconds
-        return body
-
-    @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> 'RunSubmitTaskSettings':
-        return cls(depends_on=_repeated(d, 'depends_on', TaskDependenciesItem),
-                   existing_cluster_id=d.get('existing_cluster_id', None),
-                   libraries=_repeated(d, 'libraries', compute.Library),
-                   new_cluster=_from_dict(d, 'new_cluster', compute.BaseClusterInfo),
-                   notebook_task=_from_dict(d, 'notebook_task', NotebookTask),
-                   pipeline_task=_from_dict(d, 'pipeline_task', PipelineTask),
-                   python_wheel_task=_from_dict(d, 'python_wheel_task', PythonWheelTask),
-                   spark_jar_task=_from_dict(d, 'spark_jar_task', SparkJarTask),
-                   spark_python_task=_from_dict(d, 'spark_python_task', SparkPythonTask),
-                   spark_submit_task=_from_dict(d, 'spark_submit_task', SparkSubmitTask),
-                   sql_task=_from_dict(d, 'sql_task', SqlTask),
-                   task_key=d.get('task_key', None),
-                   timeout_seconds=d.get('timeout_seconds', None))
-
-
-@dataclass
 class RunTask:
     attempt_number: Optional[int] = None
     cleanup_duration: Optional[int] = None
     cluster_instance: Optional['ClusterInstance'] = None
+    condition_task: Optional['RunConditionTask'] = None
     dbt_task: Optional['DbtTask'] = None
-    depends_on: Optional['List[TaskDependenciesItem]'] = None
+    depends_on: Optional['List[TaskDependency]'] = None
     description: Optional[str] = None
     end_time: Optional[int] = None
     execution_duration: Optional[int] = None
     existing_cluster_id: Optional[str] = None
     git_source: Optional['GitSource'] = None
     libraries: Optional['List[compute.Library]'] = None
-    new_cluster: Optional['compute.BaseClusterInfo'] = None
+    new_cluster: Optional['compute.ClusterSpec'] = None
     notebook_task: Optional['NotebookTask'] = None
     pipeline_task: Optional['PipelineTask'] = None
     python_wheel_task: Optional['PythonWheelTask'] = None
+    resolved_values: Optional['ResolvedValues'] = None
     run_id: Optional[int] = None
+    run_if: Optional['RunIf'] = None
+    run_job_task: Optional['RunJobTask'] = None
     setup_duration: Optional[int] = None
     spark_jar_task: Optional['SparkJarTask'] = None
     spark_python_task: Optional['SparkPythonTask'] = None
@@ -1421,6 +1657,7 @@ class RunTask:
         if self.attempt_number is not None: body['attempt_number'] = self.attempt_number
         if self.cleanup_duration is not None: body['cleanup_duration'] = self.cleanup_duration
         if self.cluster_instance: body['cluster_instance'] = self.cluster_instance.as_dict()
+        if self.condition_task: body['condition_task'] = self.condition_task.as_dict()
         if self.dbt_task: body['dbt_task'] = self.dbt_task.as_dict()
         if self.depends_on: body['depends_on'] = [v.as_dict() for v in self.depends_on]
         if self.description is not None: body['description'] = self.description
@@ -1433,7 +1670,10 @@ class RunTask:
         if self.notebook_task: body['notebook_task'] = self.notebook_task.as_dict()
         if self.pipeline_task: body['pipeline_task'] = self.pipeline_task.as_dict()
         if self.python_wheel_task: body['python_wheel_task'] = self.python_wheel_task.as_dict()
+        if self.resolved_values: body['resolved_values'] = self.resolved_values.as_dict()
         if self.run_id is not None: body['run_id'] = self.run_id
+        if self.run_if is not None: body['run_if'] = self.run_if.value
+        if self.run_job_task: body['run_job_task'] = self.run_job_task.as_dict()
         if self.setup_duration is not None: body['setup_duration'] = self.setup_duration
         if self.spark_jar_task: body['spark_jar_task'] = self.spark_jar_task.as_dict()
         if self.spark_python_task: body['spark_python_task'] = self.spark_python_task.as_dict()
@@ -1449,19 +1689,23 @@ class RunTask:
         return cls(attempt_number=d.get('attempt_number', None),
                    cleanup_duration=d.get('cleanup_duration', None),
                    cluster_instance=_from_dict(d, 'cluster_instance', ClusterInstance),
+                   condition_task=_from_dict(d, 'condition_task', RunConditionTask),
                    dbt_task=_from_dict(d, 'dbt_task', DbtTask),
-                   depends_on=_repeated(d, 'depends_on', TaskDependenciesItem),
+                   depends_on=_repeated(d, 'depends_on', TaskDependency),
                    description=d.get('description', None),
                    end_time=d.get('end_time', None),
                    execution_duration=d.get('execution_duration', None),
                    existing_cluster_id=d.get('existing_cluster_id', None),
                    git_source=_from_dict(d, 'git_source', GitSource),
                    libraries=_repeated(d, 'libraries', compute.Library),
-                   new_cluster=_from_dict(d, 'new_cluster', compute.BaseClusterInfo),
+                   new_cluster=_from_dict(d, 'new_cluster', compute.ClusterSpec),
                    notebook_task=_from_dict(d, 'notebook_task', NotebookTask),
                    pipeline_task=_from_dict(d, 'pipeline_task', PipelineTask),
                    python_wheel_task=_from_dict(d, 'python_wheel_task', PythonWheelTask),
+                   resolved_values=_from_dict(d, 'resolved_values', ResolvedValues),
                    run_id=d.get('run_id', None),
+                   run_if=_enum(d, 'run_if', RunIf),
+                   run_job_task=_from_dict(d, 'run_job_task', RunJobTask),
                    setup_duration=d.get('setup_duration', None),
                    spark_jar_task=_from_dict(d, 'spark_jar_task', SparkJarTask),
                    spark_python_task=_from_dict(d, 'spark_python_task', SparkPythonTask),
@@ -1478,6 +1722,12 @@ class RunType(Enum):
     JOB_RUN = 'JOB_RUN'
     SUBMIT_RUN = 'SUBMIT_RUN'
     WORKFLOW_RUN = 'WORKFLOW_RUN'
+
+
+class Source(Enum):
+
+    GIT = 'GIT'
+    WORKSPACE = 'WORKSPACE'
 
 
 @dataclass
@@ -1504,7 +1754,7 @@ class SparkJarTask:
 class SparkPythonTask:
     python_file: str
     parameters: Optional['List[str]'] = None
-    source: Optional['SparkPythonTaskSource'] = None
+    source: Optional['Source'] = None
 
     def as_dict(self) -> dict:
         body = {}
@@ -1517,14 +1767,7 @@ class SparkPythonTask:
     def from_dict(cls, d: Dict[str, any]) -> 'SparkPythonTask':
         return cls(parameters=d.get('parameters', None),
                    python_file=d.get('python_file', None),
-                   source=_enum(d, 'source', SparkPythonTaskSource))
-
-
-class SparkPythonTaskSource(Enum):
-    """This describes an enum"""
-
-    GIT = 'GIT'
-    WORKSPACE = 'WORKSPACE'
+                   source=_enum(d, 'source', Source))
 
 
 @dataclass
@@ -1581,18 +1824,18 @@ class SqlAlertState(Enum):
 @dataclass
 class SqlDashboardOutput:
     warehouse_id: Optional[str] = None
-    widgets: Optional['SqlDashboardWidgetOutput'] = None
+    widgets: Optional['List[SqlDashboardWidgetOutput]'] = None
 
     def as_dict(self) -> dict:
         body = {}
         if self.warehouse_id is not None: body['warehouse_id'] = self.warehouse_id
-        if self.widgets: body['widgets'] = self.widgets.as_dict()
+        if self.widgets: body['widgets'] = [v.as_dict() for v in self.widgets]
         return body
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'SqlDashboardOutput':
         return cls(warehouse_id=d.get('warehouse_id', None),
-                   widgets=_from_dict(d, 'widgets', SqlDashboardWidgetOutput))
+                   widgets=_repeated(d, 'widgets', SqlDashboardWidgetOutput))
 
 
 @dataclass
@@ -1827,19 +2070,23 @@ class SqlTaskSubscription:
 @dataclass
 class SubmitRun:
     access_control_list: Optional['List[iam.AccessControlRequest]'] = None
+    email_notifications: Optional['JobEmailNotifications'] = None
     git_source: Optional['GitSource'] = None
+    health: Optional['JobsHealthRules'] = None
     idempotency_token: Optional[str] = None
     notification_settings: Optional['JobNotificationSettings'] = None
     run_name: Optional[str] = None
-    tasks: Optional['List[RunSubmitTaskSettings]'] = None
+    tasks: Optional['List[SubmitTask]'] = None
     timeout_seconds: Optional[int] = None
-    webhook_notifications: Optional['JobWebhookNotifications'] = None
+    webhook_notifications: Optional['WebhookNotifications'] = None
 
     def as_dict(self) -> dict:
         body = {}
         if self.access_control_list:
             body['access_control_list'] = [v.as_dict() for v in self.access_control_list]
+        if self.email_notifications: body['email_notifications'] = self.email_notifications.as_dict()
         if self.git_source: body['git_source'] = self.git_source.as_dict()
+        if self.health: body['health'] = self.health.as_dict()
         if self.idempotency_token is not None: body['idempotency_token'] = self.idempotency_token
         if self.notification_settings: body['notification_settings'] = self.notification_settings.as_dict()
         if self.run_name is not None: body['run_name'] = self.run_name
@@ -1851,13 +2098,15 @@ class SubmitRun:
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'SubmitRun':
         return cls(access_control_list=_repeated(d, 'access_control_list', iam.AccessControlRequest),
+                   email_notifications=_from_dict(d, 'email_notifications', JobEmailNotifications),
                    git_source=_from_dict(d, 'git_source', GitSource),
+                   health=_from_dict(d, 'health', JobsHealthRules),
                    idempotency_token=d.get('idempotency_token', None),
                    notification_settings=_from_dict(d, 'notification_settings', JobNotificationSettings),
                    run_name=d.get('run_name', None),
-                   tasks=_repeated(d, 'tasks', RunSubmitTaskSettings),
+                   tasks=_repeated(d, 'tasks', SubmitTask),
                    timeout_seconds=d.get('timeout_seconds', None),
-                   webhook_notifications=_from_dict(d, 'webhook_notifications', JobWebhookNotifications))
+                   webhook_notifications=_from_dict(d, 'webhook_notifications', WebhookNotifications))
 
 
 @dataclass
@@ -1875,27 +2124,186 @@ class SubmitRunResponse:
 
 
 @dataclass
-class TaskDependenciesItem:
-    task_key: Optional[str] = None
+class SubmitTask:
+    task_key: str
+    condition_task: Optional['ConditionTask'] = None
+    depends_on: Optional['List[TaskDependency]'] = None
+    email_notifications: Optional['JobEmailNotifications'] = None
+    existing_cluster_id: Optional[str] = None
+    health: Optional['JobsHealthRules'] = None
+    libraries: Optional['List[compute.Library]'] = None
+    new_cluster: Optional['compute.ClusterSpec'] = None
+    notebook_task: Optional['NotebookTask'] = None
+    notification_settings: Optional['TaskNotificationSettings'] = None
+    pipeline_task: Optional['PipelineTask'] = None
+    python_wheel_task: Optional['PythonWheelTask'] = None
+    spark_jar_task: Optional['SparkJarTask'] = None
+    spark_python_task: Optional['SparkPythonTask'] = None
+    spark_submit_task: Optional['SparkSubmitTask'] = None
+    sql_task: Optional['SqlTask'] = None
+    timeout_seconds: Optional[int] = None
 
     def as_dict(self) -> dict:
         body = {}
+        if self.condition_task: body['condition_task'] = self.condition_task.as_dict()
+        if self.depends_on: body['depends_on'] = [v.as_dict() for v in self.depends_on]
+        if self.email_notifications: body['email_notifications'] = self.email_notifications.as_dict()
+        if self.existing_cluster_id is not None: body['existing_cluster_id'] = self.existing_cluster_id
+        if self.health: body['health'] = self.health.as_dict()
+        if self.libraries: body['libraries'] = [v.as_dict() for v in self.libraries]
+        if self.new_cluster: body['new_cluster'] = self.new_cluster.as_dict()
+        if self.notebook_task: body['notebook_task'] = self.notebook_task.as_dict()
+        if self.notification_settings: body['notification_settings'] = self.notification_settings.as_dict()
+        if self.pipeline_task: body['pipeline_task'] = self.pipeline_task.as_dict()
+        if self.python_wheel_task: body['python_wheel_task'] = self.python_wheel_task.as_dict()
+        if self.spark_jar_task: body['spark_jar_task'] = self.spark_jar_task.as_dict()
+        if self.spark_python_task: body['spark_python_task'] = self.spark_python_task.as_dict()
+        if self.spark_submit_task: body['spark_submit_task'] = self.spark_submit_task.as_dict()
+        if self.sql_task: body['sql_task'] = self.sql_task.as_dict()
+        if self.task_key is not None: body['task_key'] = self.task_key
+        if self.timeout_seconds is not None: body['timeout_seconds'] = self.timeout_seconds
+        return body
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, any]) -> 'SubmitTask':
+        return cls(condition_task=_from_dict(d, 'condition_task', ConditionTask),
+                   depends_on=_repeated(d, 'depends_on', TaskDependency),
+                   email_notifications=_from_dict(d, 'email_notifications', JobEmailNotifications),
+                   existing_cluster_id=d.get('existing_cluster_id', None),
+                   health=_from_dict(d, 'health', JobsHealthRules),
+                   libraries=_repeated(d, 'libraries', compute.Library),
+                   new_cluster=_from_dict(d, 'new_cluster', compute.ClusterSpec),
+                   notebook_task=_from_dict(d, 'notebook_task', NotebookTask),
+                   notification_settings=_from_dict(d, 'notification_settings', TaskNotificationSettings),
+                   pipeline_task=_from_dict(d, 'pipeline_task', PipelineTask),
+                   python_wheel_task=_from_dict(d, 'python_wheel_task', PythonWheelTask),
+                   spark_jar_task=_from_dict(d, 'spark_jar_task', SparkJarTask),
+                   spark_python_task=_from_dict(d, 'spark_python_task', SparkPythonTask),
+                   spark_submit_task=_from_dict(d, 'spark_submit_task', SparkSubmitTask),
+                   sql_task=_from_dict(d, 'sql_task', SqlTask),
+                   task_key=d.get('task_key', None),
+                   timeout_seconds=d.get('timeout_seconds', None))
+
+
+@dataclass
+class Task:
+    task_key: str
+    compute_key: Optional[str] = None
+    condition_task: Optional['ConditionTask'] = None
+    dbt_task: Optional['DbtTask'] = None
+    depends_on: Optional['List[TaskDependency]'] = None
+    description: Optional[str] = None
+    email_notifications: Optional['TaskEmailNotifications'] = None
+    existing_cluster_id: Optional[str] = None
+    health: Optional['JobsHealthRules'] = None
+    job_cluster_key: Optional[str] = None
+    libraries: Optional['List[compute.Library]'] = None
+    max_retries: Optional[int] = None
+    min_retry_interval_millis: Optional[int] = None
+    new_cluster: Optional['compute.ClusterSpec'] = None
+    notebook_task: Optional['NotebookTask'] = None
+    notification_settings: Optional['TaskNotificationSettings'] = None
+    pipeline_task: Optional['PipelineTask'] = None
+    python_wheel_task: Optional['PythonWheelTask'] = None
+    retry_on_timeout: Optional[bool] = None
+    run_if: Optional['RunIf'] = None
+    run_job_task: Optional['RunJobTask'] = None
+    spark_jar_task: Optional['SparkJarTask'] = None
+    spark_python_task: Optional['SparkPythonTask'] = None
+    spark_submit_task: Optional['SparkSubmitTask'] = None
+    sql_task: Optional['SqlTask'] = None
+    timeout_seconds: Optional[int] = None
+
+    def as_dict(self) -> dict:
+        body = {}
+        if self.compute_key is not None: body['compute_key'] = self.compute_key
+        if self.condition_task: body['condition_task'] = self.condition_task.as_dict()
+        if self.dbt_task: body['dbt_task'] = self.dbt_task.as_dict()
+        if self.depends_on: body['depends_on'] = [v.as_dict() for v in self.depends_on]
+        if self.description is not None: body['description'] = self.description
+        if self.email_notifications: body['email_notifications'] = self.email_notifications.as_dict()
+        if self.existing_cluster_id is not None: body['existing_cluster_id'] = self.existing_cluster_id
+        if self.health: body['health'] = self.health.as_dict()
+        if self.job_cluster_key is not None: body['job_cluster_key'] = self.job_cluster_key
+        if self.libraries: body['libraries'] = [v.as_dict() for v in self.libraries]
+        if self.max_retries is not None: body['max_retries'] = self.max_retries
+        if self.min_retry_interval_millis is not None:
+            body['min_retry_interval_millis'] = self.min_retry_interval_millis
+        if self.new_cluster: body['new_cluster'] = self.new_cluster.as_dict()
+        if self.notebook_task: body['notebook_task'] = self.notebook_task.as_dict()
+        if self.notification_settings: body['notification_settings'] = self.notification_settings.as_dict()
+        if self.pipeline_task: body['pipeline_task'] = self.pipeline_task.as_dict()
+        if self.python_wheel_task: body['python_wheel_task'] = self.python_wheel_task.as_dict()
+        if self.retry_on_timeout is not None: body['retry_on_timeout'] = self.retry_on_timeout
+        if self.run_if is not None: body['run_if'] = self.run_if.value
+        if self.run_job_task: body['run_job_task'] = self.run_job_task.as_dict()
+        if self.spark_jar_task: body['spark_jar_task'] = self.spark_jar_task.as_dict()
+        if self.spark_python_task: body['spark_python_task'] = self.spark_python_task.as_dict()
+        if self.spark_submit_task: body['spark_submit_task'] = self.spark_submit_task.as_dict()
+        if self.sql_task: body['sql_task'] = self.sql_task.as_dict()
+        if self.task_key is not None: body['task_key'] = self.task_key
+        if self.timeout_seconds is not None: body['timeout_seconds'] = self.timeout_seconds
+        return body
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, any]) -> 'Task':
+        return cls(compute_key=d.get('compute_key', None),
+                   condition_task=_from_dict(d, 'condition_task', ConditionTask),
+                   dbt_task=_from_dict(d, 'dbt_task', DbtTask),
+                   depends_on=_repeated(d, 'depends_on', TaskDependency),
+                   description=d.get('description', None),
+                   email_notifications=_from_dict(d, 'email_notifications', TaskEmailNotifications),
+                   existing_cluster_id=d.get('existing_cluster_id', None),
+                   health=_from_dict(d, 'health', JobsHealthRules),
+                   job_cluster_key=d.get('job_cluster_key', None),
+                   libraries=_repeated(d, 'libraries', compute.Library),
+                   max_retries=d.get('max_retries', None),
+                   min_retry_interval_millis=d.get('min_retry_interval_millis', None),
+                   new_cluster=_from_dict(d, 'new_cluster', compute.ClusterSpec),
+                   notebook_task=_from_dict(d, 'notebook_task', NotebookTask),
+                   notification_settings=_from_dict(d, 'notification_settings', TaskNotificationSettings),
+                   pipeline_task=_from_dict(d, 'pipeline_task', PipelineTask),
+                   python_wheel_task=_from_dict(d, 'python_wheel_task', PythonWheelTask),
+                   retry_on_timeout=d.get('retry_on_timeout', None),
+                   run_if=_enum(d, 'run_if', RunIf),
+                   run_job_task=_from_dict(d, 'run_job_task', RunJobTask),
+                   spark_jar_task=_from_dict(d, 'spark_jar_task', SparkJarTask),
+                   spark_python_task=_from_dict(d, 'spark_python_task', SparkPythonTask),
+                   spark_submit_task=_from_dict(d, 'spark_submit_task', SparkSubmitTask),
+                   sql_task=_from_dict(d, 'sql_task', SqlTask),
+                   task_key=d.get('task_key', None),
+                   timeout_seconds=d.get('timeout_seconds', None))
+
+
+@dataclass
+class TaskDependency:
+    task_key: str
+    outcome: Optional[str] = None
+
+    def as_dict(self) -> dict:
+        body = {}
+        if self.outcome is not None: body['outcome'] = self.outcome
         if self.task_key is not None: body['task_key'] = self.task_key
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> 'TaskDependenciesItem':
-        return cls(task_key=d.get('task_key', None))
+    def from_dict(cls, d: Dict[str, any]) -> 'TaskDependency':
+        return cls(outcome=d.get('outcome', None), task_key=d.get('task_key', None))
 
 
 @dataclass
 class TaskEmailNotifications:
+    on_duration_warning_threshold_exceeded: Optional['List[str]'] = None
     on_failure: Optional['List[str]'] = None
     on_start: Optional['List[str]'] = None
     on_success: Optional['List[str]'] = None
 
     def as_dict(self) -> dict:
         body = {}
+        if self.on_duration_warning_threshold_exceeded:
+            body['on_duration_warning_threshold_exceeded'] = [
+                v for v in self.on_duration_warning_threshold_exceeded
+            ]
         if self.on_failure: body['on_failure'] = [v for v in self.on_failure]
         if self.on_start: body['on_start'] = [v for v in self.on_start]
         if self.on_success: body['on_success'] = [v for v in self.on_success]
@@ -1903,7 +2311,9 @@ class TaskEmailNotifications:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'TaskEmailNotifications':
-        return cls(on_failure=d.get('on_failure', None),
+        return cls(on_duration_warning_threshold_exceeded=d.get('on_duration_warning_threshold_exceeded',
+                                                                None),
+                   on_failure=d.get('on_failure', None),
                    on_start=d.get('on_start', None),
                    on_success=d.get('on_success', None))
 
@@ -1971,9 +2381,23 @@ class TriggerHistory:
 
 
 @dataclass
+class TriggerInfo:
+    run_id: Optional[int] = None
+
+    def as_dict(self) -> dict:
+        body = {}
+        if self.run_id is not None: body['run_id'] = self.run_id
+        return body
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, any]) -> 'TriggerInfo':
+        return cls(run_id=d.get('run_id', None))
+
+
+@dataclass
 class TriggerSettings:
-    file_arrival: Optional['FileArrivalTriggerSettings'] = None
-    pause_status: Optional['TriggerSettingsPauseStatus'] = None
+    file_arrival: Optional['FileArrivalTriggerConfiguration'] = None
+    pause_status: Optional['PauseStatus'] = None
 
     def as_dict(self) -> dict:
         body = {}
@@ -1983,15 +2407,8 @@ class TriggerSettings:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'TriggerSettings':
-        return cls(file_arrival=_from_dict(d, 'file_arrival', FileArrivalTriggerSettings),
-                   pause_status=_enum(d, 'pause_status', TriggerSettingsPauseStatus))
-
-
-class TriggerSettingsPauseStatus(Enum):
-    """Whether this trigger is paused or not."""
-
-    PAUSED = 'PAUSED'
-    UNPAUSED = 'UNPAUSED'
+        return cls(file_arrival=_from_dict(d, 'file_arrival', FileArrivalTriggerConfiguration),
+                   pause_status=_enum(d, 'pause_status', PauseStatus))
 
 
 class TriggerType(Enum):
@@ -2001,6 +2418,7 @@ class TriggerType(Enum):
     ONE_TIME = 'ONE_TIME'
     PERIODIC = 'PERIODIC'
     RETRY = 'RETRY'
+    RUN_JOB_TASK = 'RUN_JOB_TASK'
 
 
 @dataclass
@@ -2054,6 +2472,63 @@ class ViewsToExport(Enum):
     ALL = 'ALL'
     CODE = 'CODE'
     DASHBOARDS = 'DASHBOARDS'
+
+
+@dataclass
+class Webhook:
+    id: Optional[str] = None
+
+    def as_dict(self) -> dict:
+        body = {}
+        if self.id is not None: body['id'] = self.id
+        return body
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, any]) -> 'Webhook':
+        return cls(id=d.get('id', None))
+
+
+@dataclass
+class WebhookNotifications:
+    on_duration_warning_threshold_exceeded: Optional[
+        'List[WebhookNotificationsOnDurationWarningThresholdExceededItem]'] = None
+    on_failure: Optional['List[Webhook]'] = None
+    on_start: Optional['List[Webhook]'] = None
+    on_success: Optional['List[Webhook]'] = None
+
+    def as_dict(self) -> dict:
+        body = {}
+        if self.on_duration_warning_threshold_exceeded:
+            body['on_duration_warning_threshold_exceeded'] = [
+                v.as_dict() for v in self.on_duration_warning_threshold_exceeded
+            ]
+        if self.on_failure: body['on_failure'] = [v.as_dict() for v in self.on_failure]
+        if self.on_start: body['on_start'] = [v.as_dict() for v in self.on_start]
+        if self.on_success: body['on_success'] = [v.as_dict() for v in self.on_success]
+        return body
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, any]) -> 'WebhookNotifications':
+        return cls(on_duration_warning_threshold_exceeded=_repeated(
+            d, 'on_duration_warning_threshold_exceeded',
+            WebhookNotificationsOnDurationWarningThresholdExceededItem),
+                   on_failure=_repeated(d, 'on_failure', Webhook),
+                   on_start=_repeated(d, 'on_start', Webhook),
+                   on_success=_repeated(d, 'on_success', Webhook))
+
+
+@dataclass
+class WebhookNotificationsOnDurationWarningThresholdExceededItem:
+    id: Optional[str] = None
+
+    def as_dict(self) -> dict:
+        body = {}
+        if self.id is not None: body['id'] = self.id
+        return body
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, any]) -> 'WebhookNotificationsOnDurationWarningThresholdExceededItem':
+        return cls(id=d.get('id', None))
 
 
 class JobsAPI:
@@ -2147,39 +2622,46 @@ class JobsAPI:
     def create(self,
                *,
                access_control_list: Optional[List[iam.AccessControlRequest]] = None,
+               compute: Optional[List[JobCompute]] = None,
                continuous: Optional[Continuous] = None,
                email_notifications: Optional[JobEmailNotifications] = None,
-               format: Optional[CreateJobFormat] = None,
+               format: Optional[Format] = None,
                git_source: Optional[GitSource] = None,
+               health: Optional[JobsHealthRules] = None,
                job_clusters: Optional[List[JobCluster]] = None,
                max_concurrent_runs: Optional[int] = None,
                name: Optional[str] = None,
                notification_settings: Optional[JobNotificationSettings] = None,
+               parameters: Optional[List[JobParameterDefinition]] = None,
                run_as: Optional[JobRunAs] = None,
                schedule: Optional[CronSchedule] = None,
                tags: Optional[Dict[str, str]] = None,
-               tasks: Optional[List[JobTaskSettings]] = None,
+               tasks: Optional[List[Task]] = None,
                timeout_seconds: Optional[int] = None,
                trigger: Optional[TriggerSettings] = None,
-               webhook_notifications: Optional[JobWebhookNotifications] = None) -> CreateResponse:
+               webhook_notifications: Optional[WebhookNotifications] = None) -> CreateResponse:
         """Create a new job.
         
         Create a new job.
         
         :param access_control_list: List[:class:`AccessControlRequest`] (optional)
           List of permissions to set on the job.
+        :param compute: List[:class:`JobCompute`] (optional)
+          A list of compute requirements that can be referenced by tasks of this job.
         :param continuous: :class:`Continuous` (optional)
           An optional continuous property for this job. The continuous property will ensure that there is
           always one run executing. Only one of `schedule` and `continuous` can be used.
         :param email_notifications: :class:`JobEmailNotifications` (optional)
           An optional set of email addresses that is notified when runs of this job begin or complete as well
           as when this job is deleted. The default behavior is to not send any emails.
-        :param format: :class:`CreateJobFormat` (optional)
+        :param format: :class:`Format` (optional)
           Used to tell what is the format of the job. This field is ignored in Create/Update/Reset calls. When
           using the Jobs API 2.1 this value is always set to `"MULTI_TASK"`.
         :param git_source: :class:`GitSource` (optional)
           An optional specification for a remote repository containing the notebooks used by this job's
           notebook tasks.
+        :param health: :class:`JobsHealthRules` (optional)
+          An optional set of health rules that can be defined for this job.
         :param job_clusters: List[:class:`JobCluster`] (optional)
           A list of job cluster specifications that can be shared and reused by tasks of this job. Libraries
           cannot be declared in a shared job cluster. You must declare dependent libraries in task settings.
@@ -2198,10 +2680,12 @@ class JobsAPI:
           This value cannot exceed 1000\. Setting this value to 0 causes all new runs to be skipped. The
           default behavior is to allow only 1 concurrent run.
         :param name: str (optional)
-          An optional name for the job.
+          An optional name for the job. The maximum length is 4096 bytes in UTF-8 encoding.
         :param notification_settings: :class:`JobNotificationSettings` (optional)
           Optional notification settings that are used when sending notifications to each of the
           `email_notifications` and `webhook_notifications` for this job.
+        :param parameters: List[:class:`JobParameterDefinition`] (optional)
+          Job-level parameter definitions
         :param run_as: :class:`JobRunAs` (optional)
           Write-only setting, available only in Create/Update/Reset and Submit calls. Specifies the user or
           service principal that the job runs as. If not specified, the job runs as the user who created the
@@ -2216,7 +2700,7 @@ class JobsAPI:
           A map of tags associated with the job. These are forwarded to the cluster as cluster tags for jobs
           clusters, and are subject to the same limitations as cluster tags. A maximum of 25 tags can be added
           to the job.
-        :param tasks: List[:class:`JobTaskSettings`] (optional)
+        :param tasks: List[:class:`Task`] (optional)
           A list of task specifications to be executed by this job.
         :param timeout_seconds: int (optional)
           An optional timeout applied to each run of this job. The default behavior is to have no timeout.
@@ -2224,7 +2708,7 @@ class JobsAPI:
           Trigger settings for the job. Can be used to trigger a run when new files arrive in an external
           location. The default behavior is that the job runs only when triggered by clicking “Run Now” in
           the Jobs UI or sending an API request to `runNow`.
-        :param webhook_notifications: :class:`JobWebhookNotifications` (optional)
+        :param webhook_notifications: :class:`WebhookNotifications` (optional)
           A collection of system notification IDs to notify when the run begins or completes. The default
           behavior is to not send any system notifications.
         
@@ -2232,28 +2716,24 @@ class JobsAPI:
         """
         body = {}
         if access_control_list is not None: body['access_control_list'] = [v for v in access_control_list]
-        if continuous is not None: body['continuous'] = _validated('continuous', Continuous, continuous)
-        if email_notifications is not None:
-            body['email_notifications'] = _validated('email_notifications', JobEmailNotifications,
-                                                     email_notifications)
-        if format is not None: body['format'] = _validated('format', CreateJobFormat, format)
-        if git_source is not None: body['git_source'] = _validated('git_source', GitSource, git_source)
-        if job_clusters is not None:
-            body['job_clusters'] = [_validated('job_clusters item', JobCluster, v) for v in job_clusters]
+        if compute is not None: body['compute'] = [v.as_dict() for v in compute]
+        if continuous is not None: body['continuous'] = continuous.as_dict()
+        if email_notifications is not None: body['email_notifications'] = email_notifications.as_dict()
+        if format is not None: body['format'] = format.value
+        if git_source is not None: body['git_source'] = git_source.as_dict()
+        if health is not None: body['health'] = health.as_dict()
+        if job_clusters is not None: body['job_clusters'] = [v.as_dict() for v in job_clusters]
         if max_concurrent_runs is not None: body['max_concurrent_runs'] = max_concurrent_runs
         if name is not None: body['name'] = name
-        if notification_settings is not None:
-            body['notification_settings'] = _validated('notification_settings', JobNotificationSettings,
-                                                       notification_settings)
-        if run_as is not None: body['run_as'] = _validated('run_as', JobRunAs, run_as)
-        if schedule is not None: body['schedule'] = _validated('schedule', CronSchedule, schedule)
+        if notification_settings is not None: body['notification_settings'] = notification_settings.as_dict()
+        if parameters is not None: body['parameters'] = [v.as_dict() for v in parameters]
+        if run_as is not None: body['run_as'] = run_as.as_dict()
+        if schedule is not None: body['schedule'] = schedule.as_dict()
         if tags is not None: body['tags'] = tags
-        if tasks is not None: body['tasks'] = [_validated('tasks item', JobTaskSettings, v) for v in tasks]
+        if tasks is not None: body['tasks'] = [v.as_dict() for v in tasks]
         if timeout_seconds is not None: body['timeout_seconds'] = timeout_seconds
-        if trigger is not None: body['trigger'] = _validated('trigger', TriggerSettings, trigger)
-        if webhook_notifications is not None:
-            body['webhook_notifications'] = _validated('webhook_notifications', JobWebhookNotifications,
-                                                       webhook_notifications)
+        if trigger is not None: body['trigger'] = trigger.as_dict()
+        if webhook_notifications is not None: body['webhook_notifications'] = webhook_notifications.as_dict()
 
         json = self._api.do('POST', '/api/2.1/jobs/create', body=body)
         return CreateResponse.from_dict(json)
@@ -2301,8 +2781,7 @@ class JobsAPI:
 
         query = {}
         if run_id is not None: query['run_id'] = run_id
-        if views_to_export is not None:
-            query['views_to_export'] = _validated('views_to_export', ViewsToExport, views_to_export)
+        if views_to_export is not None: query['views_to_export'] = views_to_export.value
 
         json = self._api.do('GET', '/api/2.1/jobs/runs/export', query=query)
         return ExportRunOutput.from_dict(json)
@@ -2375,15 +2854,15 @@ class JobsAPI:
              name: Optional[str] = None,
              offset: Optional[int] = None,
              page_token: Optional[str] = None) -> Iterator[BaseJob]:
-        """List all jobs.
+        """List jobs.
         
         Retrieves a list of jobs.
         
         :param expand_tasks: bool (optional)
           Whether to include task and cluster details in the response.
         :param limit: int (optional)
-          The number of jobs to return. This value must be greater than 0 and less or equal to 25. The default
-          value is 20.
+          The number of jobs to return. This value must be greater than 0 and less or equal to 100. The
+          default value is 20.
         :param name: str (optional)
           A filter on the list based on the exact (case insensitive) job name.
         :param offset: int (optional)
@@ -2426,7 +2905,7 @@ class JobsAPI:
                   run_type: Optional[ListRunsRunType] = None,
                   start_time_from: Optional[int] = None,
                   start_time_to: Optional[int] = None) -> Iterator[BaseRun]:
-        """List runs for a job.
+        """List job runs.
         
         List runs in descending order by start time.
         
@@ -2471,7 +2950,7 @@ class JobsAPI:
         if limit is not None: query['limit'] = limit
         if offset is not None: query['offset'] = offset
         if page_token is not None: query['page_token'] = page_token
-        if run_type is not None: query['run_type'] = _validated('run_type', ListRunsRunType, run_type)
+        if run_type is not None: query['run_type'] = run_type.value
         if start_time_from is not None: query['start_time_from'] = start_time_from
         if start_time_to is not None: query['start_time_to'] = start_time_to
 
@@ -2496,6 +2975,7 @@ class JobsAPI:
                    python_named_params: Optional[Dict[str, str]] = None,
                    python_params: Optional[List[str]] = None,
                    rerun_all_failed_tasks: Optional[bool] = None,
+                   rerun_dependent_tasks: Optional[bool] = None,
                    rerun_tasks: Optional[List[str]] = None,
                    spark_submit_params: Optional[List[str]] = None,
                    sql_params: Optional[Dict[str, str]] = None) -> Wait[Run]:
@@ -2557,7 +3037,10 @@ class JobsAPI:
           
           [Task parameter variables]: https://docs.databricks.com/jobs.html#parameter-variables
         :param rerun_all_failed_tasks: bool (optional)
-          If true, repair all failed tasks. Only one of rerun_tasks or rerun_all_failed_tasks can be used.
+          If true, repair all failed tasks. Only one of `rerun_tasks` or `rerun_all_failed_tasks` can be used.
+        :param rerun_dependent_tasks: bool (optional)
+          If true, repair all tasks that depend on the tasks in `rerun_tasks`, even if they were previously
+          successful. Can be also used in combination with `rerun_all_failed_tasks`.
         :param rerun_tasks: List[str] (optional)
           The task keys of the task runs to repair.
         :param spark_submit_params: List[str] (optional)
@@ -2589,11 +3072,11 @@ class JobsAPI:
         if jar_params is not None: body['jar_params'] = [v for v in jar_params]
         if latest_repair_id is not None: body['latest_repair_id'] = latest_repair_id
         if notebook_params is not None: body['notebook_params'] = notebook_params
-        if pipeline_params is not None:
-            body['pipeline_params'] = _validated('pipeline_params', PipelineParams, pipeline_params)
+        if pipeline_params is not None: body['pipeline_params'] = pipeline_params.as_dict()
         if python_named_params is not None: body['python_named_params'] = python_named_params
         if python_params is not None: body['python_params'] = [v for v in python_params]
         if rerun_all_failed_tasks is not None: body['rerun_all_failed_tasks'] = rerun_all_failed_tasks
+        if rerun_dependent_tasks is not None: body['rerun_dependent_tasks'] = rerun_dependent_tasks
         if rerun_tasks is not None: body['rerun_tasks'] = [v for v in rerun_tasks]
         if run_id is not None: body['run_id'] = run_id
         if spark_submit_params is not None: body['spark_submit_params'] = [v for v in spark_submit_params]
@@ -2615,6 +3098,7 @@ class JobsAPI:
         python_named_params: Optional[Dict[str, str]] = None,
         python_params: Optional[List[str]] = None,
         rerun_all_failed_tasks: Optional[bool] = None,
+        rerun_dependent_tasks: Optional[bool] = None,
         rerun_tasks: Optional[List[str]] = None,
         spark_submit_params: Optional[List[str]] = None,
         sql_params: Optional[Dict[str, str]] = None,
@@ -2627,6 +3111,7 @@ class JobsAPI:
                                python_named_params=python_named_params,
                                python_params=python_params,
                                rerun_all_failed_tasks=rerun_all_failed_tasks,
+                               rerun_dependent_tasks=rerun_dependent_tasks,
                                rerun_tasks=rerun_tasks,
                                run_id=run_id,
                                spark_submit_params=spark_submit_params,
@@ -2650,8 +3135,7 @@ class JobsAPI:
         """
         body = {}
         if job_id is not None: body['job_id'] = job_id
-        if new_settings is not None:
-            body['new_settings'] = _validated('new_settings', JobSettings, new_settings)
+        if new_settings is not None: body['new_settings'] = new_settings.as_dict()
         self._api.do('POST', '/api/2.1/jobs/reset', body=body)
 
     def run_now(self,
@@ -2660,6 +3144,7 @@ class JobsAPI:
                 dbt_commands: Optional[List[str]] = None,
                 idempotency_token: Optional[str] = None,
                 jar_params: Optional[List[str]] = None,
+                job_parameters: Optional[List[Dict[str, str]]] = None,
                 notebook_params: Optional[Dict[str, str]] = None,
                 pipeline_params: Optional[PipelineParams] = None,
                 python_named_params: Optional[Dict[str, str]] = None,
@@ -2697,6 +3182,8 @@ class JobsAPI:
           
           Use [Task parameter variables](/jobs.html"#parameter-variables") to set parameters containing
           information about job runs.
+        :param job_parameters: List[Dict[str,str]] (optional)
+          Job-level parameters used in the run
         :param notebook_params: Dict[str,str] (optional)
           A map from keys to values for jobs with notebook task, for example `\"notebook_params\": {\"name\":
           \"john doe\", \"age\": \"35\"}`. The map is passed to the notebook and is accessible through the
@@ -2761,9 +3248,9 @@ class JobsAPI:
         if idempotency_token is not None: body['idempotency_token'] = idempotency_token
         if jar_params is not None: body['jar_params'] = [v for v in jar_params]
         if job_id is not None: body['job_id'] = job_id
+        if job_parameters is not None: body['job_parameters'] = [v for v in job_parameters]
         if notebook_params is not None: body['notebook_params'] = notebook_params
-        if pipeline_params is not None:
-            body['pipeline_params'] = _validated('pipeline_params', PipelineParams, pipeline_params)
+        if pipeline_params is not None: body['pipeline_params'] = pipeline_params.as_dict()
         if python_named_params is not None: body['python_named_params'] = python_named_params
         if python_params is not None: body['python_params'] = [v for v in python_params]
         if spark_submit_params is not None: body['spark_submit_params'] = [v for v in spark_submit_params]
@@ -2779,6 +3266,7 @@ class JobsAPI:
                          dbt_commands: Optional[List[str]] = None,
                          idempotency_token: Optional[str] = None,
                          jar_params: Optional[List[str]] = None,
+                         job_parameters: Optional[List[Dict[str, str]]] = None,
                          notebook_params: Optional[Dict[str, str]] = None,
                          pipeline_params: Optional[PipelineParams] = None,
                          python_named_params: Optional[Dict[str, str]] = None,
@@ -2790,6 +3278,7 @@ class JobsAPI:
                             idempotency_token=idempotency_token,
                             jar_params=jar_params,
                             job_id=job_id,
+                            job_parameters=job_parameters,
                             notebook_params=notebook_params,
                             pipeline_params=pipeline_params,
                             python_named_params=python_named_params,
@@ -2800,13 +3289,15 @@ class JobsAPI:
     def submit(self,
                *,
                access_control_list: Optional[List[iam.AccessControlRequest]] = None,
+               email_notifications: Optional[JobEmailNotifications] = None,
                git_source: Optional[GitSource] = None,
+               health: Optional[JobsHealthRules] = None,
                idempotency_token: Optional[str] = None,
                notification_settings: Optional[JobNotificationSettings] = None,
                run_name: Optional[str] = None,
-               tasks: Optional[List[RunSubmitTaskSettings]] = None,
+               tasks: Optional[List[SubmitTask]] = None,
                timeout_seconds: Optional[int] = None,
-               webhook_notifications: Optional[JobWebhookNotifications] = None) -> Wait[Run]:
+               webhook_notifications: Optional[WebhookNotifications] = None) -> Wait[Run]:
         """Create and trigger a one-time run.
         
         Submit a one-time run. This endpoint allows you to submit a workload directly without creating a job.
@@ -2815,9 +3306,14 @@ class JobsAPI:
         
         :param access_control_list: List[:class:`AccessControlRequest`] (optional)
           List of permissions to set on the job.
+        :param email_notifications: :class:`JobEmailNotifications` (optional)
+          An optional set of email addresses notified when the run begins or completes. The default behavior
+          is to not send any emails.
         :param git_source: :class:`GitSource` (optional)
           An optional specification for a remote repository containing the notebooks used by this job's
           notebook tasks.
+        :param health: :class:`JobsHealthRules` (optional)
+          An optional set of health rules that can be defined for this job.
         :param idempotency_token: str (optional)
           An optional token that can be used to guarantee the idempotency of job run requests. If a run with
           the provided token already exists, the request does not create a new run but returns the ID of the
@@ -2836,10 +3332,10 @@ class JobsAPI:
           `webhook_notifications` for this run.
         :param run_name: str (optional)
           An optional name for the run. The default value is `Untitled`.
-        :param tasks: List[:class:`RunSubmitTaskSettings`] (optional)
+        :param tasks: List[:class:`SubmitTask`] (optional)
         :param timeout_seconds: int (optional)
           An optional timeout applied to each run of this job. The default behavior is to have no timeout.
-        :param webhook_notifications: :class:`JobWebhookNotifications` (optional)
+        :param webhook_notifications: :class:`WebhookNotifications` (optional)
           A collection of system notification IDs to notify when the run begins or completes. The default
           behavior is to not send any system notifications.
         
@@ -2849,18 +3345,15 @@ class JobsAPI:
         """
         body = {}
         if access_control_list is not None: body['access_control_list'] = [v for v in access_control_list]
-        if git_source is not None: body['git_source'] = _validated('git_source', GitSource, git_source)
+        if email_notifications is not None: body['email_notifications'] = email_notifications.as_dict()
+        if git_source is not None: body['git_source'] = git_source.as_dict()
+        if health is not None: body['health'] = health.as_dict()
         if idempotency_token is not None: body['idempotency_token'] = idempotency_token
-        if notification_settings is not None:
-            body['notification_settings'] = _validated('notification_settings', JobNotificationSettings,
-                                                       notification_settings)
+        if notification_settings is not None: body['notification_settings'] = notification_settings.as_dict()
         if run_name is not None: body['run_name'] = run_name
-        if tasks is not None:
-            body['tasks'] = [_validated('tasks item', RunSubmitTaskSettings, v) for v in tasks]
+        if tasks is not None: body['tasks'] = [v.as_dict() for v in tasks]
         if timeout_seconds is not None: body['timeout_seconds'] = timeout_seconds
-        if webhook_notifications is not None:
-            body['webhook_notifications'] = _validated('webhook_notifications', JobWebhookNotifications,
-                                                       webhook_notifications)
+        if webhook_notifications is not None: body['webhook_notifications'] = webhook_notifications.as_dict()
         op_response = self._api.do('POST', '/api/2.1/jobs/runs/submit', body=body)
         return Wait(self.wait_get_run_job_terminated_or_skipped,
                     response=SubmitRunResponse.from_dict(op_response),
@@ -2870,16 +3363,20 @@ class JobsAPI:
         self,
         *,
         access_control_list: Optional[List[iam.AccessControlRequest]] = None,
+        email_notifications: Optional[JobEmailNotifications] = None,
         git_source: Optional[GitSource] = None,
+        health: Optional[JobsHealthRules] = None,
         idempotency_token: Optional[str] = None,
         notification_settings: Optional[JobNotificationSettings] = None,
         run_name: Optional[str] = None,
-        tasks: Optional[List[RunSubmitTaskSettings]] = None,
+        tasks: Optional[List[SubmitTask]] = None,
         timeout_seconds: Optional[int] = None,
-        webhook_notifications: Optional[JobWebhookNotifications] = None,
+        webhook_notifications: Optional[WebhookNotifications] = None,
         timeout=timedelta(minutes=20)) -> Run:
         return self.submit(access_control_list=access_control_list,
+                           email_notifications=email_notifications,
                            git_source=git_source,
+                           health=health,
                            idempotency_token=idempotency_token,
                            notification_settings=notification_settings,
                            run_name=run_name,
@@ -2900,11 +3397,16 @@ class JobsAPI:
         :param job_id: int
           The canonical identifier of the job to update. This field is required.
         :param fields_to_remove: List[str] (optional)
-          Remove top-level fields in the job settings. Removing nested fields is not supported. This field is
-          optional.
+          Remove top-level fields in the job settings. Removing nested fields is not supported, except for
+          tasks and job clusters (`tasks/task_1`). This field is optional.
         :param new_settings: :class:`JobSettings` (optional)
-          The new settings for the job. Any top-level fields specified in `new_settings` are completely
-          replaced. Partially updating nested fields is not supported.
+          The new settings for the job.
+          
+          Top-level fields specified in `new_settings` are completely replaced, except for arrays which are
+          merged. That is, new and existing entries are completely replaced based on the respective key
+          fields, i.e. `task_key` or `job_cluster_key`, while previous entries are kept.
+          
+          Partially updating nested fields is not supported.
           
           Changes to the field `JobSettings.timeout_seconds` are applied to active runs. Changes to other
           fields are applied to future runs only.
@@ -2914,6 +3416,5 @@ class JobsAPI:
         body = {}
         if fields_to_remove is not None: body['fields_to_remove'] = [v for v in fields_to_remove]
         if job_id is not None: body['job_id'] = job_id
-        if new_settings is not None:
-            body['new_settings'] = _validated('new_settings', JobSettings, new_settings)
+        if new_settings is not None: body['new_settings'] = new_settings.as_dict()
         self._api.do('POST', '/api/2.1/jobs/update', body=body)

--- a/databricks/sdk/service/jobs.py
+++ b/databricks/sdk/service/jobs.py
@@ -6,10 +6,10 @@ import time
 from dataclasses import dataclass
 from datetime import timedelta
 from enum import Enum
-from typing import Any, Callable, Dict, Iterator, List, Optional
+from typing import Callable, Dict, Iterator, List, Optional
 
 from ..errors import OperationFailed
-from ._internal import Wait, _enum, _from_dict, _repeated
+from ._internal import Wait, _enum, _from_dict, _repeated, _validated
 
 _LOG = logging.getLogger('databricks.sdk')
 
@@ -54,7 +54,6 @@ class BaseRun:
     git_source: Optional['GitSource'] = None
     job_clusters: Optional['List[JobCluster]'] = None
     job_id: Optional[int] = None
-    job_parameters: Optional['List[JobParameter]'] = None
     number_in_job: Optional[int] = None
     original_attempt_run_id: Optional[int] = None
     overriding_parameters: Optional['RunParameters'] = None
@@ -69,7 +68,6 @@ class BaseRun:
     state: Optional['RunState'] = None
     tasks: Optional['List[RunTask]'] = None
     trigger: Optional['TriggerType'] = None
-    trigger_info: Optional['TriggerInfo'] = None
 
     def as_dict(self) -> dict:
         body = {}
@@ -84,7 +82,6 @@ class BaseRun:
         if self.git_source: body['git_source'] = self.git_source.as_dict()
         if self.job_clusters: body['job_clusters'] = [v.as_dict() for v in self.job_clusters]
         if self.job_id is not None: body['job_id'] = self.job_id
-        if self.job_parameters: body['job_parameters'] = [v.as_dict() for v in self.job_parameters]
         if self.number_in_job is not None: body['number_in_job'] = self.number_in_job
         if self.original_attempt_run_id is not None:
             body['original_attempt_run_id'] = self.original_attempt_run_id
@@ -100,7 +97,6 @@ class BaseRun:
         if self.state: body['state'] = self.state.as_dict()
         if self.tasks: body['tasks'] = [v.as_dict() for v in self.tasks]
         if self.trigger is not None: body['trigger'] = self.trigger.value
-        if self.trigger_info: body['trigger_info'] = self.trigger_info.as_dict()
         return body
 
     @classmethod
@@ -116,7 +112,6 @@ class BaseRun:
                    git_source=_from_dict(d, 'git_source', GitSource),
                    job_clusters=_repeated(d, 'job_clusters', JobCluster),
                    job_id=d.get('job_id', None),
-                   job_parameters=_repeated(d, 'job_parameters', JobParameter),
                    number_in_job=d.get('number_in_job', None),
                    original_attempt_run_id=d.get('original_attempt_run_id', None),
                    overriding_parameters=_from_dict(d, 'overriding_parameters', RunParameters),
@@ -130,8 +125,7 @@ class BaseRun:
                    start_time=d.get('start_time', None),
                    state=_from_dict(d, 'state', RunState),
                    tasks=_repeated(d, 'tasks', RunTask),
-                   trigger=_enum(d, 'trigger', TriggerType),
-                   trigger_info=_from_dict(d, 'trigger_info', TriggerInfo))
+                   trigger=_enum(d, 'trigger', TriggerType))
 
 
 @dataclass
@@ -182,7 +176,7 @@ class ClusterInstance:
 class ClusterSpec:
     existing_cluster_id: Optional[str] = None
     libraries: Optional['List[compute.Library]'] = None
-    new_cluster: Optional['compute.ClusterSpec'] = None
+    new_cluster: Optional['compute.BaseClusterInfo'] = None
 
     def as_dict(self) -> dict:
         body = {}
@@ -195,49 +189,12 @@ class ClusterSpec:
     def from_dict(cls, d: Dict[str, any]) -> 'ClusterSpec':
         return cls(existing_cluster_id=d.get('existing_cluster_id', None),
                    libraries=_repeated(d, 'libraries', compute.Library),
-                   new_cluster=_from_dict(d, 'new_cluster', compute.ClusterSpec))
-
-
-@dataclass
-class ConditionTask:
-    left: Optional[str] = None
-    op: Optional['ConditionTaskOp'] = None
-    right: Optional[str] = None
-
-    def as_dict(self) -> dict:
-        body = {}
-        if self.left is not None: body['left'] = self.left
-        if self.op is not None: body['op'] = self.op.value
-        if self.right is not None: body['right'] = self.right
-        return body
-
-    @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> 'ConditionTask':
-        return cls(left=d.get('left', None), op=_enum(d, 'op', ConditionTaskOp), right=d.get('right', None))
-
-
-class ConditionTaskOp(Enum):
-    """* `EQUAL_TO`, `NOT_EQUAL` operators perform string comparison of their operands. This means that
-    `“12.0” == “12”` will evaluate to `false`. * `GREATER_THAN`, `GREATER_THAN_OR_EQUAL`,
-    `LESS_THAN`, `LESS_THAN_OR_EQUAL` operators perform numeric comparison of their operands.
-    `“12.0” >= “12”` will evaluate to `true`, `“10.0” >= “12”` will evaluate to
-    `false`.
-    
-    The boolean comparison to task values can be implemented with operators `EQUAL_TO`, `NOT_EQUAL`.
-    If a task value was set to a boolean value, it will be serialized to `“true”` or
-    `“false”` for the comparison."""
-
-    EQUAL_TO = 'EQUAL_TO'
-    GREATER_THAN = 'GREATER_THAN'
-    GREATER_THAN_OR_EQUAL = 'GREATER_THAN_OR_EQUAL'
-    LESS_THAN = 'LESS_THAN'
-    LESS_THAN_OR_EQUAL = 'LESS_THAN_OR_EQUAL'
-    NOT_EQUAL = 'NOT_EQUAL'
+                   new_cluster=_from_dict(d, 'new_cluster', compute.BaseClusterInfo))
 
 
 @dataclass
 class Continuous:
-    pause_status: Optional['PauseStatus'] = None
+    pause_status: Optional['ContinuousPauseStatus'] = None
 
     def as_dict(self) -> dict:
         body = {}
@@ -246,46 +203,47 @@ class Continuous:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'Continuous':
-        return cls(pause_status=_enum(d, 'pause_status', PauseStatus))
+        return cls(pause_status=_enum(d, 'pause_status', ContinuousPauseStatus))
+
+
+class ContinuousPauseStatus(Enum):
+    """Indicate whether the continuous execution of the job is paused or not. Defaults to UNPAUSED."""
+
+    PAUSED = 'PAUSED'
+    UNPAUSED = 'UNPAUSED'
 
 
 @dataclass
 class CreateJob:
     access_control_list: Optional['List[iam.AccessControlRequest]'] = None
-    compute: Optional['List[JobCompute]'] = None
     continuous: Optional['Continuous'] = None
     email_notifications: Optional['JobEmailNotifications'] = None
-    format: Optional['Format'] = None
+    format: Optional['CreateJobFormat'] = None
     git_source: Optional['GitSource'] = None
-    health: Optional['JobsHealthRules'] = None
     job_clusters: Optional['List[JobCluster]'] = None
     max_concurrent_runs: Optional[int] = None
     name: Optional[str] = None
     notification_settings: Optional['JobNotificationSettings'] = None
-    parameters: Optional['List[JobParameterDefinition]'] = None
     run_as: Optional['JobRunAs'] = None
     schedule: Optional['CronSchedule'] = None
     tags: Optional['Dict[str,str]'] = None
-    tasks: Optional['List[Task]'] = None
+    tasks: Optional['List[JobTaskSettings]'] = None
     timeout_seconds: Optional[int] = None
     trigger: Optional['TriggerSettings'] = None
-    webhook_notifications: Optional['WebhookNotifications'] = None
+    webhook_notifications: Optional['JobWebhookNotifications'] = None
 
     def as_dict(self) -> dict:
         body = {}
         if self.access_control_list:
             body['access_control_list'] = [v.as_dict() for v in self.access_control_list]
-        if self.compute: body['compute'] = [v.as_dict() for v in self.compute]
         if self.continuous: body['continuous'] = self.continuous.as_dict()
         if self.email_notifications: body['email_notifications'] = self.email_notifications.as_dict()
         if self.format is not None: body['format'] = self.format.value
         if self.git_source: body['git_source'] = self.git_source.as_dict()
-        if self.health: body['health'] = self.health.as_dict()
         if self.job_clusters: body['job_clusters'] = [v.as_dict() for v in self.job_clusters]
         if self.max_concurrent_runs is not None: body['max_concurrent_runs'] = self.max_concurrent_runs
         if self.name is not None: body['name'] = self.name
         if self.notification_settings: body['notification_settings'] = self.notification_settings.as_dict()
-        if self.parameters: body['parameters'] = [v.as_dict() for v in self.parameters]
         if self.run_as: body['run_as'] = self.run_as.as_dict()
         if self.schedule: body['schedule'] = self.schedule.as_dict()
         if self.tags: body['tags'] = self.tags
@@ -298,24 +256,29 @@ class CreateJob:
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'CreateJob':
         return cls(access_control_list=_repeated(d, 'access_control_list', iam.AccessControlRequest),
-                   compute=_repeated(d, 'compute', JobCompute),
                    continuous=_from_dict(d, 'continuous', Continuous),
                    email_notifications=_from_dict(d, 'email_notifications', JobEmailNotifications),
-                   format=_enum(d, 'format', Format),
+                   format=_enum(d, 'format', CreateJobFormat),
                    git_source=_from_dict(d, 'git_source', GitSource),
-                   health=_from_dict(d, 'health', JobsHealthRules),
                    job_clusters=_repeated(d, 'job_clusters', JobCluster),
                    max_concurrent_runs=d.get('max_concurrent_runs', None),
                    name=d.get('name', None),
                    notification_settings=_from_dict(d, 'notification_settings', JobNotificationSettings),
-                   parameters=_repeated(d, 'parameters', JobParameterDefinition),
                    run_as=_from_dict(d, 'run_as', JobRunAs),
                    schedule=_from_dict(d, 'schedule', CronSchedule),
                    tags=d.get('tags', None),
-                   tasks=_repeated(d, 'tasks', Task),
+                   tasks=_repeated(d, 'tasks', JobTaskSettings),
                    timeout_seconds=d.get('timeout_seconds', None),
                    trigger=_from_dict(d, 'trigger', TriggerSettings),
-                   webhook_notifications=_from_dict(d, 'webhook_notifications', WebhookNotifications))
+                   webhook_notifications=_from_dict(d, 'webhook_notifications', JobWebhookNotifications))
+
+
+class CreateJobFormat(Enum):
+    """Used to tell what is the format of the job. This field is ignored in Create/Update/Reset calls.
+    When using the Jobs API 2.1 this value is always set to `"MULTI_TASK"`."""
+
+    MULTI_TASK = 'MULTI_TASK'
+    SINGLE_TASK = 'SINGLE_TASK'
 
 
 @dataclass
@@ -336,7 +299,7 @@ class CreateResponse:
 class CronSchedule:
     quartz_cron_expression: str
     timezone_id: str
-    pause_status: Optional['PauseStatus'] = None
+    pause_status: Optional['CronSchedulePauseStatus'] = None
 
     def as_dict(self) -> dict:
         body = {}
@@ -348,9 +311,16 @@ class CronSchedule:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'CronSchedule':
-        return cls(pause_status=_enum(d, 'pause_status', PauseStatus),
+        return cls(pause_status=_enum(d, 'pause_status', CronSchedulePauseStatus),
                    quartz_cron_expression=d.get('quartz_cron_expression', None),
                    timezone_id=d.get('timezone_id', None))
+
+
+class CronSchedulePauseStatus(Enum):
+    """Indicate whether this schedule is paused or not."""
+
+    PAUSED = 'PAUSED'
+    UNPAUSED = 'UNPAUSED'
 
 
 @dataclass
@@ -442,73 +412,25 @@ class ExportRunOutput:
 
 
 @dataclass
-class ExportRunRequest:
-    """Export and retrieve a job run"""
-
-    run_id: int
-    views_to_export: Optional['ViewsToExport'] = None
-
-
-@dataclass
-class FileArrivalTriggerConfiguration:
-    min_time_between_triggers_seconds: Optional[int] = None
+class FileArrivalTriggerSettings:
+    min_time_between_trigger_seconds: Optional[int] = None
     url: Optional[str] = None
     wait_after_last_change_seconds: Optional[int] = None
 
     def as_dict(self) -> dict:
         body = {}
-        if self.min_time_between_triggers_seconds is not None:
-            body['min_time_between_triggers_seconds'] = self.min_time_between_triggers_seconds
+        if self.min_time_between_trigger_seconds is not None:
+            body['min_time_between_trigger_seconds'] = self.min_time_between_trigger_seconds
         if self.url is not None: body['url'] = self.url
         if self.wait_after_last_change_seconds is not None:
             body['wait_after_last_change_seconds'] = self.wait_after_last_change_seconds
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> 'FileArrivalTriggerConfiguration':
-        return cls(min_time_between_triggers_seconds=d.get('min_time_between_triggers_seconds', None),
+    def from_dict(cls, d: Dict[str, any]) -> 'FileArrivalTriggerSettings':
+        return cls(min_time_between_trigger_seconds=d.get('min_time_between_trigger_seconds', None),
                    url=d.get('url', None),
                    wait_after_last_change_seconds=d.get('wait_after_last_change_seconds', None))
-
-
-class Format(Enum):
-
-    MULTI_TASK = 'MULTI_TASK'
-    SINGLE_TASK = 'SINGLE_TASK'
-
-
-@dataclass
-class GetJobRequest:
-    """Get a single job"""
-
-    job_id: int
-
-
-@dataclass
-class GetRunOutputRequest:
-    """Get the output for a single run"""
-
-    run_id: int
-
-
-@dataclass
-class GetRunRequest:
-    """Get a single job run"""
-
-    run_id: int
-    include_history: Optional[bool] = None
-
-
-class GitProvider(Enum):
-
-    AWS_CODE_COMMIT = 'awsCodeCommit'
-    AZURE_DEV_OPS_SERVICES = 'azureDevOpsServices'
-    BITBUCKET_CLOUD = 'bitbucketCloud'
-    BITBUCKET_SERVER = 'bitbucketServer'
-    GIT_HUB = 'gitHub'
-    GIT_HUB_ENTERPRISE = 'gitHubEnterprise'
-    GIT_LAB = 'gitLab'
-    GIT_LAB_ENTERPRISE_EDITION = 'gitLabEnterpriseEdition'
 
 
 @dataclass
@@ -534,12 +456,11 @@ class GitSource:
     notebook tasks."""
 
     git_url: str
-    git_provider: 'GitProvider'
+    git_provider: 'GitSourceGitProvider'
     git_branch: Optional[str] = None
     git_commit: Optional[str] = None
     git_snapshot: Optional['GitSnapshot'] = None
     git_tag: Optional[str] = None
-    job_source: Optional['JobSource'] = None
 
     def as_dict(self) -> dict:
         body = {}
@@ -549,18 +470,29 @@ class GitSource:
         if self.git_snapshot: body['git_snapshot'] = self.git_snapshot.as_dict()
         if self.git_tag is not None: body['git_tag'] = self.git_tag
         if self.git_url is not None: body['git_url'] = self.git_url
-        if self.job_source: body['job_source'] = self.job_source.as_dict()
         return body
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'GitSource':
         return cls(git_branch=d.get('git_branch', None),
                    git_commit=d.get('git_commit', None),
-                   git_provider=_enum(d, 'git_provider', GitProvider),
+                   git_provider=_enum(d, 'git_provider', GitSourceGitProvider),
                    git_snapshot=_from_dict(d, 'git_snapshot', GitSnapshot),
                    git_tag=d.get('git_tag', None),
-                   git_url=d.get('git_url', None),
-                   job_source=_from_dict(d, 'job_source', JobSource))
+                   git_url=d.get('git_url', None))
+
+
+class GitSourceGitProvider(Enum):
+    """Unique identifier of the service used to host the Git repository. The value is case insensitive."""
+
+    AWS_CODE_COMMIT = 'awsCodeCommit'
+    AZURE_DEV_OPS_SERVICES = 'azureDevOpsServices'
+    BITBUCKET_CLOUD = 'bitbucketCloud'
+    BITBUCKET_SERVER = 'bitbucketServer'
+    GIT_HUB = 'gitHub'
+    GIT_HUB_ENTERPRISE = 'gitHubEnterprise'
+    GIT_LAB = 'gitLab'
+    GIT_LAB_ENTERPRISE_EDITION = 'gitLabEnterpriseEdition'
 
 
 @dataclass
@@ -595,7 +527,7 @@ class Job:
 @dataclass
 class JobCluster:
     job_cluster_key: str
-    new_cluster: Optional['compute.ClusterSpec'] = None
+    new_cluster: Optional['compute.BaseClusterInfo'] = None
 
     def as_dict(self) -> dict:
         body = {}
@@ -606,29 +538,12 @@ class JobCluster:
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'JobCluster':
         return cls(job_cluster_key=d.get('job_cluster_key', None),
-                   new_cluster=_from_dict(d, 'new_cluster', compute.ClusterSpec))
-
-
-@dataclass
-class JobCompute:
-    compute_key: str
-    spec: 'compute.ComputeSpec'
-
-    def as_dict(self) -> dict:
-        body = {}
-        if self.compute_key is not None: body['compute_key'] = self.compute_key
-        if self.spec: body['spec'] = self.spec.as_dict()
-        return body
-
-    @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> 'JobCompute':
-        return cls(compute_key=d.get('compute_key', None), spec=_from_dict(d, 'spec', compute.ComputeSpec))
+                   new_cluster=_from_dict(d, 'new_cluster', compute.BaseClusterInfo))
 
 
 @dataclass
 class JobEmailNotifications:
     no_alert_for_skipped_runs: Optional[bool] = None
-    on_duration_warning_threshold_exceeded: Optional['List[str]'] = None
     on_failure: Optional['List[str]'] = None
     on_start: Optional['List[str]'] = None
     on_success: Optional['List[str]'] = None
@@ -637,10 +552,6 @@ class JobEmailNotifications:
         body = {}
         if self.no_alert_for_skipped_runs is not None:
             body['no_alert_for_skipped_runs'] = self.no_alert_for_skipped_runs
-        if self.on_duration_warning_threshold_exceeded:
-            body['on_duration_warning_threshold_exceeded'] = [
-                v for v in self.on_duration_warning_threshold_exceeded
-            ]
         if self.on_failure: body['on_failure'] = [v for v in self.on_failure]
         if self.on_start: body['on_start'] = [v for v in self.on_start]
         if self.on_success: body['on_success'] = [v for v in self.on_success]
@@ -649,8 +560,6 @@ class JobEmailNotifications:
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'JobEmailNotifications':
         return cls(no_alert_for_skipped_runs=d.get('no_alert_for_skipped_runs', None),
-                   on_duration_warning_threshold_exceeded=d.get('on_duration_warning_threshold_exceeded',
-                                                                None),
                    on_failure=d.get('on_failure', None),
                    on_start=d.get('on_start', None),
                    on_success=d.get('on_success', None))
@@ -673,40 +582,6 @@ class JobNotificationSettings:
     def from_dict(cls, d: Dict[str, any]) -> 'JobNotificationSettings':
         return cls(no_alert_for_canceled_runs=d.get('no_alert_for_canceled_runs', None),
                    no_alert_for_skipped_runs=d.get('no_alert_for_skipped_runs', None))
-
-
-@dataclass
-class JobParameter:
-    default: Optional[str] = None
-    name: Optional[str] = None
-    value: Optional[str] = None
-
-    def as_dict(self) -> dict:
-        body = {}
-        if self.default is not None: body['default'] = self.default
-        if self.name is not None: body['name'] = self.name
-        if self.value is not None: body['value'] = self.value
-        return body
-
-    @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> 'JobParameter':
-        return cls(default=d.get('default', None), name=d.get('name', None), value=d.get('value', None))
-
-
-@dataclass
-class JobParameterDefinition:
-    name: str
-    default: str
-
-    def as_dict(self) -> dict:
-        body = {}
-        if self.default is not None: body['default'] = self.default
-        if self.name is not None: body['name'] = self.name
-        return body
-
-    @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> 'JobParameterDefinition':
-        return cls(default=d.get('default', None), name=d.get('name', None))
 
 
 @dataclass
@@ -736,38 +611,32 @@ class JobRunAs:
 
 @dataclass
 class JobSettings:
-    compute: Optional['List[JobCompute]'] = None
     continuous: Optional['Continuous'] = None
     email_notifications: Optional['JobEmailNotifications'] = None
-    format: Optional['Format'] = None
+    format: Optional['JobSettingsFormat'] = None
     git_source: Optional['GitSource'] = None
-    health: Optional['JobsHealthRules'] = None
     job_clusters: Optional['List[JobCluster]'] = None
     max_concurrent_runs: Optional[int] = None
     name: Optional[str] = None
     notification_settings: Optional['JobNotificationSettings'] = None
-    parameters: Optional['List[JobParameterDefinition]'] = None
     run_as: Optional['JobRunAs'] = None
     schedule: Optional['CronSchedule'] = None
     tags: Optional['Dict[str,str]'] = None
-    tasks: Optional['List[Task]'] = None
+    tasks: Optional['List[JobTaskSettings]'] = None
     timeout_seconds: Optional[int] = None
     trigger: Optional['TriggerSettings'] = None
-    webhook_notifications: Optional['WebhookNotifications'] = None
+    webhook_notifications: Optional['JobWebhookNotifications'] = None
 
     def as_dict(self) -> dict:
         body = {}
-        if self.compute: body['compute'] = [v.as_dict() for v in self.compute]
         if self.continuous: body['continuous'] = self.continuous.as_dict()
         if self.email_notifications: body['email_notifications'] = self.email_notifications.as_dict()
         if self.format is not None: body['format'] = self.format.value
         if self.git_source: body['git_source'] = self.git_source.as_dict()
-        if self.health: body['health'] = self.health.as_dict()
         if self.job_clusters: body['job_clusters'] = [v.as_dict() for v in self.job_clusters]
         if self.max_concurrent_runs is not None: body['max_concurrent_runs'] = self.max_concurrent_runs
         if self.name is not None: body['name'] = self.name
         if self.notification_settings: body['notification_settings'] = self.notification_settings.as_dict()
-        if self.parameters: body['parameters'] = [v.as_dict() for v in self.parameters]
         if self.run_as: body['run_as'] = self.run_as.as_dict()
         if self.schedule: body['schedule'] = self.schedule.as_dict()
         if self.tags: body['tags'] = self.tags
@@ -779,113 +648,166 @@ class JobSettings:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'JobSettings':
-        return cls(compute=_repeated(d, 'compute', JobCompute),
-                   continuous=_from_dict(d, 'continuous', Continuous),
+        return cls(continuous=_from_dict(d, 'continuous', Continuous),
                    email_notifications=_from_dict(d, 'email_notifications', JobEmailNotifications),
-                   format=_enum(d, 'format', Format),
+                   format=_enum(d, 'format', JobSettingsFormat),
                    git_source=_from_dict(d, 'git_source', GitSource),
-                   health=_from_dict(d, 'health', JobsHealthRules),
                    job_clusters=_repeated(d, 'job_clusters', JobCluster),
                    max_concurrent_runs=d.get('max_concurrent_runs', None),
                    name=d.get('name', None),
                    notification_settings=_from_dict(d, 'notification_settings', JobNotificationSettings),
-                   parameters=_repeated(d, 'parameters', JobParameterDefinition),
                    run_as=_from_dict(d, 'run_as', JobRunAs),
                    schedule=_from_dict(d, 'schedule', CronSchedule),
                    tags=d.get('tags', None),
-                   tasks=_repeated(d, 'tasks', Task),
+                   tasks=_repeated(d, 'tasks', JobTaskSettings),
                    timeout_seconds=d.get('timeout_seconds', None),
                    trigger=_from_dict(d, 'trigger', TriggerSettings),
-                   webhook_notifications=_from_dict(d, 'webhook_notifications', WebhookNotifications))
+                   webhook_notifications=_from_dict(d, 'webhook_notifications', JobWebhookNotifications))
+
+
+class JobSettingsFormat(Enum):
+    """Used to tell what is the format of the job. This field is ignored in Create/Update/Reset calls.
+    When using the Jobs API 2.1 this value is always set to `"MULTI_TASK"`."""
+
+    MULTI_TASK = 'MULTI_TASK'
+    SINGLE_TASK = 'SINGLE_TASK'
 
 
 @dataclass
-class JobSource:
-    """The source of the job specification in the remote repository when the job is source controlled."""
-
-    job_config_path: str
-    import_from_git_branch: str
-    dirty_state: Optional['JobSourceDirtyState'] = None
+class JobTaskSettings:
+    task_key: str
+    dbt_task: Optional['DbtTask'] = None
+    depends_on: Optional['List[TaskDependenciesItem]'] = None
+    description: Optional[str] = None
+    email_notifications: Optional['TaskEmailNotifications'] = None
+    existing_cluster_id: Optional[str] = None
+    job_cluster_key: Optional[str] = None
+    libraries: Optional['List[compute.Library]'] = None
+    max_retries: Optional[int] = None
+    min_retry_interval_millis: Optional[int] = None
+    new_cluster: Optional['compute.BaseClusterInfo'] = None
+    notebook_task: Optional['NotebookTask'] = None
+    notification_settings: Optional['TaskNotificationSettings'] = None
+    pipeline_task: Optional['PipelineTask'] = None
+    python_wheel_task: Optional['PythonWheelTask'] = None
+    retry_on_timeout: Optional[bool] = None
+    spark_jar_task: Optional['SparkJarTask'] = None
+    spark_python_task: Optional['SparkPythonTask'] = None
+    spark_submit_task: Optional['SparkSubmitTask'] = None
+    sql_task: Optional['SqlTask'] = None
+    timeout_seconds: Optional[int] = None
 
     def as_dict(self) -> dict:
         body = {}
-        if self.dirty_state is not None: body['dirty_state'] = self.dirty_state.value
-        if self.import_from_git_branch is not None:
-            body['import_from_git_branch'] = self.import_from_git_branch
-        if self.job_config_path is not None: body['job_config_path'] = self.job_config_path
+        if self.dbt_task: body['dbt_task'] = self.dbt_task.as_dict()
+        if self.depends_on: body['depends_on'] = [v.as_dict() for v in self.depends_on]
+        if self.description is not None: body['description'] = self.description
+        if self.email_notifications: body['email_notifications'] = self.email_notifications.as_dict()
+        if self.existing_cluster_id is not None: body['existing_cluster_id'] = self.existing_cluster_id
+        if self.job_cluster_key is not None: body['job_cluster_key'] = self.job_cluster_key
+        if self.libraries: body['libraries'] = [v.as_dict() for v in self.libraries]
+        if self.max_retries is not None: body['max_retries'] = self.max_retries
+        if self.min_retry_interval_millis is not None:
+            body['min_retry_interval_millis'] = self.min_retry_interval_millis
+        if self.new_cluster: body['new_cluster'] = self.new_cluster.as_dict()
+        if self.notebook_task: body['notebook_task'] = self.notebook_task.as_dict()
+        if self.notification_settings: body['notification_settings'] = self.notification_settings.as_dict()
+        if self.pipeline_task: body['pipeline_task'] = self.pipeline_task.as_dict()
+        if self.python_wheel_task: body['python_wheel_task'] = self.python_wheel_task.as_dict()
+        if self.retry_on_timeout is not None: body['retry_on_timeout'] = self.retry_on_timeout
+        if self.spark_jar_task: body['spark_jar_task'] = self.spark_jar_task.as_dict()
+        if self.spark_python_task: body['spark_python_task'] = self.spark_python_task.as_dict()
+        if self.spark_submit_task: body['spark_submit_task'] = self.spark_submit_task.as_dict()
+        if self.sql_task: body['sql_task'] = self.sql_task.as_dict()
+        if self.task_key is not None: body['task_key'] = self.task_key
+        if self.timeout_seconds is not None: body['timeout_seconds'] = self.timeout_seconds
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> 'JobSource':
-        return cls(dirty_state=_enum(d, 'dirty_state', JobSourceDirtyState),
-                   import_from_git_branch=d.get('import_from_git_branch', None),
-                   job_config_path=d.get('job_config_path', None))
-
-
-class JobSourceDirtyState(Enum):
-    """This describes an enum"""
-
-    DISCONNECTED = 'DISCONNECTED'
-    NOT_SYNCED = 'NOT_SYNCED'
-
-
-class JobsHealthMetric(Enum):
-    """Specifies the health metric that is being evaluated for a particular health rule."""
-
-    RUN_DURATION_SECONDS = 'RUN_DURATION_SECONDS'
-
-
-class JobsHealthOperator(Enum):
-    """Specifies the operator used to compare the health metric value with the specified threshold."""
-
-    GREATER_THAN = 'GREATER_THAN'
+    def from_dict(cls, d: Dict[str, any]) -> 'JobTaskSettings':
+        return cls(dbt_task=_from_dict(d, 'dbt_task', DbtTask),
+                   depends_on=_repeated(d, 'depends_on', TaskDependenciesItem),
+                   description=d.get('description', None),
+                   email_notifications=_from_dict(d, 'email_notifications', TaskEmailNotifications),
+                   existing_cluster_id=d.get('existing_cluster_id', None),
+                   job_cluster_key=d.get('job_cluster_key', None),
+                   libraries=_repeated(d, 'libraries', compute.Library),
+                   max_retries=d.get('max_retries', None),
+                   min_retry_interval_millis=d.get('min_retry_interval_millis', None),
+                   new_cluster=_from_dict(d, 'new_cluster', compute.BaseClusterInfo),
+                   notebook_task=_from_dict(d, 'notebook_task', NotebookTask),
+                   notification_settings=_from_dict(d, 'notification_settings', TaskNotificationSettings),
+                   pipeline_task=_from_dict(d, 'pipeline_task', PipelineTask),
+                   python_wheel_task=_from_dict(d, 'python_wheel_task', PythonWheelTask),
+                   retry_on_timeout=d.get('retry_on_timeout', None),
+                   spark_jar_task=_from_dict(d, 'spark_jar_task', SparkJarTask),
+                   spark_python_task=_from_dict(d, 'spark_python_task', SparkPythonTask),
+                   spark_submit_task=_from_dict(d, 'spark_submit_task', SparkSubmitTask),
+                   sql_task=_from_dict(d, 'sql_task', SqlTask),
+                   task_key=d.get('task_key', None),
+                   timeout_seconds=d.get('timeout_seconds', None))
 
 
 @dataclass
-class JobsHealthRule:
-    metric: Optional['JobsHealthMetric'] = None
-    op: Optional['JobsHealthOperator'] = None
-    value: Optional[int] = None
+class JobWebhookNotifications:
+    on_failure: Optional['List[JobWebhookNotificationsOnFailureItem]'] = None
+    on_start: Optional['List[JobWebhookNotificationsOnStartItem]'] = None
+    on_success: Optional['List[JobWebhookNotificationsOnSuccessItem]'] = None
 
     def as_dict(self) -> dict:
         body = {}
-        if self.metric is not None: body['metric'] = self.metric.value
-        if self.op is not None: body['op'] = self.op.value
-        if self.value is not None: body['value'] = self.value
+        if self.on_failure: body['on_failure'] = [v.as_dict() for v in self.on_failure]
+        if self.on_start: body['on_start'] = [v.as_dict() for v in self.on_start]
+        if self.on_success: body['on_success'] = [v.as_dict() for v in self.on_success]
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> 'JobsHealthRule':
-        return cls(metric=_enum(d, 'metric', JobsHealthMetric),
-                   op=_enum(d, 'op', JobsHealthOperator),
-                   value=d.get('value', None))
+    def from_dict(cls, d: Dict[str, any]) -> 'JobWebhookNotifications':
+        return cls(on_failure=_repeated(d, 'on_failure', JobWebhookNotificationsOnFailureItem),
+                   on_start=_repeated(d, 'on_start', JobWebhookNotificationsOnStartItem),
+                   on_success=_repeated(d, 'on_success', JobWebhookNotificationsOnSuccessItem))
 
 
 @dataclass
-class JobsHealthRules:
-    """An optional set of health rules that can be defined for this job."""
-
-    rules: Optional['List[JobsHealthRule]'] = None
+class JobWebhookNotificationsOnFailureItem:
+    id: Optional[str] = None
 
     def as_dict(self) -> dict:
         body = {}
-        if self.rules: body['rules'] = [v.as_dict() for v in self.rules]
+        if self.id is not None: body['id'] = self.id
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> 'JobsHealthRules':
-        return cls(rules=_repeated(d, 'rules', JobsHealthRule))
+    def from_dict(cls, d: Dict[str, any]) -> 'JobWebhookNotificationsOnFailureItem':
+        return cls(id=d.get('id', None))
 
 
 @dataclass
-class ListJobsRequest:
-    """List jobs"""
+class JobWebhookNotificationsOnStartItem:
+    id: Optional[str] = None
 
-    expand_tasks: Optional[bool] = None
-    limit: Optional[int] = None
-    name: Optional[str] = None
-    offset: Optional[int] = None
-    page_token: Optional[str] = None
+    def as_dict(self) -> dict:
+        body = {}
+        if self.id is not None: body['id'] = self.id
+        return body
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, any]) -> 'JobWebhookNotificationsOnStartItem':
+        return cls(id=d.get('id', None))
+
+
+@dataclass
+class JobWebhookNotificationsOnSuccessItem:
+    id: Optional[str] = None
+
+    def as_dict(self) -> dict:
+        body = {}
+        if self.id is not None: body['id'] = self.id
+        return body
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, any]) -> 'JobWebhookNotificationsOnSuccessItem':
+        return cls(id=d.get('id', None))
 
 
 @dataclass
@@ -909,22 +831,6 @@ class ListJobsResponse:
                    jobs=_repeated(d, 'jobs', BaseJob),
                    next_page_token=d.get('next_page_token', None),
                    prev_page_token=d.get('prev_page_token', None))
-
-
-@dataclass
-class ListRunsRequest:
-    """List job runs"""
-
-    active_only: Optional[bool] = None
-    completed_only: Optional[bool] = None
-    expand_tasks: Optional[bool] = None
-    job_id: Optional[int] = None
-    limit: Optional[int] = None
-    offset: Optional[int] = None
-    page_token: Optional[str] = None
-    run_type: Optional['ListRunsRunType'] = None
-    start_time_from: Optional[int] = None
-    start_time_to: Optional[int] = None
 
 
 @dataclass
@@ -978,7 +884,7 @@ class NotebookOutput:
 class NotebookTask:
     notebook_path: str
     base_parameters: Optional['Dict[str,str]'] = None
-    source: Optional['Source'] = None
+    source: Optional['NotebookTaskSource'] = None
 
     def as_dict(self) -> dict:
         body = {}
@@ -991,16 +897,14 @@ class NotebookTask:
     def from_dict(cls, d: Dict[str, any]) -> 'NotebookTask':
         return cls(base_parameters=d.get('base_parameters', None),
                    notebook_path=d.get('notebook_path', None),
-                   source=_enum(d, 'source', Source))
+                   source=_enum(d, 'source', NotebookTaskSource))
 
 
-ParamPairs = Dict[str, str]
+class NotebookTaskSource(Enum):
+    """This describes an enum"""
 
-
-class PauseStatus(Enum):
-
-    PAUSED = 'PAUSED'
-    UNPAUSED = 'UNPAUSED'
+    GIT = 'GIT'
+    WORKSPACE = 'WORKSPACE'
 
 
 @dataclass
@@ -1103,7 +1007,6 @@ class RepairRun:
     python_named_params: Optional['Dict[str,str]'] = None
     python_params: Optional['List[str]'] = None
     rerun_all_failed_tasks: Optional[bool] = None
-    rerun_dependent_tasks: Optional[bool] = None
     rerun_tasks: Optional['List[str]'] = None
     spark_submit_params: Optional['List[str]'] = None
     sql_params: Optional['Dict[str,str]'] = None
@@ -1119,7 +1022,6 @@ class RepairRun:
         if self.python_params: body['python_params'] = [v for v in self.python_params]
         if self.rerun_all_failed_tasks is not None:
             body['rerun_all_failed_tasks'] = self.rerun_all_failed_tasks
-        if self.rerun_dependent_tasks is not None: body['rerun_dependent_tasks'] = self.rerun_dependent_tasks
         if self.rerun_tasks: body['rerun_tasks'] = [v for v in self.rerun_tasks]
         if self.run_id is not None: body['run_id'] = self.run_id
         if self.spark_submit_params: body['spark_submit_params'] = [v for v in self.spark_submit_params]
@@ -1136,7 +1038,6 @@ class RepairRun:
                    python_named_params=d.get('python_named_params', None),
                    python_params=d.get('python_params', None),
                    rerun_all_failed_tasks=d.get('rerun_all_failed_tasks', None),
-                   rerun_dependent_tasks=d.get('rerun_dependent_tasks', None),
                    rerun_tasks=d.get('rerun_tasks', None),
                    run_id=d.get('run_id', None),
                    spark_submit_params=d.get('spark_submit_params', None),
@@ -1174,151 +1075,6 @@ class ResetJob:
 
 
 @dataclass
-class ResolvedConditionTaskValues:
-    left: Optional[str] = None
-    right: Optional[str] = None
-
-    def as_dict(self) -> dict:
-        body = {}
-        if self.left is not None: body['left'] = self.left
-        if self.right is not None: body['right'] = self.right
-        return body
-
-    @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> 'ResolvedConditionTaskValues':
-        return cls(left=d.get('left', None), right=d.get('right', None))
-
-
-@dataclass
-class ResolvedDbtTaskValues:
-    commands: Optional['List[str]'] = None
-
-    def as_dict(self) -> dict:
-        body = {}
-        if self.commands: body['commands'] = [v for v in self.commands]
-        return body
-
-    @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> 'ResolvedDbtTaskValues':
-        return cls(commands=d.get('commands', None))
-
-
-@dataclass
-class ResolvedNotebookTaskValues:
-    base_parameters: Optional['Dict[str,str]'] = None
-
-    def as_dict(self) -> dict:
-        body = {}
-        if self.base_parameters: body['base_parameters'] = self.base_parameters
-        return body
-
-    @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> 'ResolvedNotebookTaskValues':
-        return cls(base_parameters=d.get('base_parameters', None))
-
-
-@dataclass
-class ResolvedParamPairValues:
-    parameters: Optional['Dict[str,str]'] = None
-
-    def as_dict(self) -> dict:
-        body = {}
-        if self.parameters: body['parameters'] = self.parameters
-        return body
-
-    @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> 'ResolvedParamPairValues':
-        return cls(parameters=d.get('parameters', None))
-
-
-@dataclass
-class ResolvedPythonWheelTaskValues:
-    named_parameters: Optional['Dict[str,str]'] = None
-    parameters: Optional['List[str]'] = None
-
-    def as_dict(self) -> dict:
-        body = {}
-        if self.named_parameters: body['named_parameters'] = self.named_parameters
-        if self.parameters: body['parameters'] = [v for v in self.parameters]
-        return body
-
-    @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> 'ResolvedPythonWheelTaskValues':
-        return cls(named_parameters=d.get('named_parameters', None), parameters=d.get('parameters', None))
-
-
-@dataclass
-class ResolvedRunJobTaskValues:
-    named_parameters: Optional['Dict[str,str]'] = None
-    parameters: Optional['Dict[str,str]'] = None
-
-    def as_dict(self) -> dict:
-        body = {}
-        if self.named_parameters: body['named_parameters'] = self.named_parameters
-        if self.parameters: body['parameters'] = self.parameters
-        return body
-
-    @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> 'ResolvedRunJobTaskValues':
-        return cls(named_parameters=d.get('named_parameters', None), parameters=d.get('parameters', None))
-
-
-@dataclass
-class ResolvedStringParamsValues:
-    parameters: Optional['List[str]'] = None
-
-    def as_dict(self) -> dict:
-        body = {}
-        if self.parameters: body['parameters'] = [v for v in self.parameters]
-        return body
-
-    @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> 'ResolvedStringParamsValues':
-        return cls(parameters=d.get('parameters', None))
-
-
-@dataclass
-class ResolvedValues:
-    condition_task: Optional['ResolvedConditionTaskValues'] = None
-    dbt_task: Optional['ResolvedDbtTaskValues'] = None
-    notebook_task: Optional['ResolvedNotebookTaskValues'] = None
-    python_wheel_task: Optional['ResolvedPythonWheelTaskValues'] = None
-    run_job_task: Optional['ResolvedRunJobTaskValues'] = None
-    simulation_task: Optional['ResolvedParamPairValues'] = None
-    spark_jar_task: Optional['ResolvedStringParamsValues'] = None
-    spark_python_task: Optional['ResolvedStringParamsValues'] = None
-    spark_submit_task: Optional['ResolvedStringParamsValues'] = None
-    sql_task: Optional['ResolvedParamPairValues'] = None
-
-    def as_dict(self) -> dict:
-        body = {}
-        if self.condition_task: body['condition_task'] = self.condition_task.as_dict()
-        if self.dbt_task: body['dbt_task'] = self.dbt_task.as_dict()
-        if self.notebook_task: body['notebook_task'] = self.notebook_task.as_dict()
-        if self.python_wheel_task: body['python_wheel_task'] = self.python_wheel_task.as_dict()
-        if self.run_job_task: body['run_job_task'] = self.run_job_task.as_dict()
-        if self.simulation_task: body['simulation_task'] = self.simulation_task.as_dict()
-        if self.spark_jar_task: body['spark_jar_task'] = self.spark_jar_task.as_dict()
-        if self.spark_python_task: body['spark_python_task'] = self.spark_python_task.as_dict()
-        if self.spark_submit_task: body['spark_submit_task'] = self.spark_submit_task.as_dict()
-        if self.sql_task: body['sql_task'] = self.sql_task.as_dict()
-        return body
-
-    @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> 'ResolvedValues':
-        return cls(condition_task=_from_dict(d, 'condition_task', ResolvedConditionTaskValues),
-                   dbt_task=_from_dict(d, 'dbt_task', ResolvedDbtTaskValues),
-                   notebook_task=_from_dict(d, 'notebook_task', ResolvedNotebookTaskValues),
-                   python_wheel_task=_from_dict(d, 'python_wheel_task', ResolvedPythonWheelTaskValues),
-                   run_job_task=_from_dict(d, 'run_job_task', ResolvedRunJobTaskValues),
-                   simulation_task=_from_dict(d, 'simulation_task', ResolvedParamPairValues),
-                   spark_jar_task=_from_dict(d, 'spark_jar_task', ResolvedStringParamsValues),
-                   spark_python_task=_from_dict(d, 'spark_python_task', ResolvedStringParamsValues),
-                   spark_submit_task=_from_dict(d, 'spark_submit_task', ResolvedStringParamsValues),
-                   sql_task=_from_dict(d, 'sql_task', ResolvedParamPairValues))
-
-
-@dataclass
 class Run:
     attempt_number: Optional[int] = None
     cleanup_duration: Optional[int] = None
@@ -1331,7 +1087,6 @@ class Run:
     git_source: Optional['GitSource'] = None
     job_clusters: Optional['List[JobCluster]'] = None
     job_id: Optional[int] = None
-    job_parameters: Optional['List[JobParameter]'] = None
     number_in_job: Optional[int] = None
     original_attempt_run_id: Optional[int] = None
     overriding_parameters: Optional['RunParameters'] = None
@@ -1347,7 +1102,6 @@ class Run:
     state: Optional['RunState'] = None
     tasks: Optional['List[RunTask]'] = None
     trigger: Optional['TriggerType'] = None
-    trigger_info: Optional['TriggerInfo'] = None
 
     def as_dict(self) -> dict:
         body = {}
@@ -1362,7 +1116,6 @@ class Run:
         if self.git_source: body['git_source'] = self.git_source.as_dict()
         if self.job_clusters: body['job_clusters'] = [v.as_dict() for v in self.job_clusters]
         if self.job_id is not None: body['job_id'] = self.job_id
-        if self.job_parameters: body['job_parameters'] = [v.as_dict() for v in self.job_parameters]
         if self.number_in_job is not None: body['number_in_job'] = self.number_in_job
         if self.original_attempt_run_id is not None:
             body['original_attempt_run_id'] = self.original_attempt_run_id
@@ -1379,7 +1132,6 @@ class Run:
         if self.state: body['state'] = self.state.as_dict()
         if self.tasks: body['tasks'] = [v.as_dict() for v in self.tasks]
         if self.trigger is not None: body['trigger'] = self.trigger.value
-        if self.trigger_info: body['trigger_info'] = self.trigger_info.as_dict()
         return body
 
     @classmethod
@@ -1395,7 +1147,6 @@ class Run:
                    git_source=_from_dict(d, 'git_source', GitSource),
                    job_clusters=_repeated(d, 'job_clusters', JobCluster),
                    job_id=d.get('job_id', None),
-                   job_parameters=_repeated(d, 'job_parameters', JobParameter),
                    number_in_job=d.get('number_in_job', None),
                    original_attempt_run_id=d.get('original_attempt_run_id', None),
                    overriding_parameters=_from_dict(d, 'overriding_parameters', RunParameters),
@@ -1410,83 +1161,7 @@ class Run:
                    start_time=d.get('start_time', None),
                    state=_from_dict(d, 'state', RunState),
                    tasks=_repeated(d, 'tasks', RunTask),
-                   trigger=_enum(d, 'trigger', TriggerType),
-                   trigger_info=_from_dict(d, 'trigger_info', TriggerInfo))
-
-
-@dataclass
-class RunConditionTask:
-    left: str
-    right: str
-    op: 'RunConditionTaskOp'
-    outcome: Optional[str] = None
-
-    def as_dict(self) -> dict:
-        body = {}
-        if self.left is not None: body['left'] = self.left
-        if self.op is not None: body['op'] = self.op.value
-        if self.outcome is not None: body['outcome'] = self.outcome
-        if self.right is not None: body['right'] = self.right
-        return body
-
-    @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> 'RunConditionTask':
-        return cls(left=d.get('left', None),
-                   op=_enum(d, 'op', RunConditionTaskOp),
-                   outcome=d.get('outcome', None),
-                   right=d.get('right', None))
-
-
-class RunConditionTaskOp(Enum):
-    """The condtion task operator."""
-
-    EQUAL_TO = 'EQUAL_TO'
-    GREATER_THAN = 'GREATER_THAN'
-    GREATER_THAN_OR_EQUAL = 'GREATER_THAN_OR_EQUAL'
-    LESS_THAN = 'LESS_THAN'
-    LESS_THAN_OR_EQUAL = 'LESS_THAN_OR_EQUAL'
-    NOT_EQUAL = 'NOT_EQUAL'
-
-
-class RunIf(Enum):
-    """This describes an enum"""
-
-    ALL_DONE = 'ALL_DONE'
-    ALL_FAILED = 'ALL_FAILED'
-    ALL_SUCCESS = 'ALL_SUCCESS'
-    AT_LEAST_ONE_FAILED = 'AT_LEAST_ONE_FAILED'
-    AT_LEAST_ONE_SUCCESS = 'AT_LEAST_ONE_SUCCESS'
-    NONE_FAILED = 'NONE_FAILED'
-
-
-@dataclass
-class RunJobOutput:
-    run_id: Optional[int] = None
-
-    def as_dict(self) -> dict:
-        body = {}
-        if self.run_id is not None: body['run_id'] = self.run_id
-        return body
-
-    @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> 'RunJobOutput':
-        return cls(run_id=d.get('run_id', None))
-
-
-@dataclass
-class RunJobTask:
-    job_id: int
-    job_parameters: Optional[Any] = None
-
-    def as_dict(self) -> dict:
-        body = {}
-        if self.job_id is not None: body['job_id'] = self.job_id
-        if self.job_parameters: body['job_parameters'] = self.job_parameters
-        return body
-
-    @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> 'RunJobTask':
-        return cls(job_id=d.get('job_id', None), job_parameters=d.get('job_parameters', None))
+                   trigger=_enum(d, 'trigger', TriggerType))
 
 
 class RunLifeCycleState(Enum):
@@ -1508,7 +1183,6 @@ class RunNow:
     dbt_commands: Optional['List[str]'] = None
     idempotency_token: Optional[str] = None
     jar_params: Optional['List[str]'] = None
-    job_parameters: Optional['List[Dict[str,str]]'] = None
     notebook_params: Optional['Dict[str,str]'] = None
     pipeline_params: Optional['PipelineParams'] = None
     python_named_params: Optional['Dict[str,str]'] = None
@@ -1522,7 +1196,6 @@ class RunNow:
         if self.idempotency_token is not None: body['idempotency_token'] = self.idempotency_token
         if self.jar_params: body['jar_params'] = [v for v in self.jar_params]
         if self.job_id is not None: body['job_id'] = self.job_id
-        if self.job_parameters: body['job_parameters'] = [v for v in self.job_parameters]
         if self.notebook_params: body['notebook_params'] = self.notebook_params
         if self.pipeline_params: body['pipeline_params'] = self.pipeline_params.as_dict()
         if self.python_named_params: body['python_named_params'] = self.python_named_params
@@ -1537,7 +1210,6 @@ class RunNow:
                    idempotency_token=d.get('idempotency_token', None),
                    jar_params=d.get('jar_params', None),
                    job_id=d.get('job_id', None),
-                   job_parameters=d.get('job_parameters', None),
                    notebook_params=d.get('notebook_params', None),
                    pipeline_params=_from_dict(d, 'pipeline_params', PipelineParams),
                    python_named_params=d.get('python_named_params', None),
@@ -1564,7 +1236,6 @@ class RunNowResponse:
 
 @dataclass
 class RunOutput:
-    condition_task: Optional[Any] = None
     dbt_output: Optional['DbtOutput'] = None
     error: Optional[str] = None
     error_trace: Optional[str] = None
@@ -1572,12 +1243,10 @@ class RunOutput:
     logs_truncated: Optional[bool] = None
     metadata: Optional['Run'] = None
     notebook_output: Optional['NotebookOutput'] = None
-    run_job_output: Optional['RunJobOutput'] = None
     sql_output: Optional['SqlOutput'] = None
 
     def as_dict(self) -> dict:
         body = {}
-        if self.condition_task: body['condition_task'] = self.condition_task
         if self.dbt_output: body['dbt_output'] = self.dbt_output.as_dict()
         if self.error is not None: body['error'] = self.error
         if self.error_trace is not None: body['error_trace'] = self.error_trace
@@ -1585,21 +1254,18 @@ class RunOutput:
         if self.logs_truncated is not None: body['logs_truncated'] = self.logs_truncated
         if self.metadata: body['metadata'] = self.metadata.as_dict()
         if self.notebook_output: body['notebook_output'] = self.notebook_output.as_dict()
-        if self.run_job_output: body['run_job_output'] = self.run_job_output.as_dict()
         if self.sql_output: body['sql_output'] = self.sql_output.as_dict()
         return body
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'RunOutput':
-        return cls(condition_task=d.get('condition_task', None),
-                   dbt_output=_from_dict(d, 'dbt_output', DbtOutput),
+        return cls(dbt_output=_from_dict(d, 'dbt_output', DbtOutput),
                    error=d.get('error', None),
                    error_trace=d.get('error_trace', None),
                    logs=d.get('logs', None),
                    logs_truncated=d.get('logs_truncated', None),
                    metadata=_from_dict(d, 'metadata', Run),
                    notebook_output=_from_dict(d, 'notebook_output', NotebookOutput),
-                   run_job_output=_from_dict(d, 'run_job_output', RunJobOutput),
                    sql_output=_from_dict(d, 'sql_output', SqlOutput))
 
 
@@ -1642,19 +1308,14 @@ class RunResultState(Enum):
     """This describes an enum"""
 
     CANCELED = 'CANCELED'
-    EXCLUDED = 'EXCLUDED'
     FAILED = 'FAILED'
-    MAXIMUM_CONCURRENT_RUNS_REACHED = 'MAXIMUM_CONCURRENT_RUNS_REACHED'
     SUCCESS = 'SUCCESS'
-    SUCCESS_WITH_FAILURES = 'SUCCESS_WITH_FAILURES'
     TIMEDOUT = 'TIMEDOUT'
-    UPSTREAM_CANCELED = 'UPSTREAM_CANCELED'
-    UPSTREAM_FAILED = 'UPSTREAM_FAILED'
 
 
 @dataclass
 class RunState:
-    """The current state of the run."""
+    """The result and lifecycle state of the run."""
 
     life_cycle_state: Optional['RunLifeCycleState'] = None
     result_state: Optional['RunResultState'] = None
@@ -1679,27 +1340,73 @@ class RunState:
 
 
 @dataclass
+class RunSubmitTaskSettings:
+    task_key: str
+    depends_on: Optional['List[TaskDependenciesItem]'] = None
+    existing_cluster_id: Optional[str] = None
+    libraries: Optional['List[compute.Library]'] = None
+    new_cluster: Optional['compute.BaseClusterInfo'] = None
+    notebook_task: Optional['NotebookTask'] = None
+    pipeline_task: Optional['PipelineTask'] = None
+    python_wheel_task: Optional['PythonWheelTask'] = None
+    spark_jar_task: Optional['SparkJarTask'] = None
+    spark_python_task: Optional['SparkPythonTask'] = None
+    spark_submit_task: Optional['SparkSubmitTask'] = None
+    sql_task: Optional['SqlTask'] = None
+    timeout_seconds: Optional[int] = None
+
+    def as_dict(self) -> dict:
+        body = {}
+        if self.depends_on: body['depends_on'] = [v.as_dict() for v in self.depends_on]
+        if self.existing_cluster_id is not None: body['existing_cluster_id'] = self.existing_cluster_id
+        if self.libraries: body['libraries'] = [v.as_dict() for v in self.libraries]
+        if self.new_cluster: body['new_cluster'] = self.new_cluster.as_dict()
+        if self.notebook_task: body['notebook_task'] = self.notebook_task.as_dict()
+        if self.pipeline_task: body['pipeline_task'] = self.pipeline_task.as_dict()
+        if self.python_wheel_task: body['python_wheel_task'] = self.python_wheel_task.as_dict()
+        if self.spark_jar_task: body['spark_jar_task'] = self.spark_jar_task.as_dict()
+        if self.spark_python_task: body['spark_python_task'] = self.spark_python_task.as_dict()
+        if self.spark_submit_task: body['spark_submit_task'] = self.spark_submit_task.as_dict()
+        if self.sql_task: body['sql_task'] = self.sql_task.as_dict()
+        if self.task_key is not None: body['task_key'] = self.task_key
+        if self.timeout_seconds is not None: body['timeout_seconds'] = self.timeout_seconds
+        return body
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, any]) -> 'RunSubmitTaskSettings':
+        return cls(depends_on=_repeated(d, 'depends_on', TaskDependenciesItem),
+                   existing_cluster_id=d.get('existing_cluster_id', None),
+                   libraries=_repeated(d, 'libraries', compute.Library),
+                   new_cluster=_from_dict(d, 'new_cluster', compute.BaseClusterInfo),
+                   notebook_task=_from_dict(d, 'notebook_task', NotebookTask),
+                   pipeline_task=_from_dict(d, 'pipeline_task', PipelineTask),
+                   python_wheel_task=_from_dict(d, 'python_wheel_task', PythonWheelTask),
+                   spark_jar_task=_from_dict(d, 'spark_jar_task', SparkJarTask),
+                   spark_python_task=_from_dict(d, 'spark_python_task', SparkPythonTask),
+                   spark_submit_task=_from_dict(d, 'spark_submit_task', SparkSubmitTask),
+                   sql_task=_from_dict(d, 'sql_task', SqlTask),
+                   task_key=d.get('task_key', None),
+                   timeout_seconds=d.get('timeout_seconds', None))
+
+
+@dataclass
 class RunTask:
     attempt_number: Optional[int] = None
     cleanup_duration: Optional[int] = None
     cluster_instance: Optional['ClusterInstance'] = None
-    condition_task: Optional['RunConditionTask'] = None
     dbt_task: Optional['DbtTask'] = None
-    depends_on: Optional['List[TaskDependency]'] = None
+    depends_on: Optional['List[TaskDependenciesItem]'] = None
     description: Optional[str] = None
     end_time: Optional[int] = None
     execution_duration: Optional[int] = None
     existing_cluster_id: Optional[str] = None
     git_source: Optional['GitSource'] = None
     libraries: Optional['List[compute.Library]'] = None
-    new_cluster: Optional['compute.ClusterSpec'] = None
+    new_cluster: Optional['compute.BaseClusterInfo'] = None
     notebook_task: Optional['NotebookTask'] = None
     pipeline_task: Optional['PipelineTask'] = None
     python_wheel_task: Optional['PythonWheelTask'] = None
-    resolved_values: Optional['ResolvedValues'] = None
     run_id: Optional[int] = None
-    run_if: Optional['RunIf'] = None
-    run_job_task: Optional['RunJobTask'] = None
     setup_duration: Optional[int] = None
     spark_jar_task: Optional['SparkJarTask'] = None
     spark_python_task: Optional['SparkPythonTask'] = None
@@ -1714,7 +1421,6 @@ class RunTask:
         if self.attempt_number is not None: body['attempt_number'] = self.attempt_number
         if self.cleanup_duration is not None: body['cleanup_duration'] = self.cleanup_duration
         if self.cluster_instance: body['cluster_instance'] = self.cluster_instance.as_dict()
-        if self.condition_task: body['condition_task'] = self.condition_task.as_dict()
         if self.dbt_task: body['dbt_task'] = self.dbt_task.as_dict()
         if self.depends_on: body['depends_on'] = [v.as_dict() for v in self.depends_on]
         if self.description is not None: body['description'] = self.description
@@ -1727,10 +1433,7 @@ class RunTask:
         if self.notebook_task: body['notebook_task'] = self.notebook_task.as_dict()
         if self.pipeline_task: body['pipeline_task'] = self.pipeline_task.as_dict()
         if self.python_wheel_task: body['python_wheel_task'] = self.python_wheel_task.as_dict()
-        if self.resolved_values: body['resolved_values'] = self.resolved_values.as_dict()
         if self.run_id is not None: body['run_id'] = self.run_id
-        if self.run_if is not None: body['run_if'] = self.run_if.value
-        if self.run_job_task: body['run_job_task'] = self.run_job_task.as_dict()
         if self.setup_duration is not None: body['setup_duration'] = self.setup_duration
         if self.spark_jar_task: body['spark_jar_task'] = self.spark_jar_task.as_dict()
         if self.spark_python_task: body['spark_python_task'] = self.spark_python_task.as_dict()
@@ -1746,23 +1449,19 @@ class RunTask:
         return cls(attempt_number=d.get('attempt_number', None),
                    cleanup_duration=d.get('cleanup_duration', None),
                    cluster_instance=_from_dict(d, 'cluster_instance', ClusterInstance),
-                   condition_task=_from_dict(d, 'condition_task', RunConditionTask),
                    dbt_task=_from_dict(d, 'dbt_task', DbtTask),
-                   depends_on=_repeated(d, 'depends_on', TaskDependency),
+                   depends_on=_repeated(d, 'depends_on', TaskDependenciesItem),
                    description=d.get('description', None),
                    end_time=d.get('end_time', None),
                    execution_duration=d.get('execution_duration', None),
                    existing_cluster_id=d.get('existing_cluster_id', None),
                    git_source=_from_dict(d, 'git_source', GitSource),
                    libraries=_repeated(d, 'libraries', compute.Library),
-                   new_cluster=_from_dict(d, 'new_cluster', compute.ClusterSpec),
+                   new_cluster=_from_dict(d, 'new_cluster', compute.BaseClusterInfo),
                    notebook_task=_from_dict(d, 'notebook_task', NotebookTask),
                    pipeline_task=_from_dict(d, 'pipeline_task', PipelineTask),
                    python_wheel_task=_from_dict(d, 'python_wheel_task', PythonWheelTask),
-                   resolved_values=_from_dict(d, 'resolved_values', ResolvedValues),
                    run_id=d.get('run_id', None),
-                   run_if=_enum(d, 'run_if', RunIf),
-                   run_job_task=_from_dict(d, 'run_job_task', RunJobTask),
                    setup_duration=d.get('setup_duration', None),
                    spark_jar_task=_from_dict(d, 'spark_jar_task', SparkJarTask),
                    spark_python_task=_from_dict(d, 'spark_python_task', SparkPythonTask),
@@ -1779,12 +1478,6 @@ class RunType(Enum):
     JOB_RUN = 'JOB_RUN'
     SUBMIT_RUN = 'SUBMIT_RUN'
     WORKFLOW_RUN = 'WORKFLOW_RUN'
-
-
-class Source(Enum):
-
-    GIT = 'GIT'
-    WORKSPACE = 'WORKSPACE'
 
 
 @dataclass
@@ -1811,7 +1504,7 @@ class SparkJarTask:
 class SparkPythonTask:
     python_file: str
     parameters: Optional['List[str]'] = None
-    source: Optional['Source'] = None
+    source: Optional['SparkPythonTaskSource'] = None
 
     def as_dict(self) -> dict:
         body = {}
@@ -1824,7 +1517,14 @@ class SparkPythonTask:
     def from_dict(cls, d: Dict[str, any]) -> 'SparkPythonTask':
         return cls(parameters=d.get('parameters', None),
                    python_file=d.get('python_file', None),
-                   source=_enum(d, 'source', Source))
+                   source=_enum(d, 'source', SparkPythonTaskSource))
+
+
+class SparkPythonTaskSource(Enum):
+    """This describes an enum"""
+
+    GIT = 'GIT'
+    WORKSPACE = 'WORKSPACE'
 
 
 @dataclass
@@ -1881,18 +1581,18 @@ class SqlAlertState(Enum):
 @dataclass
 class SqlDashboardOutput:
     warehouse_id: Optional[str] = None
-    widgets: Optional['List[SqlDashboardWidgetOutput]'] = None
+    widgets: Optional['SqlDashboardWidgetOutput'] = None
 
     def as_dict(self) -> dict:
         body = {}
         if self.warehouse_id is not None: body['warehouse_id'] = self.warehouse_id
-        if self.widgets: body['widgets'] = [v.as_dict() for v in self.widgets]
+        if self.widgets: body['widgets'] = self.widgets.as_dict()
         return body
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'SqlDashboardOutput':
         return cls(warehouse_id=d.get('warehouse_id', None),
-                   widgets=_repeated(d, 'widgets', SqlDashboardWidgetOutput))
+                   widgets=_from_dict(d, 'widgets', SqlDashboardWidgetOutput))
 
 
 @dataclass
@@ -2127,23 +1827,19 @@ class SqlTaskSubscription:
 @dataclass
 class SubmitRun:
     access_control_list: Optional['List[iam.AccessControlRequest]'] = None
-    email_notifications: Optional['JobEmailNotifications'] = None
     git_source: Optional['GitSource'] = None
-    health: Optional['JobsHealthRules'] = None
     idempotency_token: Optional[str] = None
     notification_settings: Optional['JobNotificationSettings'] = None
     run_name: Optional[str] = None
-    tasks: Optional['List[SubmitTask]'] = None
+    tasks: Optional['List[RunSubmitTaskSettings]'] = None
     timeout_seconds: Optional[int] = None
-    webhook_notifications: Optional['WebhookNotifications'] = None
+    webhook_notifications: Optional['JobWebhookNotifications'] = None
 
     def as_dict(self) -> dict:
         body = {}
         if self.access_control_list:
             body['access_control_list'] = [v.as_dict() for v in self.access_control_list]
-        if self.email_notifications: body['email_notifications'] = self.email_notifications.as_dict()
         if self.git_source: body['git_source'] = self.git_source.as_dict()
-        if self.health: body['health'] = self.health.as_dict()
         if self.idempotency_token is not None: body['idempotency_token'] = self.idempotency_token
         if self.notification_settings: body['notification_settings'] = self.notification_settings.as_dict()
         if self.run_name is not None: body['run_name'] = self.run_name
@@ -2155,15 +1851,13 @@ class SubmitRun:
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'SubmitRun':
         return cls(access_control_list=_repeated(d, 'access_control_list', iam.AccessControlRequest),
-                   email_notifications=_from_dict(d, 'email_notifications', JobEmailNotifications),
                    git_source=_from_dict(d, 'git_source', GitSource),
-                   health=_from_dict(d, 'health', JobsHealthRules),
                    idempotency_token=d.get('idempotency_token', None),
                    notification_settings=_from_dict(d, 'notification_settings', JobNotificationSettings),
                    run_name=d.get('run_name', None),
-                   tasks=_repeated(d, 'tasks', SubmitTask),
+                   tasks=_repeated(d, 'tasks', RunSubmitTaskSettings),
                    timeout_seconds=d.get('timeout_seconds', None),
-                   webhook_notifications=_from_dict(d, 'webhook_notifications', WebhookNotifications))
+                   webhook_notifications=_from_dict(d, 'webhook_notifications', JobWebhookNotifications))
 
 
 @dataclass
@@ -2181,186 +1875,27 @@ class SubmitRunResponse:
 
 
 @dataclass
-class SubmitTask:
-    task_key: str
-    condition_task: Optional['ConditionTask'] = None
-    depends_on: Optional['List[TaskDependency]'] = None
-    email_notifications: Optional['JobEmailNotifications'] = None
-    existing_cluster_id: Optional[str] = None
-    health: Optional['JobsHealthRules'] = None
-    libraries: Optional['List[compute.Library]'] = None
-    new_cluster: Optional['compute.ClusterSpec'] = None
-    notebook_task: Optional['NotebookTask'] = None
-    notification_settings: Optional['TaskNotificationSettings'] = None
-    pipeline_task: Optional['PipelineTask'] = None
-    python_wheel_task: Optional['PythonWheelTask'] = None
-    spark_jar_task: Optional['SparkJarTask'] = None
-    spark_python_task: Optional['SparkPythonTask'] = None
-    spark_submit_task: Optional['SparkSubmitTask'] = None
-    sql_task: Optional['SqlTask'] = None
-    timeout_seconds: Optional[int] = None
+class TaskDependenciesItem:
+    task_key: Optional[str] = None
 
     def as_dict(self) -> dict:
         body = {}
-        if self.condition_task: body['condition_task'] = self.condition_task.as_dict()
-        if self.depends_on: body['depends_on'] = [v.as_dict() for v in self.depends_on]
-        if self.email_notifications: body['email_notifications'] = self.email_notifications.as_dict()
-        if self.existing_cluster_id is not None: body['existing_cluster_id'] = self.existing_cluster_id
-        if self.health: body['health'] = self.health.as_dict()
-        if self.libraries: body['libraries'] = [v.as_dict() for v in self.libraries]
-        if self.new_cluster: body['new_cluster'] = self.new_cluster.as_dict()
-        if self.notebook_task: body['notebook_task'] = self.notebook_task.as_dict()
-        if self.notification_settings: body['notification_settings'] = self.notification_settings.as_dict()
-        if self.pipeline_task: body['pipeline_task'] = self.pipeline_task.as_dict()
-        if self.python_wheel_task: body['python_wheel_task'] = self.python_wheel_task.as_dict()
-        if self.spark_jar_task: body['spark_jar_task'] = self.spark_jar_task.as_dict()
-        if self.spark_python_task: body['spark_python_task'] = self.spark_python_task.as_dict()
-        if self.spark_submit_task: body['spark_submit_task'] = self.spark_submit_task.as_dict()
-        if self.sql_task: body['sql_task'] = self.sql_task.as_dict()
-        if self.task_key is not None: body['task_key'] = self.task_key
-        if self.timeout_seconds is not None: body['timeout_seconds'] = self.timeout_seconds
-        return body
-
-    @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> 'SubmitTask':
-        return cls(condition_task=_from_dict(d, 'condition_task', ConditionTask),
-                   depends_on=_repeated(d, 'depends_on', TaskDependency),
-                   email_notifications=_from_dict(d, 'email_notifications', JobEmailNotifications),
-                   existing_cluster_id=d.get('existing_cluster_id', None),
-                   health=_from_dict(d, 'health', JobsHealthRules),
-                   libraries=_repeated(d, 'libraries', compute.Library),
-                   new_cluster=_from_dict(d, 'new_cluster', compute.ClusterSpec),
-                   notebook_task=_from_dict(d, 'notebook_task', NotebookTask),
-                   notification_settings=_from_dict(d, 'notification_settings', TaskNotificationSettings),
-                   pipeline_task=_from_dict(d, 'pipeline_task', PipelineTask),
-                   python_wheel_task=_from_dict(d, 'python_wheel_task', PythonWheelTask),
-                   spark_jar_task=_from_dict(d, 'spark_jar_task', SparkJarTask),
-                   spark_python_task=_from_dict(d, 'spark_python_task', SparkPythonTask),
-                   spark_submit_task=_from_dict(d, 'spark_submit_task', SparkSubmitTask),
-                   sql_task=_from_dict(d, 'sql_task', SqlTask),
-                   task_key=d.get('task_key', None),
-                   timeout_seconds=d.get('timeout_seconds', None))
-
-
-@dataclass
-class Task:
-    task_key: str
-    compute_key: Optional[str] = None
-    condition_task: Optional['ConditionTask'] = None
-    dbt_task: Optional['DbtTask'] = None
-    depends_on: Optional['List[TaskDependency]'] = None
-    description: Optional[str] = None
-    email_notifications: Optional['TaskEmailNotifications'] = None
-    existing_cluster_id: Optional[str] = None
-    health: Optional['JobsHealthRules'] = None
-    job_cluster_key: Optional[str] = None
-    libraries: Optional['List[compute.Library]'] = None
-    max_retries: Optional[int] = None
-    min_retry_interval_millis: Optional[int] = None
-    new_cluster: Optional['compute.ClusterSpec'] = None
-    notebook_task: Optional['NotebookTask'] = None
-    notification_settings: Optional['TaskNotificationSettings'] = None
-    pipeline_task: Optional['PipelineTask'] = None
-    python_wheel_task: Optional['PythonWheelTask'] = None
-    retry_on_timeout: Optional[bool] = None
-    run_if: Optional['RunIf'] = None
-    run_job_task: Optional['RunJobTask'] = None
-    spark_jar_task: Optional['SparkJarTask'] = None
-    spark_python_task: Optional['SparkPythonTask'] = None
-    spark_submit_task: Optional['SparkSubmitTask'] = None
-    sql_task: Optional['SqlTask'] = None
-    timeout_seconds: Optional[int] = None
-
-    def as_dict(self) -> dict:
-        body = {}
-        if self.compute_key is not None: body['compute_key'] = self.compute_key
-        if self.condition_task: body['condition_task'] = self.condition_task.as_dict()
-        if self.dbt_task: body['dbt_task'] = self.dbt_task.as_dict()
-        if self.depends_on: body['depends_on'] = [v.as_dict() for v in self.depends_on]
-        if self.description is not None: body['description'] = self.description
-        if self.email_notifications: body['email_notifications'] = self.email_notifications.as_dict()
-        if self.existing_cluster_id is not None: body['existing_cluster_id'] = self.existing_cluster_id
-        if self.health: body['health'] = self.health.as_dict()
-        if self.job_cluster_key is not None: body['job_cluster_key'] = self.job_cluster_key
-        if self.libraries: body['libraries'] = [v.as_dict() for v in self.libraries]
-        if self.max_retries is not None: body['max_retries'] = self.max_retries
-        if self.min_retry_interval_millis is not None:
-            body['min_retry_interval_millis'] = self.min_retry_interval_millis
-        if self.new_cluster: body['new_cluster'] = self.new_cluster.as_dict()
-        if self.notebook_task: body['notebook_task'] = self.notebook_task.as_dict()
-        if self.notification_settings: body['notification_settings'] = self.notification_settings.as_dict()
-        if self.pipeline_task: body['pipeline_task'] = self.pipeline_task.as_dict()
-        if self.python_wheel_task: body['python_wheel_task'] = self.python_wheel_task.as_dict()
-        if self.retry_on_timeout is not None: body['retry_on_timeout'] = self.retry_on_timeout
-        if self.run_if is not None: body['run_if'] = self.run_if.value
-        if self.run_job_task: body['run_job_task'] = self.run_job_task.as_dict()
-        if self.spark_jar_task: body['spark_jar_task'] = self.spark_jar_task.as_dict()
-        if self.spark_python_task: body['spark_python_task'] = self.spark_python_task.as_dict()
-        if self.spark_submit_task: body['spark_submit_task'] = self.spark_submit_task.as_dict()
-        if self.sql_task: body['sql_task'] = self.sql_task.as_dict()
-        if self.task_key is not None: body['task_key'] = self.task_key
-        if self.timeout_seconds is not None: body['timeout_seconds'] = self.timeout_seconds
-        return body
-
-    @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> 'Task':
-        return cls(compute_key=d.get('compute_key', None),
-                   condition_task=_from_dict(d, 'condition_task', ConditionTask),
-                   dbt_task=_from_dict(d, 'dbt_task', DbtTask),
-                   depends_on=_repeated(d, 'depends_on', TaskDependency),
-                   description=d.get('description', None),
-                   email_notifications=_from_dict(d, 'email_notifications', TaskEmailNotifications),
-                   existing_cluster_id=d.get('existing_cluster_id', None),
-                   health=_from_dict(d, 'health', JobsHealthRules),
-                   job_cluster_key=d.get('job_cluster_key', None),
-                   libraries=_repeated(d, 'libraries', compute.Library),
-                   max_retries=d.get('max_retries', None),
-                   min_retry_interval_millis=d.get('min_retry_interval_millis', None),
-                   new_cluster=_from_dict(d, 'new_cluster', compute.ClusterSpec),
-                   notebook_task=_from_dict(d, 'notebook_task', NotebookTask),
-                   notification_settings=_from_dict(d, 'notification_settings', TaskNotificationSettings),
-                   pipeline_task=_from_dict(d, 'pipeline_task', PipelineTask),
-                   python_wheel_task=_from_dict(d, 'python_wheel_task', PythonWheelTask),
-                   retry_on_timeout=d.get('retry_on_timeout', None),
-                   run_if=_enum(d, 'run_if', RunIf),
-                   run_job_task=_from_dict(d, 'run_job_task', RunJobTask),
-                   spark_jar_task=_from_dict(d, 'spark_jar_task', SparkJarTask),
-                   spark_python_task=_from_dict(d, 'spark_python_task', SparkPythonTask),
-                   spark_submit_task=_from_dict(d, 'spark_submit_task', SparkSubmitTask),
-                   sql_task=_from_dict(d, 'sql_task', SqlTask),
-                   task_key=d.get('task_key', None),
-                   timeout_seconds=d.get('timeout_seconds', None))
-
-
-@dataclass
-class TaskDependency:
-    task_key: str
-    outcome: Optional[str] = None
-
-    def as_dict(self) -> dict:
-        body = {}
-        if self.outcome is not None: body['outcome'] = self.outcome
         if self.task_key is not None: body['task_key'] = self.task_key
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> 'TaskDependency':
-        return cls(outcome=d.get('outcome', None), task_key=d.get('task_key', None))
+    def from_dict(cls, d: Dict[str, any]) -> 'TaskDependenciesItem':
+        return cls(task_key=d.get('task_key', None))
 
 
 @dataclass
 class TaskEmailNotifications:
-    on_duration_warning_threshold_exceeded: Optional['List[str]'] = None
     on_failure: Optional['List[str]'] = None
     on_start: Optional['List[str]'] = None
     on_success: Optional['List[str]'] = None
 
     def as_dict(self) -> dict:
         body = {}
-        if self.on_duration_warning_threshold_exceeded:
-            body['on_duration_warning_threshold_exceeded'] = [
-                v for v in self.on_duration_warning_threshold_exceeded
-            ]
         if self.on_failure: body['on_failure'] = [v for v in self.on_failure]
         if self.on_start: body['on_start'] = [v for v in self.on_start]
         if self.on_success: body['on_success'] = [v for v in self.on_success]
@@ -2368,9 +1903,7 @@ class TaskEmailNotifications:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'TaskEmailNotifications':
-        return cls(on_duration_warning_threshold_exceeded=d.get('on_duration_warning_threshold_exceeded',
-                                                                None),
-                   on_failure=d.get('on_failure', None),
+        return cls(on_failure=d.get('on_failure', None),
                    on_start=d.get('on_start', None),
                    on_success=d.get('on_success', None))
 
@@ -2438,23 +1971,9 @@ class TriggerHistory:
 
 
 @dataclass
-class TriggerInfo:
-    run_id: Optional[int] = None
-
-    def as_dict(self) -> dict:
-        body = {}
-        if self.run_id is not None: body['run_id'] = self.run_id
-        return body
-
-    @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> 'TriggerInfo':
-        return cls(run_id=d.get('run_id', None))
-
-
-@dataclass
 class TriggerSettings:
-    file_arrival: Optional['FileArrivalTriggerConfiguration'] = None
-    pause_status: Optional['PauseStatus'] = None
+    file_arrival: Optional['FileArrivalTriggerSettings'] = None
+    pause_status: Optional['TriggerSettingsPauseStatus'] = None
 
     def as_dict(self) -> dict:
         body = {}
@@ -2464,8 +1983,15 @@ class TriggerSettings:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'TriggerSettings':
-        return cls(file_arrival=_from_dict(d, 'file_arrival', FileArrivalTriggerConfiguration),
-                   pause_status=_enum(d, 'pause_status', PauseStatus))
+        return cls(file_arrival=_from_dict(d, 'file_arrival', FileArrivalTriggerSettings),
+                   pause_status=_enum(d, 'pause_status', TriggerSettingsPauseStatus))
+
+
+class TriggerSettingsPauseStatus(Enum):
+    """Whether this trigger is paused or not."""
+
+    PAUSED = 'PAUSED'
+    UNPAUSED = 'UNPAUSED'
 
 
 class TriggerType(Enum):
@@ -2475,7 +2001,6 @@ class TriggerType(Enum):
     ONE_TIME = 'ONE_TIME'
     PERIODIC = 'PERIODIC'
     RETRY = 'RETRY'
-    RUN_JOB_TASK = 'RUN_JOB_TASK'
 
 
 @dataclass
@@ -2531,63 +2056,6 @@ class ViewsToExport(Enum):
     DASHBOARDS = 'DASHBOARDS'
 
 
-@dataclass
-class Webhook:
-    id: Optional[str] = None
-
-    def as_dict(self) -> dict:
-        body = {}
-        if self.id is not None: body['id'] = self.id
-        return body
-
-    @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> 'Webhook':
-        return cls(id=d.get('id', None))
-
-
-@dataclass
-class WebhookNotifications:
-    on_duration_warning_threshold_exceeded: Optional[
-        'List[WebhookNotificationsOnDurationWarningThresholdExceededItem]'] = None
-    on_failure: Optional['List[Webhook]'] = None
-    on_start: Optional['List[Webhook]'] = None
-    on_success: Optional['List[Webhook]'] = None
-
-    def as_dict(self) -> dict:
-        body = {}
-        if self.on_duration_warning_threshold_exceeded:
-            body['on_duration_warning_threshold_exceeded'] = [
-                v.as_dict() for v in self.on_duration_warning_threshold_exceeded
-            ]
-        if self.on_failure: body['on_failure'] = [v.as_dict() for v in self.on_failure]
-        if self.on_start: body['on_start'] = [v.as_dict() for v in self.on_start]
-        if self.on_success: body['on_success'] = [v.as_dict() for v in self.on_success]
-        return body
-
-    @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> 'WebhookNotifications':
-        return cls(on_duration_warning_threshold_exceeded=_repeated(
-            d, 'on_duration_warning_threshold_exceeded',
-            WebhookNotificationsOnDurationWarningThresholdExceededItem),
-                   on_failure=_repeated(d, 'on_failure', Webhook),
-                   on_start=_repeated(d, 'on_start', Webhook),
-                   on_success=_repeated(d, 'on_success', Webhook))
-
-
-@dataclass
-class WebhookNotificationsOnDurationWarningThresholdExceededItem:
-    id: Optional[str] = None
-
-    def as_dict(self) -> dict:
-        body = {}
-        if self.id is not None: body['id'] = self.id
-        return body
-
-    @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> 'WebhookNotificationsOnDurationWarningThresholdExceededItem':
-        return cls(id=d.get('id', None))
-
-
 class JobsAPI:
     """The Jobs API allows you to create, edit, and delete jobs.
     
@@ -2640,7 +2108,7 @@ class JobsAPI:
             attempt += 1
         raise TimeoutError(f'timed out after {timeout}: {status_message}')
 
-    def cancel_all_runs(self, job_id: int, **kwargs):
+    def cancel_all_runs(self, job_id: int):
         """Cancel all runs of a job.
         
         Cancels all active runs of a job. The runs are canceled asynchronously, so it doesn't prevent new runs
@@ -2651,13 +2119,11 @@ class JobsAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = CancelAllRuns(job_id=job_id)
-        body = request.as_dict()
+        body = {}
+        if job_id is not None: body['job_id'] = job_id
         self._api.do('POST', '/api/2.1/jobs/runs/cancel-all', body=body)
 
-    def cancel_run(self, run_id: int, **kwargs) -> Wait[Run]:
+    def cancel_run(self, run_id: int) -> Wait[Run]:
         """Cancel a job run.
         
         Cancels a job run. The run is canceled asynchronously, so it may still be running when this request
@@ -2670,12 +2136,10 @@ class JobsAPI:
           Long-running operation waiter for :class:`Run`.
           See :method:wait_get_run_job_terminated_or_skipped for more details.
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = CancelRun(run_id=run_id)
-        body = request.as_dict()
+        body = {}
+        if run_id is not None: body['run_id'] = run_id
         self._api.do('POST', '/api/2.1/jobs/runs/cancel', body=body)
-        return Wait(self.wait_get_run_job_terminated_or_skipped, run_id=request.run_id)
+        return Wait(self.wait_get_run_job_terminated_or_skipped, run_id=run_id)
 
     def cancel_run_and_wait(self, run_id: int, timeout=timedelta(minutes=20)) -> Run:
         return self.cancel_run(run_id=run_id).result(timeout=timeout)
@@ -2683,47 +2147,39 @@ class JobsAPI:
     def create(self,
                *,
                access_control_list: Optional[List[iam.AccessControlRequest]] = None,
-               compute: Optional[List[JobCompute]] = None,
                continuous: Optional[Continuous] = None,
                email_notifications: Optional[JobEmailNotifications] = None,
-               format: Optional[Format] = None,
+               format: Optional[CreateJobFormat] = None,
                git_source: Optional[GitSource] = None,
-               health: Optional[JobsHealthRules] = None,
                job_clusters: Optional[List[JobCluster]] = None,
                max_concurrent_runs: Optional[int] = None,
                name: Optional[str] = None,
                notification_settings: Optional[JobNotificationSettings] = None,
-               parameters: Optional[List[JobParameterDefinition]] = None,
                run_as: Optional[JobRunAs] = None,
                schedule: Optional[CronSchedule] = None,
                tags: Optional[Dict[str, str]] = None,
-               tasks: Optional[List[Task]] = None,
+               tasks: Optional[List[JobTaskSettings]] = None,
                timeout_seconds: Optional[int] = None,
                trigger: Optional[TriggerSettings] = None,
-               webhook_notifications: Optional[WebhookNotifications] = None,
-               **kwargs) -> CreateResponse:
+               webhook_notifications: Optional[JobWebhookNotifications] = None) -> CreateResponse:
         """Create a new job.
         
         Create a new job.
         
         :param access_control_list: List[:class:`AccessControlRequest`] (optional)
           List of permissions to set on the job.
-        :param compute: List[:class:`JobCompute`] (optional)
-          A list of compute requirements that can be referenced by tasks of this job.
         :param continuous: :class:`Continuous` (optional)
           An optional continuous property for this job. The continuous property will ensure that there is
           always one run executing. Only one of `schedule` and `continuous` can be used.
         :param email_notifications: :class:`JobEmailNotifications` (optional)
           An optional set of email addresses that is notified when runs of this job begin or complete as well
           as when this job is deleted. The default behavior is to not send any emails.
-        :param format: :class:`Format` (optional)
+        :param format: :class:`CreateJobFormat` (optional)
           Used to tell what is the format of the job. This field is ignored in Create/Update/Reset calls. When
           using the Jobs API 2.1 this value is always set to `"MULTI_TASK"`.
         :param git_source: :class:`GitSource` (optional)
           An optional specification for a remote repository containing the notebooks used by this job's
           notebook tasks.
-        :param health: :class:`JobsHealthRules` (optional)
-          An optional set of health rules that can be defined for this job.
         :param job_clusters: List[:class:`JobCluster`] (optional)
           A list of job cluster specifications that can be shared and reused by tasks of this job. Libraries
           cannot be declared in a shared job cluster. You must declare dependent libraries in task settings.
@@ -2742,12 +2198,10 @@ class JobsAPI:
           This value cannot exceed 1000\. Setting this value to 0 causes all new runs to be skipped. The
           default behavior is to allow only 1 concurrent run.
         :param name: str (optional)
-          An optional name for the job. The maximum length is 4096 bytes in UTF-8 encoding.
+          An optional name for the job.
         :param notification_settings: :class:`JobNotificationSettings` (optional)
           Optional notification settings that are used when sending notifications to each of the
           `email_notifications` and `webhook_notifications` for this job.
-        :param parameters: List[:class:`JobParameterDefinition`] (optional)
-          Job-level parameter definitions
         :param run_as: :class:`JobRunAs` (optional)
           Write-only setting, available only in Create/Update/Reset and Submit calls. Specifies the user or
           service principal that the job runs as. If not specified, the job runs as the user who created the
@@ -2762,7 +2216,7 @@ class JobsAPI:
           A map of tags associated with the job. These are forwarded to the cluster as cluster tags for jobs
           clusters, and are subject to the same limitations as cluster tags. A maximum of 25 tags can be added
           to the job.
-        :param tasks: List[:class:`Task`] (optional)
+        :param tasks: List[:class:`JobTaskSettings`] (optional)
           A list of task specifications to be executed by this job.
         :param timeout_seconds: int (optional)
           An optional timeout applied to each run of this job. The default behavior is to have no timeout.
@@ -2770,39 +2224,41 @@ class JobsAPI:
           Trigger settings for the job. Can be used to trigger a run when new files arrive in an external
           location. The default behavior is that the job runs only when triggered by clicking “Run Now” in
           the Jobs UI or sending an API request to `runNow`.
-        :param webhook_notifications: :class:`WebhookNotifications` (optional)
+        :param webhook_notifications: :class:`JobWebhookNotifications` (optional)
           A collection of system notification IDs to notify when the run begins or completes. The default
           behavior is to not send any system notifications.
         
         :returns: :class:`CreateResponse`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = CreateJob(access_control_list=access_control_list,
-                                compute=compute,
-                                continuous=continuous,
-                                email_notifications=email_notifications,
-                                format=format,
-                                git_source=git_source,
-                                health=health,
-                                job_clusters=job_clusters,
-                                max_concurrent_runs=max_concurrent_runs,
-                                name=name,
-                                notification_settings=notification_settings,
-                                parameters=parameters,
-                                run_as=run_as,
-                                schedule=schedule,
-                                tags=tags,
-                                tasks=tasks,
-                                timeout_seconds=timeout_seconds,
-                                trigger=trigger,
-                                webhook_notifications=webhook_notifications)
-        body = request.as_dict()
+        body = {}
+        if access_control_list is not None: body['access_control_list'] = [v for v in access_control_list]
+        if continuous is not None: body['continuous'] = _validated('continuous', Continuous, continuous)
+        if email_notifications is not None:
+            body['email_notifications'] = _validated('email_notifications', JobEmailNotifications,
+                                                     email_notifications)
+        if format is not None: body['format'] = _validated('format', CreateJobFormat, format)
+        if git_source is not None: body['git_source'] = _validated('git_source', GitSource, git_source)
+        if job_clusters is not None:
+            body['job_clusters'] = [_validated('job_clusters item', JobCluster, v) for v in job_clusters]
+        if max_concurrent_runs is not None: body['max_concurrent_runs'] = max_concurrent_runs
+        if name is not None: body['name'] = name
+        if notification_settings is not None:
+            body['notification_settings'] = _validated('notification_settings', JobNotificationSettings,
+                                                       notification_settings)
+        if run_as is not None: body['run_as'] = _validated('run_as', JobRunAs, run_as)
+        if schedule is not None: body['schedule'] = _validated('schedule', CronSchedule, schedule)
+        if tags is not None: body['tags'] = tags
+        if tasks is not None: body['tasks'] = [_validated('tasks item', JobTaskSettings, v) for v in tasks]
+        if timeout_seconds is not None: body['timeout_seconds'] = timeout_seconds
+        if trigger is not None: body['trigger'] = _validated('trigger', TriggerSettings, trigger)
+        if webhook_notifications is not None:
+            body['webhook_notifications'] = _validated('webhook_notifications', JobWebhookNotifications,
+                                                       webhook_notifications)
 
         json = self._api.do('POST', '/api/2.1/jobs/create', body=body)
         return CreateResponse.from_dict(json)
 
-    def delete(self, job_id: int, **kwargs):
+    def delete(self, job_id: int):
         """Delete a job.
         
         Deletes a job.
@@ -2812,13 +2268,11 @@ class JobsAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = DeleteJob(job_id=job_id)
-        body = request.as_dict()
+        body = {}
+        if job_id is not None: body['job_id'] = job_id
         self._api.do('POST', '/api/2.1/jobs/delete', body=body)
 
-    def delete_run(self, run_id: int, **kwargs):
+    def delete_run(self, run_id: int):
         """Delete a job run.
         
         Deletes a non-active run. Returns an error if the run is active.
@@ -2828,17 +2282,11 @@ class JobsAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = DeleteRun(run_id=run_id)
-        body = request.as_dict()
+        body = {}
+        if run_id is not None: body['run_id'] = run_id
         self._api.do('POST', '/api/2.1/jobs/runs/delete', body=body)
 
-    def export_run(self,
-                   run_id: int,
-                   *,
-                   views_to_export: Optional[ViewsToExport] = None,
-                   **kwargs) -> ExportRunOutput:
+    def export_run(self, run_id: int, *, views_to_export: Optional[ViewsToExport] = None) -> ExportRunOutput:
         """Export and retrieve a job run.
         
         Export and retrieve the job run task.
@@ -2850,18 +2298,16 @@ class JobsAPI:
         
         :returns: :class:`ExportRunOutput`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = ExportRunRequest(run_id=run_id, views_to_export=views_to_export)
 
         query = {}
-        if run_id: query['run_id'] = request.run_id
-        if views_to_export: query['views_to_export'] = request.views_to_export.value
+        if run_id is not None: query['run_id'] = run_id
+        if views_to_export is not None:
+            query['views_to_export'] = _validated('views_to_export', ViewsToExport, views_to_export)
 
         json = self._api.do('GET', '/api/2.1/jobs/runs/export', query=query)
         return ExportRunOutput.from_dict(json)
 
-    def get(self, job_id: int, **kwargs) -> Job:
+    def get(self, job_id: int) -> Job:
         """Get a single job.
         
         Retrieves the details for a single job.
@@ -2871,17 +2317,14 @@ class JobsAPI:
         
         :returns: :class:`Job`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = GetJobRequest(job_id=job_id)
 
         query = {}
-        if job_id: query['job_id'] = request.job_id
+        if job_id is not None: query['job_id'] = job_id
 
         json = self._api.do('GET', '/api/2.1/jobs/get', query=query)
         return Job.from_dict(json)
 
-    def get_run(self, run_id: int, *, include_history: Optional[bool] = None, **kwargs) -> Run:
+    def get_run(self, run_id: int, *, include_history: Optional[bool] = None) -> Run:
         """Get a single job run.
         
         Retrieve the metadata of a run.
@@ -2893,18 +2336,15 @@ class JobsAPI:
         
         :returns: :class:`Run`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = GetRunRequest(include_history=include_history, run_id=run_id)
 
         query = {}
-        if include_history: query['include_history'] = request.include_history
-        if run_id: query['run_id'] = request.run_id
+        if include_history is not None: query['include_history'] = include_history
+        if run_id is not None: query['run_id'] = run_id
 
         json = self._api.do('GET', '/api/2.1/jobs/runs/get', query=query)
         return Run.from_dict(json)
 
-    def get_run_output(self, run_id: int, **kwargs) -> RunOutput:
+    def get_run_output(self, run_id: int) -> RunOutput:
         """Get the output for a single run.
         
         Retrieve the output and metadata of a single task run. When a notebook task returns a value through
@@ -2921,12 +2361,9 @@ class JobsAPI:
         
         :returns: :class:`RunOutput`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = GetRunOutputRequest(run_id=run_id)
 
         query = {}
-        if run_id: query['run_id'] = request.run_id
+        if run_id is not None: query['run_id'] = run_id
 
         json = self._api.do('GET', '/api/2.1/jobs/runs/get-output', query=query)
         return RunOutput.from_dict(json)
@@ -2937,17 +2374,16 @@ class JobsAPI:
              limit: Optional[int] = None,
              name: Optional[str] = None,
              offset: Optional[int] = None,
-             page_token: Optional[str] = None,
-             **kwargs) -> Iterator[BaseJob]:
-        """List jobs.
+             page_token: Optional[str] = None) -> Iterator[BaseJob]:
+        """List all jobs.
         
         Retrieves a list of jobs.
         
         :param expand_tasks: bool (optional)
           Whether to include task and cluster details in the response.
         :param limit: int (optional)
-          The number of jobs to return. This value must be greater than 0 and less or equal to 100. The
-          default value is 20.
+          The number of jobs to return. This value must be greater than 0 and less or equal to 25. The default
+          value is 20.
         :param name: str (optional)
           A filter on the list based on the exact (case insensitive) job name.
         :param offset: int (optional)
@@ -2960,20 +2396,13 @@ class JobsAPI:
         
         :returns: Iterator over :class:`BaseJob`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = ListJobsRequest(expand_tasks=expand_tasks,
-                                      limit=limit,
-                                      name=name,
-                                      offset=offset,
-                                      page_token=page_token)
 
         query = {}
-        if expand_tasks: query['expand_tasks'] = request.expand_tasks
-        if limit: query['limit'] = request.limit
-        if name: query['name'] = request.name
-        if offset: query['offset'] = request.offset
-        if page_token: query['page_token'] = request.page_token
+        if expand_tasks is not None: query['expand_tasks'] = expand_tasks
+        if limit is not None: query['limit'] = limit
+        if name is not None: query['name'] = name
+        if offset is not None: query['offset'] = offset
+        if page_token is not None: query['page_token'] = page_token
 
         while True:
             json = self._api.do('GET', '/api/2.1/jobs/list', query=query)
@@ -2996,9 +2425,8 @@ class JobsAPI:
                   page_token: Optional[str] = None,
                   run_type: Optional[ListRunsRunType] = None,
                   start_time_from: Optional[int] = None,
-                  start_time_to: Optional[int] = None,
-                  **kwargs) -> Iterator[BaseRun]:
-        """List job runs.
+                  start_time_to: Optional[int] = None) -> Iterator[BaseRun]:
+        """List runs for a job.
         
         List runs in descending order by start time.
         
@@ -3034,30 +2462,18 @@ class JobsAPI:
         
         :returns: Iterator over :class:`BaseRun`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = ListRunsRequest(active_only=active_only,
-                                      completed_only=completed_only,
-                                      expand_tasks=expand_tasks,
-                                      job_id=job_id,
-                                      limit=limit,
-                                      offset=offset,
-                                      page_token=page_token,
-                                      run_type=run_type,
-                                      start_time_from=start_time_from,
-                                      start_time_to=start_time_to)
 
         query = {}
-        if active_only: query['active_only'] = request.active_only
-        if completed_only: query['completed_only'] = request.completed_only
-        if expand_tasks: query['expand_tasks'] = request.expand_tasks
-        if job_id: query['job_id'] = request.job_id
-        if limit: query['limit'] = request.limit
-        if offset: query['offset'] = request.offset
-        if page_token: query['page_token'] = request.page_token
-        if run_type: query['run_type'] = request.run_type.value
-        if start_time_from: query['start_time_from'] = request.start_time_from
-        if start_time_to: query['start_time_to'] = request.start_time_to
+        if active_only is not None: query['active_only'] = active_only
+        if completed_only is not None: query['completed_only'] = completed_only
+        if expand_tasks is not None: query['expand_tasks'] = expand_tasks
+        if job_id is not None: query['job_id'] = job_id
+        if limit is not None: query['limit'] = limit
+        if offset is not None: query['offset'] = offset
+        if page_token is not None: query['page_token'] = page_token
+        if run_type is not None: query['run_type'] = _validated('run_type', ListRunsRunType, run_type)
+        if start_time_from is not None: query['start_time_from'] = start_time_from
+        if start_time_to is not None: query['start_time_to'] = start_time_to
 
         while True:
             json = self._api.do('GET', '/api/2.1/jobs/runs/list', query=query)
@@ -3080,11 +2496,9 @@ class JobsAPI:
                    python_named_params: Optional[Dict[str, str]] = None,
                    python_params: Optional[List[str]] = None,
                    rerun_all_failed_tasks: Optional[bool] = None,
-                   rerun_dependent_tasks: Optional[bool] = None,
                    rerun_tasks: Optional[List[str]] = None,
                    spark_submit_params: Optional[List[str]] = None,
-                   sql_params: Optional[Dict[str, str]] = None,
-                   **kwargs) -> Wait[Run]:
+                   sql_params: Optional[Dict[str, str]] = None) -> Wait[Run]:
         """Repair a job run.
         
         Re-run one or more tasks. Tasks are re-run as part of the original job run. They use the current job
@@ -3143,10 +2557,7 @@ class JobsAPI:
           
           [Task parameter variables]: https://docs.databricks.com/jobs.html#parameter-variables
         :param rerun_all_failed_tasks: bool (optional)
-          If true, repair all failed tasks. Only one of `rerun_tasks` or `rerun_all_failed_tasks` can be used.
-        :param rerun_dependent_tasks: bool (optional)
-          If true, repair all tasks that depend on the tasks in `rerun_tasks`, even if they were previously
-          successful. Can be also used in combination with `rerun_all_failed_tasks`.
+          If true, repair all failed tasks. Only one of rerun_tasks or rerun_all_failed_tasks can be used.
         :param rerun_tasks: List[str] (optional)
           The task keys of the task runs to repair.
         :param spark_submit_params: List[str] (optional)
@@ -3173,26 +2584,24 @@ class JobsAPI:
           Long-running operation waiter for :class:`Run`.
           See :method:wait_get_run_job_terminated_or_skipped for more details.
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = RepairRun(dbt_commands=dbt_commands,
-                                jar_params=jar_params,
-                                latest_repair_id=latest_repair_id,
-                                notebook_params=notebook_params,
-                                pipeline_params=pipeline_params,
-                                python_named_params=python_named_params,
-                                python_params=python_params,
-                                rerun_all_failed_tasks=rerun_all_failed_tasks,
-                                rerun_dependent_tasks=rerun_dependent_tasks,
-                                rerun_tasks=rerun_tasks,
-                                run_id=run_id,
-                                spark_submit_params=spark_submit_params,
-                                sql_params=sql_params)
-        body = request.as_dict()
+        body = {}
+        if dbt_commands is not None: body['dbt_commands'] = [v for v in dbt_commands]
+        if jar_params is not None: body['jar_params'] = [v for v in jar_params]
+        if latest_repair_id is not None: body['latest_repair_id'] = latest_repair_id
+        if notebook_params is not None: body['notebook_params'] = notebook_params
+        if pipeline_params is not None:
+            body['pipeline_params'] = _validated('pipeline_params', PipelineParams, pipeline_params)
+        if python_named_params is not None: body['python_named_params'] = python_named_params
+        if python_params is not None: body['python_params'] = [v for v in python_params]
+        if rerun_all_failed_tasks is not None: body['rerun_all_failed_tasks'] = rerun_all_failed_tasks
+        if rerun_tasks is not None: body['rerun_tasks'] = [v for v in rerun_tasks]
+        if run_id is not None: body['run_id'] = run_id
+        if spark_submit_params is not None: body['spark_submit_params'] = [v for v in spark_submit_params]
+        if sql_params is not None: body['sql_params'] = sql_params
         op_response = self._api.do('POST', '/api/2.1/jobs/runs/repair', body=body)
         return Wait(self.wait_get_run_job_terminated_or_skipped,
                     response=RepairRunResponse.from_dict(op_response),
-                    run_id=request.run_id)
+                    run_id=run_id)
 
     def repair_run_and_wait(
         self,
@@ -3206,7 +2615,6 @@ class JobsAPI:
         python_named_params: Optional[Dict[str, str]] = None,
         python_params: Optional[List[str]] = None,
         rerun_all_failed_tasks: Optional[bool] = None,
-        rerun_dependent_tasks: Optional[bool] = None,
         rerun_tasks: Optional[List[str]] = None,
         spark_submit_params: Optional[List[str]] = None,
         sql_params: Optional[Dict[str, str]] = None,
@@ -3219,13 +2627,12 @@ class JobsAPI:
                                python_named_params=python_named_params,
                                python_params=python_params,
                                rerun_all_failed_tasks=rerun_all_failed_tasks,
-                               rerun_dependent_tasks=rerun_dependent_tasks,
                                rerun_tasks=rerun_tasks,
                                run_id=run_id,
                                spark_submit_params=spark_submit_params,
                                sql_params=sql_params).result(timeout=timeout)
 
-    def reset(self, job_id: int, new_settings: JobSettings, **kwargs):
+    def reset(self, job_id: int, new_settings: JobSettings):
         """Overwrites all settings for a job.
         
         Overwrites all the settings for a specific job. Use the Update endpoint to update job settings
@@ -3241,10 +2648,10 @@ class JobsAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = ResetJob(job_id=job_id, new_settings=new_settings)
-        body = request.as_dict()
+        body = {}
+        if job_id is not None: body['job_id'] = job_id
+        if new_settings is not None:
+            body['new_settings'] = _validated('new_settings', JobSettings, new_settings)
         self._api.do('POST', '/api/2.1/jobs/reset', body=body)
 
     def run_now(self,
@@ -3253,14 +2660,12 @@ class JobsAPI:
                 dbt_commands: Optional[List[str]] = None,
                 idempotency_token: Optional[str] = None,
                 jar_params: Optional[List[str]] = None,
-                job_parameters: Optional[List[Dict[str, str]]] = None,
                 notebook_params: Optional[Dict[str, str]] = None,
                 pipeline_params: Optional[PipelineParams] = None,
                 python_named_params: Optional[Dict[str, str]] = None,
                 python_params: Optional[List[str]] = None,
                 spark_submit_params: Optional[List[str]] = None,
-                sql_params: Optional[Dict[str, str]] = None,
-                **kwargs) -> Wait[Run]:
+                sql_params: Optional[Dict[str, str]] = None) -> Wait[Run]:
         """Trigger a new job run.
         
         Run a job and return the `run_id` of the triggered run.
@@ -3292,8 +2697,6 @@ class JobsAPI:
           
           Use [Task parameter variables](/jobs.html"#parameter-variables") to set parameters containing
           information about job runs.
-        :param job_parameters: List[Dict[str,str]] (optional)
-          Job-level parameters used in the run
         :param notebook_params: Dict[str,str] (optional)
           A map from keys to values for jobs with notebook task, for example `\"notebook_params\": {\"name\":
           \"john doe\", \"age\": \"35\"}`. The map is passed to the notebook and is accessible through the
@@ -3353,20 +2756,18 @@ class JobsAPI:
           Long-running operation waiter for :class:`Run`.
           See :method:wait_get_run_job_terminated_or_skipped for more details.
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = RunNow(dbt_commands=dbt_commands,
-                             idempotency_token=idempotency_token,
-                             jar_params=jar_params,
-                             job_id=job_id,
-                             job_parameters=job_parameters,
-                             notebook_params=notebook_params,
-                             pipeline_params=pipeline_params,
-                             python_named_params=python_named_params,
-                             python_params=python_params,
-                             spark_submit_params=spark_submit_params,
-                             sql_params=sql_params)
-        body = request.as_dict()
+        body = {}
+        if dbt_commands is not None: body['dbt_commands'] = [v for v in dbt_commands]
+        if idempotency_token is not None: body['idempotency_token'] = idempotency_token
+        if jar_params is not None: body['jar_params'] = [v for v in jar_params]
+        if job_id is not None: body['job_id'] = job_id
+        if notebook_params is not None: body['notebook_params'] = notebook_params
+        if pipeline_params is not None:
+            body['pipeline_params'] = _validated('pipeline_params', PipelineParams, pipeline_params)
+        if python_named_params is not None: body['python_named_params'] = python_named_params
+        if python_params is not None: body['python_params'] = [v for v in python_params]
+        if spark_submit_params is not None: body['spark_submit_params'] = [v for v in spark_submit_params]
+        if sql_params is not None: body['sql_params'] = sql_params
         op_response = self._api.do('POST', '/api/2.1/jobs/run-now', body=body)
         return Wait(self.wait_get_run_job_terminated_or_skipped,
                     response=RunNowResponse.from_dict(op_response),
@@ -3378,7 +2779,6 @@ class JobsAPI:
                          dbt_commands: Optional[List[str]] = None,
                          idempotency_token: Optional[str] = None,
                          jar_params: Optional[List[str]] = None,
-                         job_parameters: Optional[List[Dict[str, str]]] = None,
                          notebook_params: Optional[Dict[str, str]] = None,
                          pipeline_params: Optional[PipelineParams] = None,
                          python_named_params: Optional[Dict[str, str]] = None,
@@ -3390,7 +2790,6 @@ class JobsAPI:
                             idempotency_token=idempotency_token,
                             jar_params=jar_params,
                             job_id=job_id,
-                            job_parameters=job_parameters,
                             notebook_params=notebook_params,
                             pipeline_params=pipeline_params,
                             python_named_params=python_named_params,
@@ -3401,16 +2800,13 @@ class JobsAPI:
     def submit(self,
                *,
                access_control_list: Optional[List[iam.AccessControlRequest]] = None,
-               email_notifications: Optional[JobEmailNotifications] = None,
                git_source: Optional[GitSource] = None,
-               health: Optional[JobsHealthRules] = None,
                idempotency_token: Optional[str] = None,
                notification_settings: Optional[JobNotificationSettings] = None,
                run_name: Optional[str] = None,
-               tasks: Optional[List[SubmitTask]] = None,
+               tasks: Optional[List[RunSubmitTaskSettings]] = None,
                timeout_seconds: Optional[int] = None,
-               webhook_notifications: Optional[WebhookNotifications] = None,
-               **kwargs) -> Wait[Run]:
+               webhook_notifications: Optional[JobWebhookNotifications] = None) -> Wait[Run]:
         """Create and trigger a one-time run.
         
         Submit a one-time run. This endpoint allows you to submit a workload directly without creating a job.
@@ -3419,14 +2815,9 @@ class JobsAPI:
         
         :param access_control_list: List[:class:`AccessControlRequest`] (optional)
           List of permissions to set on the job.
-        :param email_notifications: :class:`JobEmailNotifications` (optional)
-          An optional set of email addresses notified when the run begins or completes. The default behavior
-          is to not send any emails.
         :param git_source: :class:`GitSource` (optional)
           An optional specification for a remote repository containing the notebooks used by this job's
           notebook tasks.
-        :param health: :class:`JobsHealthRules` (optional)
-          An optional set of health rules that can be defined for this job.
         :param idempotency_token: str (optional)
           An optional token that can be used to guarantee the idempotency of job run requests. If a run with
           the provided token already exists, the request does not create a new run but returns the ID of the
@@ -3445,10 +2836,10 @@ class JobsAPI:
           `webhook_notifications` for this run.
         :param run_name: str (optional)
           An optional name for the run. The default value is `Untitled`.
-        :param tasks: List[:class:`SubmitTask`] (optional)
+        :param tasks: List[:class:`RunSubmitTaskSettings`] (optional)
         :param timeout_seconds: int (optional)
           An optional timeout applied to each run of this job. The default behavior is to have no timeout.
-        :param webhook_notifications: :class:`WebhookNotifications` (optional)
+        :param webhook_notifications: :class:`JobWebhookNotifications` (optional)
           A collection of system notification IDs to notify when the run begins or completes. The default
           behavior is to not send any system notifications.
         
@@ -3456,19 +2847,20 @@ class JobsAPI:
           Long-running operation waiter for :class:`Run`.
           See :method:wait_get_run_job_terminated_or_skipped for more details.
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = SubmitRun(access_control_list=access_control_list,
-                                email_notifications=email_notifications,
-                                git_source=git_source,
-                                health=health,
-                                idempotency_token=idempotency_token,
-                                notification_settings=notification_settings,
-                                run_name=run_name,
-                                tasks=tasks,
-                                timeout_seconds=timeout_seconds,
-                                webhook_notifications=webhook_notifications)
-        body = request.as_dict()
+        body = {}
+        if access_control_list is not None: body['access_control_list'] = [v for v in access_control_list]
+        if git_source is not None: body['git_source'] = _validated('git_source', GitSource, git_source)
+        if idempotency_token is not None: body['idempotency_token'] = idempotency_token
+        if notification_settings is not None:
+            body['notification_settings'] = _validated('notification_settings', JobNotificationSettings,
+                                                       notification_settings)
+        if run_name is not None: body['run_name'] = run_name
+        if tasks is not None:
+            body['tasks'] = [_validated('tasks item', RunSubmitTaskSettings, v) for v in tasks]
+        if timeout_seconds is not None: body['timeout_seconds'] = timeout_seconds
+        if webhook_notifications is not None:
+            body['webhook_notifications'] = _validated('webhook_notifications', JobWebhookNotifications,
+                                                       webhook_notifications)
         op_response = self._api.do('POST', '/api/2.1/jobs/runs/submit', body=body)
         return Wait(self.wait_get_run_job_terminated_or_skipped,
                     response=SubmitRunResponse.from_dict(op_response),
@@ -3478,20 +2870,16 @@ class JobsAPI:
         self,
         *,
         access_control_list: Optional[List[iam.AccessControlRequest]] = None,
-        email_notifications: Optional[JobEmailNotifications] = None,
         git_source: Optional[GitSource] = None,
-        health: Optional[JobsHealthRules] = None,
         idempotency_token: Optional[str] = None,
         notification_settings: Optional[JobNotificationSettings] = None,
         run_name: Optional[str] = None,
-        tasks: Optional[List[SubmitTask]] = None,
+        tasks: Optional[List[RunSubmitTaskSettings]] = None,
         timeout_seconds: Optional[int] = None,
-        webhook_notifications: Optional[WebhookNotifications] = None,
+        webhook_notifications: Optional[JobWebhookNotifications] = None,
         timeout=timedelta(minutes=20)) -> Run:
         return self.submit(access_control_list=access_control_list,
-                           email_notifications=email_notifications,
                            git_source=git_source,
-                           health=health,
                            idempotency_token=idempotency_token,
                            notification_settings=notification_settings,
                            run_name=run_name,
@@ -3503,8 +2891,7 @@ class JobsAPI:
                job_id: int,
                *,
                fields_to_remove: Optional[List[str]] = None,
-               new_settings: Optional[JobSettings] = None,
-               **kwargs):
+               new_settings: Optional[JobSettings] = None):
         """Partially update a job.
         
         Add, update, or remove specific settings of an existing job. Use the ResetJob to overwrite all job
@@ -3513,24 +2900,20 @@ class JobsAPI:
         :param job_id: int
           The canonical identifier of the job to update. This field is required.
         :param fields_to_remove: List[str] (optional)
-          Remove top-level fields in the job settings. Removing nested fields is not supported, except for
-          tasks and job clusters (`tasks/task_1`). This field is optional.
+          Remove top-level fields in the job settings. Removing nested fields is not supported. This field is
+          optional.
         :param new_settings: :class:`JobSettings` (optional)
-          The new settings for the job.
-          
-          Top-level fields specified in `new_settings` are completely replaced, except for arrays which are
-          merged. That is, new and existing entries are completely replaced based on the respective key
-          fields, i.e. `task_key` or `job_cluster_key`, while previous entries are kept.
-          
-          Partially updating nested fields is not supported.
+          The new settings for the job. Any top-level fields specified in `new_settings` are completely
+          replaced. Partially updating nested fields is not supported.
           
           Changes to the field `JobSettings.timeout_seconds` are applied to active runs. Changes to other
           fields are applied to future runs only.
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = UpdateJob(fields_to_remove=fields_to_remove, job_id=job_id, new_settings=new_settings)
-        body = request.as_dict()
+        body = {}
+        if fields_to_remove is not None: body['fields_to_remove'] = [v for v in fields_to_remove]
+        if job_id is not None: body['job_id'] = job_id
+        if new_settings is not None:
+            body['new_settings'] = _validated('new_settings', JobSettings, new_settings)
         self._api.do('POST', '/api/2.1/jobs/update', body=body)

--- a/databricks/sdk/service/ml.py
+++ b/databricks/sdk/service/ml.py
@@ -459,13 +459,6 @@ class DatasetInput:
 
 
 @dataclass
-class DeleteCommentRequest:
-    """Delete a comment"""
-
-    id: str
-
-
-@dataclass
 class DeleteExperiment:
     experiment_id: str
 
@@ -477,38 +470,6 @@ class DeleteExperiment:
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'DeleteExperiment':
         return cls(experiment_id=d.get('experiment_id', None))
-
-
-@dataclass
-class DeleteModelRequest:
-    """Delete a model"""
-
-    name: str
-
-
-@dataclass
-class DeleteModelTagRequest:
-    """Delete a model tag"""
-
-    name: str
-    key: str
-
-
-@dataclass
-class DeleteModelVersionRequest:
-    """Delete a model version."""
-
-    name: str
-    version: str
-
-
-@dataclass
-class DeleteModelVersionTagRequest:
-    """Delete a model version tag"""
-
-    name: str
-    version: str
-    key: str
 
 
 @dataclass
@@ -541,30 +502,12 @@ class DeleteTag:
         return cls(key=d.get('key', None), run_id=d.get('run_id', None))
 
 
-@dataclass
-class DeleteTransitionRequestRequest:
-    """Delete a transition request"""
-
-    name: str
-    version: str
-    stage: 'DeleteTransitionRequestStage'
-    creator: str
-    comment: Optional[str] = None
-
-
 class DeleteTransitionRequestStage(Enum):
 
     ARCHIVED = 'Archived'
     NONE = 'None'
     PRODUCTION = 'Production'
     STAGING = 'Staging'
-
-
-@dataclass
-class DeleteWebhookRequest:
-    """Delete a webhook"""
-
-    id: Optional[str] = None
 
 
 @dataclass
@@ -634,13 +577,6 @@ class FileInfo:
 
 
 @dataclass
-class GetByNameRequest:
-    """Get metadata"""
-
-    experiment_name: str
-
-
-@dataclass
 class GetExperimentByNameResponse:
     experiment: Optional['Experiment'] = None
 
@@ -652,24 +588,6 @@ class GetExperimentByNameResponse:
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'GetExperimentByNameResponse':
         return cls(experiment=_from_dict(d, 'experiment', Experiment))
-
-
-@dataclass
-class GetExperimentRequest:
-    """Get an experiment"""
-
-    experiment_id: str
-
-
-@dataclass
-class GetHistoryRequest:
-    """Get history of a given metric within a run"""
-
-    metric_key: str
-    max_results: Optional[int] = None
-    page_token: Optional[str] = None
-    run_id: Optional[str] = None
-    run_uuid: Optional[str] = None
 
 
 @dataclass
@@ -719,13 +637,6 @@ class GetMetricHistoryResponse:
 
 
 @dataclass
-class GetModelRequest:
-    """Get model"""
-
-    name: str
-
-
-@dataclass
 class GetModelResponse:
     registered_model_databricks: Optional['ModelDatabricks'] = None
 
@@ -738,14 +649,6 @@ class GetModelResponse:
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'GetModelResponse':
         return cls(registered_model_databricks=_from_dict(d, 'registered_model_databricks', ModelDatabricks))
-
-
-@dataclass
-class GetModelVersionDownloadUriRequest:
-    """Get a model version URI"""
-
-    name: str
-    version: str
 
 
 @dataclass
@@ -763,14 +666,6 @@ class GetModelVersionDownloadUriResponse:
 
 
 @dataclass
-class GetModelVersionRequest:
-    """Get a model version"""
-
-    name: str
-    version: str
-
-
-@dataclass
 class GetModelVersionResponse:
     model_version: Optional['ModelVersion'] = None
 
@@ -782,14 +677,6 @@ class GetModelVersionResponse:
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'GetModelVersionResponse':
         return cls(model_version=_from_dict(d, 'model_version', ModelVersion))
-
-
-@dataclass
-class GetRunRequest:
-    """Get a run"""
-
-    run_id: str
-    run_uuid: Optional[str] = None
 
 
 @dataclass
@@ -900,16 +787,6 @@ class JobSpecWithoutSecret:
 
 
 @dataclass
-class ListArtifactsRequest:
-    """Get all artifacts"""
-
-    page_token: Optional[str] = None
-    path: Optional[str] = None
-    run_id: Optional[str] = None
-    run_uuid: Optional[str] = None
-
-
-@dataclass
 class ListArtifactsResponse:
     files: Optional['List[FileInfo]'] = None
     next_page_token: Optional[str] = None
@@ -930,15 +807,6 @@ class ListArtifactsResponse:
 
 
 @dataclass
-class ListExperimentsRequest:
-    """List experiments"""
-
-    max_results: Optional[int] = None
-    page_token: Optional[str] = None
-    view_type: Optional[str] = None
-
-
-@dataclass
 class ListExperimentsResponse:
     experiments: Optional['List[Experiment]'] = None
     next_page_token: Optional[str] = None
@@ -953,14 +821,6 @@ class ListExperimentsResponse:
     def from_dict(cls, d: Dict[str, any]) -> 'ListExperimentsResponse':
         return cls(experiments=_repeated(d, 'experiments', Experiment),
                    next_page_token=d.get('next_page_token', None))
-
-
-@dataclass
-class ListModelsRequest:
-    """List models"""
-
-    max_results: Optional[int] = None
-    page_token: Optional[str] = None
 
 
 @dataclass
@@ -998,14 +858,6 @@ class ListRegistryWebhooks:
 
 
 @dataclass
-class ListTransitionRequestsRequest:
-    """List transition requests"""
-
-    name: str
-    version: str
-
-
-@dataclass
 class ListTransitionRequestsResponse:
     requests: Optional['List[Activity]'] = None
 
@@ -1017,15 +869,6 @@ class ListTransitionRequestsResponse:
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'ListTransitionRequestsResponse':
         return cls(requests=_repeated(d, 'requests', Activity))
-
-
-@dataclass
-class ListWebhooksRequest:
-    """List registry webhooks"""
-
-    events: Optional['List[RegistryWebhookEvent]'] = None
-    model_name: Optional[str] = None
-    page_token: Optional[str] = None
 
 
 @dataclass
@@ -1731,16 +1574,6 @@ class SearchExperimentsViewType(Enum):
 
 
 @dataclass
-class SearchModelVersionsRequest:
-    """Searches model versions"""
-
-    filter: Optional[str] = None
-    max_results: Optional[int] = None
-    order_by: Optional['List[str]'] = None
-    page_token: Optional[str] = None
-
-
-@dataclass
 class SearchModelVersionsResponse:
     model_versions: Optional['List[ModelVersion]'] = None
     next_page_token: Optional[str] = None
@@ -1755,16 +1588,6 @@ class SearchModelVersionsResponse:
     def from_dict(cls, d: Dict[str, any]) -> 'SearchModelVersionsResponse':
         return cls(model_versions=_repeated(d, 'model_versions', ModelVersion),
                    next_page_token=d.get('next_page_token', None))
-
-
-@dataclass
-class SearchModelsRequest:
-    """Search models"""
-
-    filter: Optional[str] = None
-    max_results: Optional[int] = None
-    order_by: Optional['List[str]'] = None
-    page_token: Optional[str] = None
 
 
 @dataclass
@@ -2228,8 +2051,7 @@ class ExperimentsAPI:
                           name: str,
                           *,
                           artifact_location: Optional[str] = None,
-                          tags: Optional[List[ExperimentTag]] = None,
-                          **kwargs) -> CreateExperimentResponse:
+                          tags: Optional[List[ExperimentTag]] = None) -> CreateExperimentResponse:
         """Create experiment.
         
         Creates an experiment with a name. Returns the ID of the newly created experiment. Validates that
@@ -2251,10 +2073,10 @@ class ExperimentsAPI:
         
         :returns: :class:`CreateExperimentResponse`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = CreateExperiment(artifact_location=artifact_location, name=name, tags=tags)
-        body = request.as_dict()
+        body = {}
+        if artifact_location is not None: body['artifact_location'] = artifact_location
+        if name is not None: body['name'] = name
+        if tags is not None: body['tags'] = [v.as_dict() for v in tags]
 
         json = self._api.do('POST', '/api/2.0/mlflow/experiments/create', body=body)
         return CreateExperimentResponse.from_dict(json)
@@ -2264,8 +2086,7 @@ class ExperimentsAPI:
                    experiment_id: Optional[str] = None,
                    start_time: Optional[int] = None,
                    tags: Optional[List[RunTag]] = None,
-                   user_id: Optional[str] = None,
-                   **kwargs) -> CreateRunResponse:
+                   user_id: Optional[str] = None) -> CreateRunResponse:
         """Create a run.
         
         Creates a new run within an experiment. A run is usually a single execution of a machine learning or
@@ -2284,18 +2105,16 @@ class ExperimentsAPI:
         
         :returns: :class:`CreateRunResponse`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = CreateRun(experiment_id=experiment_id,
-                                start_time=start_time,
-                                tags=tags,
-                                user_id=user_id)
-        body = request.as_dict()
+        body = {}
+        if experiment_id is not None: body['experiment_id'] = experiment_id
+        if start_time is not None: body['start_time'] = start_time
+        if tags is not None: body['tags'] = [v.as_dict() for v in tags]
+        if user_id is not None: body['user_id'] = user_id
 
         json = self._api.do('POST', '/api/2.0/mlflow/runs/create', body=body)
         return CreateRunResponse.from_dict(json)
 
-    def delete_experiment(self, experiment_id: str, **kwargs):
+    def delete_experiment(self, experiment_id: str):
         """Delete an experiment.
         
         Marks an experiment and associated metadata, runs, metrics, params, and tags for deletion. If the
@@ -2306,13 +2125,11 @@ class ExperimentsAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = DeleteExperiment(experiment_id=experiment_id)
-        body = request.as_dict()
+        body = {}
+        if experiment_id is not None: body['experiment_id'] = experiment_id
         self._api.do('POST', '/api/2.0/mlflow/experiments/delete', body=body)
 
-    def delete_run(self, run_id: str, **kwargs):
+    def delete_run(self, run_id: str):
         """Delete a run.
         
         Marks a run for deletion.
@@ -2322,13 +2139,11 @@ class ExperimentsAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = DeleteRun(run_id=run_id)
-        body = request.as_dict()
+        body = {}
+        if run_id is not None: body['run_id'] = run_id
         self._api.do('POST', '/api/2.0/mlflow/runs/delete', body=body)
 
-    def delete_tag(self, run_id: str, key: str, **kwargs):
+    def delete_tag(self, run_id: str, key: str):
         """Delete a tag.
         
         Deletes a tag on a run. Tags are run metadata that can be updated during a run and after a run
@@ -2341,13 +2156,12 @@ class ExperimentsAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = DeleteTag(key=key, run_id=run_id)
-        body = request.as_dict()
+        body = {}
+        if key is not None: body['key'] = key
+        if run_id is not None: body['run_id'] = run_id
         self._api.do('POST', '/api/2.0/mlflow/runs/delete-tag', body=body)
 
-    def get_by_name(self, experiment_name: str, **kwargs) -> GetExperimentByNameResponse:
+    def get_by_name(self, experiment_name: str) -> GetExperimentByNameResponse:
         """Get metadata.
         
         Gets metadata for an experiment.
@@ -2363,17 +2177,14 @@ class ExperimentsAPI:
         
         :returns: :class:`GetExperimentByNameResponse`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = GetByNameRequest(experiment_name=experiment_name)
 
         query = {}
-        if experiment_name: query['experiment_name'] = request.experiment_name
+        if experiment_name is not None: query['experiment_name'] = experiment_name
 
         json = self._api.do('GET', '/api/2.0/mlflow/experiments/get-by-name', query=query)
         return GetExperimentByNameResponse.from_dict(json)
 
-    def get_experiment(self, experiment_id: str, **kwargs) -> Experiment:
+    def get_experiment(self, experiment_id: str) -> Experiment:
         """Get an experiment.
         
         Gets metadata for an experiment. This method works on deleted experiments.
@@ -2383,12 +2194,9 @@ class ExperimentsAPI:
         
         :returns: :class:`Experiment`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = GetExperimentRequest(experiment_id=experiment_id)
 
         query = {}
-        if experiment_id: query['experiment_id'] = request.experiment_id
+        if experiment_id is not None: query['experiment_id'] = experiment_id
 
         json = self._api.do('GET', '/api/2.0/mlflow/experiments/get', query=query)
         return Experiment.from_dict(json)
@@ -2399,8 +2207,7 @@ class ExperimentsAPI:
                     max_results: Optional[int] = None,
                     page_token: Optional[str] = None,
                     run_id: Optional[str] = None,
-                    run_uuid: Optional[str] = None,
-                    **kwargs) -> GetMetricHistoryResponse:
+                    run_uuid: Optional[str] = None) -> GetMetricHistoryResponse:
         """Get history of a given metric within a run.
         
         Gets a list of all values for the specified metric for a given run.
@@ -2420,25 +2227,18 @@ class ExperimentsAPI:
         
         :returns: :class:`GetMetricHistoryResponse`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = GetHistoryRequest(max_results=max_results,
-                                        metric_key=metric_key,
-                                        page_token=page_token,
-                                        run_id=run_id,
-                                        run_uuid=run_uuid)
 
         query = {}
-        if max_results: query['max_results'] = request.max_results
-        if metric_key: query['metric_key'] = request.metric_key
-        if page_token: query['page_token'] = request.page_token
-        if run_id: query['run_id'] = request.run_id
-        if run_uuid: query['run_uuid'] = request.run_uuid
+        if max_results is not None: query['max_results'] = max_results
+        if metric_key is not None: query['metric_key'] = metric_key
+        if page_token is not None: query['page_token'] = page_token
+        if run_id is not None: query['run_id'] = run_id
+        if run_uuid is not None: query['run_uuid'] = run_uuid
 
         json = self._api.do('GET', '/api/2.0/mlflow/metrics/get-history', query=query)
         return GetMetricHistoryResponse.from_dict(json)
 
-    def get_run(self, run_id: str, *, run_uuid: Optional[str] = None, **kwargs) -> GetRunResponse:
+    def get_run(self, run_id: str, *, run_uuid: Optional[str] = None) -> GetRunResponse:
         """Get a run.
         
         Gets the metadata, metrics, params, and tags for a run. In the case where multiple metrics with the
@@ -2454,13 +2254,10 @@ class ExperimentsAPI:
         
         :returns: :class:`GetRunResponse`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = GetRunRequest(run_id=run_id, run_uuid=run_uuid)
 
         query = {}
-        if run_id: query['run_id'] = request.run_id
-        if run_uuid: query['run_uuid'] = request.run_uuid
+        if run_id is not None: query['run_id'] = run_id
+        if run_uuid is not None: query['run_uuid'] = run_uuid
 
         json = self._api.do('GET', '/api/2.0/mlflow/runs/get', query=query)
         return GetRunResponse.from_dict(json)
@@ -2470,8 +2267,7 @@ class ExperimentsAPI:
                        page_token: Optional[str] = None,
                        path: Optional[str] = None,
                        run_id: Optional[str] = None,
-                       run_uuid: Optional[str] = None,
-                       **kwargs) -> Iterator[FileInfo]:
+                       run_uuid: Optional[str] = None) -> Iterator[FileInfo]:
         """Get all artifacts.
         
         List artifacts for a run. Takes an optional `artifact_path` prefix. If it is specified, the response
@@ -2489,15 +2285,12 @@ class ExperimentsAPI:
         
         :returns: Iterator over :class:`FileInfo`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = ListArtifactsRequest(page_token=page_token, path=path, run_id=run_id, run_uuid=run_uuid)
 
         query = {}
-        if page_token: query['page_token'] = request.page_token
-        if path: query['path'] = request.path
-        if run_id: query['run_id'] = request.run_id
-        if run_uuid: query['run_uuid'] = request.run_uuid
+        if page_token is not None: query['page_token'] = page_token
+        if path is not None: query['path'] = path
+        if run_id is not None: query['run_id'] = run_id
+        if run_uuid is not None: query['run_uuid'] = run_uuid
 
         while True:
             json = self._api.do('GET', '/api/2.0/mlflow/artifacts/list', query=query)
@@ -2513,8 +2306,7 @@ class ExperimentsAPI:
                          *,
                          max_results: Optional[int] = None,
                          page_token: Optional[str] = None,
-                         view_type: Optional[str] = None,
-                         **kwargs) -> Iterator[Experiment]:
+                         view_type: Optional[str] = None) -> Iterator[Experiment]:
         """List experiments.
         
         Gets a list of all experiments.
@@ -2530,16 +2322,11 @@ class ExperimentsAPI:
         
         :returns: Iterator over :class:`Experiment`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = ListExperimentsRequest(max_results=max_results,
-                                             page_token=page_token,
-                                             view_type=view_type)
 
         query = {}
-        if max_results: query['max_results'] = request.max_results
-        if page_token: query['page_token'] = request.page_token
-        if view_type: query['view_type'] = request.view_type
+        if max_results is not None: query['max_results'] = max_results
+        if page_token is not None: query['page_token'] = page_token
+        if view_type is not None: query['view_type'] = view_type
 
         while True:
             json = self._api.do('GET', '/api/2.0/mlflow/experiments/list', query=query)
@@ -2556,8 +2343,7 @@ class ExperimentsAPI:
                   metrics: Optional[List[Metric]] = None,
                   params: Optional[List[Param]] = None,
                   run_id: Optional[str] = None,
-                  tags: Optional[List[RunTag]] = None,
-                  **kwargs):
+                  tags: Optional[List[RunTag]] = None):
         """Log a batch.
         
         Logs a batch of metrics, params, and tags for a run. If any data failed to be persisted, the server
@@ -2609,17 +2395,14 @@ class ExperimentsAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = LogBatch(metrics=metrics, params=params, run_id=run_id, tags=tags)
-        body = request.as_dict()
+        body = {}
+        if metrics is not None: body['metrics'] = [v.as_dict() for v in metrics]
+        if params is not None: body['params'] = [v.as_dict() for v in params]
+        if run_id is not None: body['run_id'] = run_id
+        if tags is not None: body['tags'] = [v.as_dict() for v in tags]
         self._api.do('POST', '/api/2.0/mlflow/runs/log-batch', body=body)
 
-    def log_inputs(self,
-                   *,
-                   datasets: Optional[List[DatasetInput]] = None,
-                   run_id: Optional[str] = None,
-                   **kwargs):
+    def log_inputs(self, *, datasets: Optional[List[DatasetInput]] = None, run_id: Optional[str] = None):
         """Log inputs to a run.
         
         **NOTE:** Experimental: This API may change or be removed in a future release without warning.
@@ -2631,10 +2414,9 @@ class ExperimentsAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = LogInputs(datasets=datasets, run_id=run_id)
-        body = request.as_dict()
+        body = {}
+        if datasets is not None: body['datasets'] = [v.as_dict() for v in datasets]
+        if run_id is not None: body['run_id'] = run_id
         self._api.do('POST', '/api/2.0/mlflow/runs/log-inputs', body=body)
 
     def log_metric(self,
@@ -2644,8 +2426,7 @@ class ExperimentsAPI:
                    *,
                    run_id: Optional[str] = None,
                    run_uuid: Optional[str] = None,
-                   step: Optional[int] = None,
-                   **kwargs):
+                   step: Optional[int] = None):
         """Log a metric.
         
         Logs a metric for a run. A metric is a key-value pair (string key, float value) with an associated
@@ -2668,18 +2449,16 @@ class ExperimentsAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = LogMetric(key=key,
-                                run_id=run_id,
-                                run_uuid=run_uuid,
-                                step=step,
-                                timestamp=timestamp,
-                                value=value)
-        body = request.as_dict()
+        body = {}
+        if key is not None: body['key'] = key
+        if run_id is not None: body['run_id'] = run_id
+        if run_uuid is not None: body['run_uuid'] = run_uuid
+        if step is not None: body['step'] = step
+        if timestamp is not None: body['timestamp'] = timestamp
+        if value is not None: body['value'] = value
         self._api.do('POST', '/api/2.0/mlflow/runs/log-metric', body=body)
 
-    def log_model(self, *, model_json: Optional[str] = None, run_id: Optional[str] = None, **kwargs):
+    def log_model(self, *, model_json: Optional[str] = None, run_id: Optional[str] = None):
         """Log a model.
         
         **NOTE:** Experimental: This API may change or be removed in a future release without warning.
@@ -2691,10 +2470,9 @@ class ExperimentsAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = LogModel(model_json=model_json, run_id=run_id)
-        body = request.as_dict()
+        body = {}
+        if model_json is not None: body['model_json'] = model_json
+        if run_id is not None: body['run_id'] = run_id
         self._api.do('POST', '/api/2.0/mlflow/runs/log-model', body=body)
 
     def log_param(self,
@@ -2702,8 +2480,7 @@ class ExperimentsAPI:
                   value: str,
                   *,
                   run_id: Optional[str] = None,
-                  run_uuid: Optional[str] = None,
-                  **kwargs):
+                  run_uuid: Optional[str] = None):
         """Log a param.
         
         Logs a param used for a run. A param is a key-value pair (string key, string value). Examples include
@@ -2722,13 +2499,14 @@ class ExperimentsAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = LogParam(key=key, run_id=run_id, run_uuid=run_uuid, value=value)
-        body = request.as_dict()
+        body = {}
+        if key is not None: body['key'] = key
+        if run_id is not None: body['run_id'] = run_id
+        if run_uuid is not None: body['run_uuid'] = run_uuid
+        if value is not None: body['value'] = value
         self._api.do('POST', '/api/2.0/mlflow/runs/log-parameter', body=body)
 
-    def restore_experiment(self, experiment_id: str, **kwargs):
+    def restore_experiment(self, experiment_id: str):
         """Restores an experiment.
         
         Restore an experiment marked for deletion. This also restores associated metadata, runs, metrics,
@@ -2742,13 +2520,11 @@ class ExperimentsAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = RestoreExperiment(experiment_id=experiment_id)
-        body = request.as_dict()
+        body = {}
+        if experiment_id is not None: body['experiment_id'] = experiment_id
         self._api.do('POST', '/api/2.0/mlflow/experiments/restore', body=body)
 
-    def restore_run(self, run_id: str, **kwargs):
+    def restore_run(self, run_id: str):
         """Restore a run.
         
         Restores a deleted run.
@@ -2758,10 +2534,8 @@ class ExperimentsAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = RestoreRun(run_id=run_id)
-        body = request.as_dict()
+        body = {}
+        if run_id is not None: body['run_id'] = run_id
         self._api.do('POST', '/api/2.0/mlflow/runs/restore', body=body)
 
     def search_experiments(self,
@@ -2770,8 +2544,7 @@ class ExperimentsAPI:
                            max_results: Optional[int] = None,
                            order_by: Optional[List[str]] = None,
                            page_token: Optional[str] = None,
-                           view_type: Optional[SearchExperimentsViewType] = None,
-                           **kwargs) -> Iterator[Experiment]:
+                           view_type: Optional[SearchExperimentsViewType] = None) -> Iterator[Experiment]:
         """Search experiments.
         
         Searches for experiments that satisfy specified search criteria.
@@ -2791,14 +2564,12 @@ class ExperimentsAPI:
         
         :returns: Iterator over :class:`Experiment`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = SearchExperiments(filter=filter,
-                                        max_results=max_results,
-                                        order_by=order_by,
-                                        page_token=page_token,
-                                        view_type=view_type)
-        body = request.as_dict()
+        body = {}
+        if filter is not None: body['filter'] = filter
+        if max_results is not None: body['max_results'] = max_results
+        if order_by is not None: body['order_by'] = [v for v in order_by]
+        if page_token is not None: body['page_token'] = page_token
+        if view_type is not None: body['view_type'] = view_type.value
 
         while True:
             json = self._api.do('POST', '/api/2.0/mlflow/experiments/search', body=body)
@@ -2817,8 +2588,7 @@ class ExperimentsAPI:
                     max_results: Optional[int] = None,
                     order_by: Optional[List[str]] = None,
                     page_token: Optional[str] = None,
-                    run_view_type: Optional[SearchRunsRunViewType] = None,
-                    **kwargs) -> Iterator[Run]:
+                    run_view_type: Optional[SearchRunsRunViewType] = None) -> Iterator[Run]:
         """Search for runs.
         
         Searches for runs that satisfy expressions.
@@ -2853,15 +2623,13 @@ class ExperimentsAPI:
         
         :returns: Iterator over :class:`Run`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = SearchRuns(experiment_ids=experiment_ids,
-                                 filter=filter,
-                                 max_results=max_results,
-                                 order_by=order_by,
-                                 page_token=page_token,
-                                 run_view_type=run_view_type)
-        body = request.as_dict()
+        body = {}
+        if experiment_ids is not None: body['experiment_ids'] = [v for v in experiment_ids]
+        if filter is not None: body['filter'] = filter
+        if max_results is not None: body['max_results'] = max_results
+        if order_by is not None: body['order_by'] = [v for v in order_by]
+        if page_token is not None: body['page_token'] = page_token
+        if run_view_type is not None: body['run_view_type'] = run_view_type.value
 
         while True:
             json = self._api.do('POST', '/api/2.0/mlflow/runs/search', body=body)
@@ -2873,7 +2641,7 @@ class ExperimentsAPI:
                 return
             body['page_token'] = json['next_page_token']
 
-    def set_experiment_tag(self, experiment_id: str, key: str, value: str, **kwargs):
+    def set_experiment_tag(self, experiment_id: str, key: str, value: str):
         """Set a tag.
         
         Sets a tag on an experiment. Experiment tags are metadata that can be updated.
@@ -2889,19 +2657,13 @@ class ExperimentsAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = SetExperimentTag(experiment_id=experiment_id, key=key, value=value)
-        body = request.as_dict()
+        body = {}
+        if experiment_id is not None: body['experiment_id'] = experiment_id
+        if key is not None: body['key'] = key
+        if value is not None: body['value'] = value
         self._api.do('POST', '/api/2.0/mlflow/experiments/set-experiment-tag', body=body)
 
-    def set_tag(self,
-                key: str,
-                value: str,
-                *,
-                run_id: Optional[str] = None,
-                run_uuid: Optional[str] = None,
-                **kwargs):
+    def set_tag(self, key: str, value: str, *, run_id: Optional[str] = None, run_uuid: Optional[str] = None):
         """Set a tag.
         
         Sets a tag on a run. Tags are run metadata that can be updated during a run and after a run completes.
@@ -2920,13 +2682,14 @@ class ExperimentsAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = SetTag(key=key, run_id=run_id, run_uuid=run_uuid, value=value)
-        body = request.as_dict()
+        body = {}
+        if key is not None: body['key'] = key
+        if run_id is not None: body['run_id'] = run_id
+        if run_uuid is not None: body['run_uuid'] = run_uuid
+        if value is not None: body['value'] = value
         self._api.do('POST', '/api/2.0/mlflow/runs/set-tag', body=body)
 
-    def update_experiment(self, experiment_id: str, *, new_name: Optional[str] = None, **kwargs):
+    def update_experiment(self, experiment_id: str, *, new_name: Optional[str] = None):
         """Update an experiment.
         
         Updates experiment metadata.
@@ -2938,10 +2701,9 @@ class ExperimentsAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = UpdateExperiment(experiment_id=experiment_id, new_name=new_name)
-        body = request.as_dict()
+        body = {}
+        if experiment_id is not None: body['experiment_id'] = experiment_id
+        if new_name is not None: body['new_name'] = new_name
         self._api.do('POST', '/api/2.0/mlflow/experiments/update', body=body)
 
     def update_run(self,
@@ -2949,8 +2711,7 @@ class ExperimentsAPI:
                    end_time: Optional[int] = None,
                    run_id: Optional[str] = None,
                    run_uuid: Optional[str] = None,
-                   status: Optional[UpdateRunStatus] = None,
-                   **kwargs) -> UpdateRunResponse:
+                   status: Optional[UpdateRunStatus] = None) -> UpdateRunResponse:
         """Update a run.
         
         Updates run metadata.
@@ -2967,10 +2728,11 @@ class ExperimentsAPI:
         
         :returns: :class:`UpdateRunResponse`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = UpdateRun(end_time=end_time, run_id=run_id, run_uuid=run_uuid, status=status)
-        body = request.as_dict()
+        body = {}
+        if end_time is not None: body['end_time'] = end_time
+        if run_id is not None: body['run_id'] = run_id
+        if run_uuid is not None: body['run_uuid'] = run_uuid
+        if status is not None: body['status'] = status.value
 
         json = self._api.do('POST', '/api/2.0/mlflow/runs/update', body=body)
         return UpdateRunResponse.from_dict(json)
@@ -2989,8 +2751,7 @@ class ModelRegistryAPI:
                                    stage: Stage,
                                    archive_existing_versions: bool,
                                    *,
-                                   comment: Optional[str] = None,
-                                   **kwargs) -> ApproveTransitionRequestResponse:
+                                   comment: Optional[str] = None) -> ApproveTransitionRequestResponse:
         """Approve transition request.
         
         Approves a model version stage transition request.
@@ -3016,19 +2777,18 @@ class ModelRegistryAPI:
         
         :returns: :class:`ApproveTransitionRequestResponse`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = ApproveTransitionRequest(archive_existing_versions=archive_existing_versions,
-                                               comment=comment,
-                                               name=name,
-                                               stage=stage,
-                                               version=version)
-        body = request.as_dict()
+        body = {}
+        if archive_existing_versions is not None:
+            body['archive_existing_versions'] = archive_existing_versions
+        if comment is not None: body['comment'] = comment
+        if name is not None: body['name'] = name
+        if stage is not None: body['stage'] = stage.value
+        if version is not None: body['version'] = version
 
         json = self._api.do('POST', '/api/2.0/mlflow/transition-requests/approve', body=body)
         return ApproveTransitionRequestResponse.from_dict(json)
 
-    def create_comment(self, name: str, version: str, comment: str, **kwargs) -> CreateCommentResponse:
+    def create_comment(self, name: str, version: str, comment: str) -> CreateCommentResponse:
         """Post a comment.
         
         Posts a comment on a model version. A comment can be submitted either by a user or programmatically to
@@ -3043,10 +2803,10 @@ class ModelRegistryAPI:
         
         :returns: :class:`CreateCommentResponse`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = CreateComment(comment=comment, name=name, version=version)
-        body = request.as_dict()
+        body = {}
+        if comment is not None: body['comment'] = comment
+        if name is not None: body['name'] = name
+        if version is not None: body['version'] = version
 
         json = self._api.do('POST', '/api/2.0/mlflow/comments/create', body=body)
         return CreateCommentResponse.from_dict(json)
@@ -3055,8 +2815,7 @@ class ModelRegistryAPI:
                      name: str,
                      *,
                      description: Optional[str] = None,
-                     tags: Optional[List[ModelTag]] = None,
-                     **kwargs) -> CreateModelResponse:
+                     tags: Optional[List[ModelTag]] = None) -> CreateModelResponse:
         """Create a model.
         
         Creates a new registered model with the name specified in the request body.
@@ -3072,10 +2831,10 @@ class ModelRegistryAPI:
         
         :returns: :class:`CreateModelResponse`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = CreateModelRequest(description=description, name=name, tags=tags)
-        body = request.as_dict()
+        body = {}
+        if description is not None: body['description'] = description
+        if name is not None: body['name'] = name
+        if tags is not None: body['tags'] = [v.as_dict() for v in tags]
 
         json = self._api.do('POST', '/api/2.0/mlflow/registered-models/create', body=body)
         return CreateModelResponse.from_dict(json)
@@ -3087,8 +2846,7 @@ class ModelRegistryAPI:
                              description: Optional[str] = None,
                              run_id: Optional[str] = None,
                              run_link: Optional[str] = None,
-                             tags: Optional[List[ModelVersionTag]] = None,
-                             **kwargs) -> CreateModelVersionResponse:
+                             tags: Optional[List[ModelVersionTag]] = None) -> CreateModelVersionResponse:
         """Create a model version.
         
         Creates a model version.
@@ -3110,15 +2868,13 @@ class ModelRegistryAPI:
         
         :returns: :class:`CreateModelVersionResponse`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = CreateModelVersionRequest(description=description,
-                                                name=name,
-                                                run_id=run_id,
-                                                run_link=run_link,
-                                                source=source,
-                                                tags=tags)
-        body = request.as_dict()
+        body = {}
+        if description is not None: body['description'] = description
+        if name is not None: body['name'] = name
+        if run_id is not None: body['run_id'] = run_id
+        if run_link is not None: body['run_link'] = run_link
+        if source is not None: body['source'] = source
+        if tags is not None: body['tags'] = [v.as_dict() for v in tags]
 
         json = self._api.do('POST', '/api/2.0/mlflow/model-versions/create', body=body)
         return CreateModelVersionResponse.from_dict(json)
@@ -3128,8 +2884,7 @@ class ModelRegistryAPI:
                                   version: str,
                                   stage: Stage,
                                   *,
-                                  comment: Optional[str] = None,
-                                  **kwargs) -> CreateTransitionRequestResponse:
+                                  comment: Optional[str] = None) -> CreateTransitionRequestResponse:
         """Make a transition request.
         
         Creates a model version stage transition request.
@@ -3153,10 +2908,11 @@ class ModelRegistryAPI:
         
         :returns: :class:`CreateTransitionRequestResponse`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = CreateTransitionRequest(comment=comment, name=name, stage=stage, version=version)
-        body = request.as_dict()
+        body = {}
+        if comment is not None: body['comment'] = comment
+        if name is not None: body['name'] = name
+        if stage is not None: body['stage'] = stage.value
+        if version is not None: body['version'] = version
 
         json = self._api.do('POST', '/api/2.0/mlflow/transition-requests/create', body=body)
         return CreateTransitionRequestResponse.from_dict(json)
@@ -3168,8 +2924,7 @@ class ModelRegistryAPI:
                        http_url_spec: Optional[HttpUrlSpec] = None,
                        job_spec: Optional[JobSpec] = None,
                        model_name: Optional[str] = None,
-                       status: Optional[RegistryWebhookStatus] = None,
-                       **kwargs) -> CreateWebhookResponse:
+                       status: Optional[RegistryWebhookStatus] = None) -> CreateWebhookResponse:
         """Create a webhook.
         
         **NOTE**: This endpoint is in Public Preview.
@@ -3216,20 +2971,18 @@ class ModelRegistryAPI:
         
         :returns: :class:`CreateWebhookResponse`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = CreateRegistryWebhook(description=description,
-                                            events=events,
-                                            http_url_spec=http_url_spec,
-                                            job_spec=job_spec,
-                                            model_name=model_name,
-                                            status=status)
-        body = request.as_dict()
+        body = {}
+        if description is not None: body['description'] = description
+        if events is not None: body['events'] = [v for v in events]
+        if http_url_spec is not None: body['http_url_spec'] = http_url_spec.as_dict()
+        if job_spec is not None: body['job_spec'] = job_spec.as_dict()
+        if model_name is not None: body['model_name'] = model_name
+        if status is not None: body['status'] = status.value
 
         json = self._api.do('POST', '/api/2.0/mlflow/registry-webhooks/create', body=body)
         return CreateWebhookResponse.from_dict(json)
 
-    def delete_comment(self, id: str, **kwargs):
+    def delete_comment(self, id: str):
         """Delete a comment.
         
         Deletes a comment on a model version.
@@ -3238,16 +2991,12 @@ class ModelRegistryAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = DeleteCommentRequest(id=id)
 
         query = {}
-        if id: query['id'] = request.id
-
+        if id is not None: query['id'] = id
         self._api.do('DELETE', '/api/2.0/mlflow/comments/delete', query=query)
 
-    def delete_model(self, name: str, **kwargs):
+    def delete_model(self, name: str):
         """Delete a model.
         
         Deletes a registered model.
@@ -3257,16 +3006,12 @@ class ModelRegistryAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = DeleteModelRequest(name=name)
 
         query = {}
-        if name: query['name'] = request.name
-
+        if name is not None: query['name'] = name
         self._api.do('DELETE', '/api/2.0/mlflow/registered-models/delete', query=query)
 
-    def delete_model_tag(self, name: str, key: str, **kwargs):
+    def delete_model_tag(self, name: str, key: str):
         """Delete a model tag.
         
         Deletes the tag for a registered model.
@@ -3279,17 +3024,13 @@ class ModelRegistryAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = DeleteModelTagRequest(key=key, name=name)
 
         query = {}
-        if key: query['key'] = request.key
-        if name: query['name'] = request.name
-
+        if key is not None: query['key'] = key
+        if name is not None: query['name'] = name
         self._api.do('DELETE', '/api/2.0/mlflow/registered-models/delete-tag', query=query)
 
-    def delete_model_version(self, name: str, version: str, **kwargs):
+    def delete_model_version(self, name: str, version: str):
         """Delete a model version.
         
         Deletes a model version.
@@ -3301,17 +3042,13 @@ class ModelRegistryAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = DeleteModelVersionRequest(name=name, version=version)
 
         query = {}
-        if name: query['name'] = request.name
-        if version: query['version'] = request.version
-
+        if name is not None: query['name'] = name
+        if version is not None: query['version'] = version
         self._api.do('DELETE', '/api/2.0/mlflow/model-versions/delete', query=query)
 
-    def delete_model_version_tag(self, name: str, version: str, key: str, **kwargs):
+    def delete_model_version_tag(self, name: str, version: str, key: str):
         """Delete a model version tag.
         
         Deletes a model version tag.
@@ -3326,15 +3063,11 @@ class ModelRegistryAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = DeleteModelVersionTagRequest(key=key, name=name, version=version)
 
         query = {}
-        if key: query['key'] = request.key
-        if name: query['name'] = request.name
-        if version: query['version'] = request.version
-
+        if key is not None: query['key'] = key
+        if name is not None: query['name'] = name
+        if version is not None: query['version'] = version
         self._api.do('DELETE', '/api/2.0/mlflow/model-versions/delete-tag', query=query)
 
     def delete_transition_request(self,
@@ -3343,8 +3076,7 @@ class ModelRegistryAPI:
                                   stage: DeleteTransitionRequestStage,
                                   creator: str,
                                   *,
-                                  comment: Optional[str] = None,
-                                  **kwargs):
+                                  comment: Optional[str] = None):
         """Delete a transition request.
         
         Cancels a model version stage transition request.
@@ -3371,24 +3103,16 @@ class ModelRegistryAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = DeleteTransitionRequestRequest(comment=comment,
-                                                     creator=creator,
-                                                     name=name,
-                                                     stage=stage,
-                                                     version=version)
 
         query = {}
-        if comment: query['comment'] = request.comment
-        if creator: query['creator'] = request.creator
-        if name: query['name'] = request.name
-        if stage: query['stage'] = request.stage.value
-        if version: query['version'] = request.version
-
+        if comment is not None: query['comment'] = comment
+        if creator is not None: query['creator'] = creator
+        if name is not None: query['name'] = name
+        if stage is not None: query['stage'] = stage.value
+        if version is not None: query['version'] = version
         self._api.do('DELETE', '/api/2.0/mlflow/transition-requests/delete', query=query)
 
-    def delete_webhook(self, *, id: Optional[str] = None, **kwargs):
+    def delete_webhook(self, *, id: Optional[str] = None):
         """Delete a webhook.
         
         **NOTE:** This endpoint is in Public Preview.
@@ -3400,20 +3124,12 @@ class ModelRegistryAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = DeleteWebhookRequest(id=id)
 
         query = {}
-        if id: query['id'] = request.id
-
+        if id is not None: query['id'] = id
         self._api.do('DELETE', '/api/2.0/mlflow/registry-webhooks/delete', query=query)
 
-    def get_latest_versions(self,
-                            name: str,
-                            *,
-                            stages: Optional[List[str]] = None,
-                            **kwargs) -> Iterator[ModelVersion]:
+    def get_latest_versions(self, name: str, *, stages: Optional[List[str]] = None) -> Iterator[ModelVersion]:
         """Get the latest version.
         
         Gets the latest version of a registered model.
@@ -3425,15 +3141,14 @@ class ModelRegistryAPI:
         
         :returns: Iterator over :class:`ModelVersion`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = GetLatestVersionsRequest(name=name, stages=stages)
-        body = request.as_dict()
+        body = {}
+        if name is not None: body['name'] = name
+        if stages is not None: body['stages'] = [v for v in stages]
 
         json = self._api.do('POST', '/api/2.0/mlflow/registered-models/get-latest-versions', body=body)
         return [ModelVersion.from_dict(v) for v in json.get('model_versions', [])]
 
-    def get_model(self, name: str, **kwargs) -> GetModelResponse:
+    def get_model(self, name: str) -> GetModelResponse:
         """Get model.
         
         Get the details of a model. This is a Databricks workspace version of the [MLflow endpoint] that also
@@ -3447,17 +3162,14 @@ class ModelRegistryAPI:
         
         :returns: :class:`GetModelResponse`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = GetModelRequest(name=name)
 
         query = {}
-        if name: query['name'] = request.name
+        if name is not None: query['name'] = name
 
         json = self._api.do('GET', '/api/2.0/mlflow/databricks/registered-models/get', query=query)
         return GetModelResponse.from_dict(json)
 
-    def get_model_version(self, name: str, version: str, **kwargs) -> GetModelVersionResponse:
+    def get_model_version(self, name: str, version: str) -> GetModelVersionResponse:
         """Get a model version.
         
         Get a model version.
@@ -3469,19 +3181,15 @@ class ModelRegistryAPI:
         
         :returns: :class:`GetModelVersionResponse`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = GetModelVersionRequest(name=name, version=version)
 
         query = {}
-        if name: query['name'] = request.name
-        if version: query['version'] = request.version
+        if name is not None: query['name'] = name
+        if version is not None: query['version'] = version
 
         json = self._api.do('GET', '/api/2.0/mlflow/model-versions/get', query=query)
         return GetModelVersionResponse.from_dict(json)
 
-    def get_model_version_download_uri(self, name: str, version: str,
-                                       **kwargs) -> GetModelVersionDownloadUriResponse:
+    def get_model_version_download_uri(self, name: str, version: str) -> GetModelVersionDownloadUriResponse:
         """Get a model version URI.
         
         Gets a URI to download the model version.
@@ -3493,13 +3201,10 @@ class ModelRegistryAPI:
         
         :returns: :class:`GetModelVersionDownloadUriResponse`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = GetModelVersionDownloadUriRequest(name=name, version=version)
 
         query = {}
-        if name: query['name'] = request.name
-        if version: query['version'] = request.version
+        if name is not None: query['name'] = name
+        if version is not None: query['version'] = version
 
         json = self._api.do('GET', '/api/2.0/mlflow/model-versions/get-download-uri', query=query)
         return GetModelVersionDownloadUriResponse.from_dict(json)
@@ -3507,8 +3212,7 @@ class ModelRegistryAPI:
     def list_models(self,
                     *,
                     max_results: Optional[int] = None,
-                    page_token: Optional[str] = None,
-                    **kwargs) -> Iterator[Model]:
+                    page_token: Optional[str] = None) -> Iterator[Model]:
         """List models.
         
         Lists all available registered models, up to the limit specified in __max_results__.
@@ -3520,13 +3224,10 @@ class ModelRegistryAPI:
         
         :returns: Iterator over :class:`Model`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = ListModelsRequest(max_results=max_results, page_token=page_token)
 
         query = {}
-        if max_results: query['max_results'] = request.max_results
-        if page_token: query['page_token'] = request.page_token
+        if max_results is not None: query['max_results'] = max_results
+        if page_token is not None: query['page_token'] = page_token
 
         while True:
             json = self._api.do('GET', '/api/2.0/mlflow/registered-models/list', query=query)
@@ -3538,7 +3239,7 @@ class ModelRegistryAPI:
                 return
             query['page_token'] = json['next_page_token']
 
-    def list_transition_requests(self, name: str, version: str, **kwargs) -> Iterator[Activity]:
+    def list_transition_requests(self, name: str, version: str) -> Iterator[Activity]:
         """List transition requests.
         
         Gets a list of all open stage transition requests for the model version.
@@ -3550,13 +3251,10 @@ class ModelRegistryAPI:
         
         :returns: Iterator over :class:`Activity`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = ListTransitionRequestsRequest(name=name, version=version)
 
         query = {}
-        if name: query['name'] = request.name
-        if version: query['version'] = request.version
+        if name is not None: query['name'] = name
+        if version is not None: query['version'] = version
 
         json = self._api.do('GET', '/api/2.0/mlflow/transition-requests/list', query=query)
         return [Activity.from_dict(v) for v in json.get('requests', [])]
@@ -3565,8 +3263,7 @@ class ModelRegistryAPI:
                       *,
                       events: Optional[List[RegistryWebhookEvent]] = None,
                       model_name: Optional[str] = None,
-                      page_token: Optional[str] = None,
-                      **kwargs) -> Iterator[RegistryWebhook]:
+                      page_token: Optional[str] = None) -> Iterator[RegistryWebhook]:
         """List registry webhooks.
         
         **NOTE:** This endpoint is in Public Preview.
@@ -3584,14 +3281,11 @@ class ModelRegistryAPI:
         
         :returns: Iterator over :class:`RegistryWebhook`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = ListWebhooksRequest(events=events, model_name=model_name, page_token=page_token)
 
         query = {}
-        if events: query['events'] = [v for v in request.events]
-        if model_name: query['model_name'] = request.model_name
-        if page_token: query['page_token'] = request.page_token
+        if events is not None: query['events'] = [v for v in events]
+        if model_name is not None: query['model_name'] = model_name
+        if page_token is not None: query['page_token'] = page_token
 
         while True:
             json = self._api.do('GET', '/api/2.0/mlflow/registry-webhooks/list', query=query)
@@ -3608,8 +3302,7 @@ class ModelRegistryAPI:
                                   version: str,
                                   stage: Stage,
                                   *,
-                                  comment: Optional[str] = None,
-                                  **kwargs) -> RejectTransitionRequestResponse:
+                                  comment: Optional[str] = None) -> RejectTransitionRequestResponse:
         """Reject a transition request.
         
         Rejects a model version stage transition request.
@@ -3633,15 +3326,16 @@ class ModelRegistryAPI:
         
         :returns: :class:`RejectTransitionRequestResponse`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = RejectTransitionRequest(comment=comment, name=name, stage=stage, version=version)
-        body = request.as_dict()
+        body = {}
+        if comment is not None: body['comment'] = comment
+        if name is not None: body['name'] = name
+        if stage is not None: body['stage'] = stage.value
+        if version is not None: body['version'] = version
 
         json = self._api.do('POST', '/api/2.0/mlflow/transition-requests/reject', body=body)
         return RejectTransitionRequestResponse.from_dict(json)
 
-    def rename_model(self, name: str, *, new_name: Optional[str] = None, **kwargs) -> RenameModelResponse:
+    def rename_model(self, name: str, *, new_name: Optional[str] = None) -> RenameModelResponse:
         """Rename a model.
         
         Renames a registered model.
@@ -3653,10 +3347,9 @@ class ModelRegistryAPI:
         
         :returns: :class:`RenameModelResponse`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = RenameModelRequest(name=name, new_name=new_name)
-        body = request.as_dict()
+        body = {}
+        if name is not None: body['name'] = name
+        if new_name is not None: body['new_name'] = new_name
 
         json = self._api.do('POST', '/api/2.0/mlflow/registered-models/rename', body=body)
         return RenameModelResponse.from_dict(json)
@@ -3666,8 +3359,7 @@ class ModelRegistryAPI:
                               filter: Optional[str] = None,
                               max_results: Optional[int] = None,
                               order_by: Optional[List[str]] = None,
-                              page_token: Optional[str] = None,
-                              **kwargs) -> Iterator[ModelVersion]:
+                              page_token: Optional[str] = None) -> Iterator[ModelVersion]:
         """Searches model versions.
         
         Searches for specific model versions based on the supplied __filter__.
@@ -3686,18 +3378,12 @@ class ModelRegistryAPI:
         
         :returns: Iterator over :class:`ModelVersion`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = SearchModelVersionsRequest(filter=filter,
-                                                 max_results=max_results,
-                                                 order_by=order_by,
-                                                 page_token=page_token)
 
         query = {}
-        if filter: query['filter'] = request.filter
-        if max_results: query['max_results'] = request.max_results
-        if order_by: query['order_by'] = [v for v in request.order_by]
-        if page_token: query['page_token'] = request.page_token
+        if filter is not None: query['filter'] = filter
+        if max_results is not None: query['max_results'] = max_results
+        if order_by is not None: query['order_by'] = [v for v in order_by]
+        if page_token is not None: query['page_token'] = page_token
 
         while True:
             json = self._api.do('GET', '/api/2.0/mlflow/model-versions/search', query=query)
@@ -3714,8 +3400,7 @@ class ModelRegistryAPI:
                       filter: Optional[str] = None,
                       max_results: Optional[int] = None,
                       order_by: Optional[List[str]] = None,
-                      page_token: Optional[str] = None,
-                      **kwargs) -> Iterator[Model]:
+                      page_token: Optional[str] = None) -> Iterator[Model]:
         """Search models.
         
         Search for registered models based on the specified __filter__.
@@ -3735,18 +3420,12 @@ class ModelRegistryAPI:
         
         :returns: Iterator over :class:`Model`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = SearchModelsRequest(filter=filter,
-                                          max_results=max_results,
-                                          order_by=order_by,
-                                          page_token=page_token)
 
         query = {}
-        if filter: query['filter'] = request.filter
-        if max_results: query['max_results'] = request.max_results
-        if order_by: query['order_by'] = [v for v in request.order_by]
-        if page_token: query['page_token'] = request.page_token
+        if filter is not None: query['filter'] = filter
+        if max_results is not None: query['max_results'] = max_results
+        if order_by is not None: query['order_by'] = [v for v in order_by]
+        if page_token is not None: query['page_token'] = page_token
 
         while True:
             json = self._api.do('GET', '/api/2.0/mlflow/registered-models/search', query=query)
@@ -3758,7 +3437,7 @@ class ModelRegistryAPI:
                 return
             query['page_token'] = json['next_page_token']
 
-    def set_model_tag(self, name: str, key: str, value: str, **kwargs):
+    def set_model_tag(self, name: str, key: str, value: str):
         """Set a tag.
         
         Sets a tag on a registered model.
@@ -3775,13 +3454,13 @@ class ModelRegistryAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = SetModelTagRequest(key=key, name=name, value=value)
-        body = request.as_dict()
+        body = {}
+        if key is not None: body['key'] = key
+        if name is not None: body['name'] = name
+        if value is not None: body['value'] = value
         self._api.do('POST', '/api/2.0/mlflow/registered-models/set-tag', body=body)
 
-    def set_model_version_tag(self, name: str, version: str, key: str, value: str, **kwargs):
+    def set_model_version_tag(self, name: str, version: str, key: str, value: str):
         """Set a version tag.
         
         Sets a model version tag.
@@ -3800,17 +3479,17 @@ class ModelRegistryAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = SetModelVersionTagRequest(key=key, name=name, value=value, version=version)
-        body = request.as_dict()
+        body = {}
+        if key is not None: body['key'] = key
+        if name is not None: body['name'] = name
+        if value is not None: body['value'] = value
+        if version is not None: body['version'] = version
         self._api.do('POST', '/api/2.0/mlflow/model-versions/set-tag', body=body)
 
     def test_registry_webhook(self,
                               id: str,
                               *,
-                              event: Optional[RegistryWebhookEvent] = None,
-                              **kwargs) -> TestRegistryWebhookResponse:
+                              event: Optional[RegistryWebhookEvent] = None) -> TestRegistryWebhookResponse:
         """Test a webhook.
         
         **NOTE:** This endpoint is in Public Preview.
@@ -3825,10 +3504,9 @@ class ModelRegistryAPI:
         
         :returns: :class:`TestRegistryWebhookResponse`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = TestRegistryWebhookRequest(event=event, id=id)
-        body = request.as_dict()
+        body = {}
+        if event is not None: body['event'] = event.value
+        if id is not None: body['id'] = id
 
         json = self._api.do('POST', '/api/2.0/mlflow/registry-webhooks/test', body=body)
         return TestRegistryWebhookResponse.from_dict(json)
@@ -3839,8 +3517,7 @@ class ModelRegistryAPI:
                          stage: Stage,
                          archive_existing_versions: bool,
                          *,
-                         comment: Optional[str] = None,
-                         **kwargs) -> TransitionStageResponse:
+                         comment: Optional[str] = None) -> TransitionStageResponse:
         """Transition a stage.
         
         Transition a model version's stage. This is a Databricks workspace version of the [MLflow endpoint]
@@ -3869,20 +3546,18 @@ class ModelRegistryAPI:
         
         :returns: :class:`TransitionStageResponse`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = TransitionModelVersionStageDatabricks(
-                archive_existing_versions=archive_existing_versions,
-                comment=comment,
-                name=name,
-                stage=stage,
-                version=version)
-        body = request.as_dict()
+        body = {}
+        if archive_existing_versions is not None:
+            body['archive_existing_versions'] = archive_existing_versions
+        if comment is not None: body['comment'] = comment
+        if name is not None: body['name'] = name
+        if stage is not None: body['stage'] = stage.value
+        if version is not None: body['version'] = version
 
         json = self._api.do('POST', '/api/2.0/mlflow/databricks/model-versions/transition-stage', body=body)
         return TransitionStageResponse.from_dict(json)
 
-    def update_comment(self, id: str, comment: str, **kwargs) -> UpdateCommentResponse:
+    def update_comment(self, id: str, comment: str) -> UpdateCommentResponse:
         """Update a comment.
         
         Post an edit to a comment on a model version.
@@ -3894,15 +3569,14 @@ class ModelRegistryAPI:
         
         :returns: :class:`UpdateCommentResponse`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = UpdateComment(comment=comment, id=id)
-        body = request.as_dict()
+        body = {}
+        if comment is not None: body['comment'] = comment
+        if id is not None: body['id'] = id
 
         json = self._api.do('PATCH', '/api/2.0/mlflow/comments/update', body=body)
         return UpdateCommentResponse.from_dict(json)
 
-    def update_model(self, name: str, *, description: Optional[str] = None, **kwargs):
+    def update_model(self, name: str, *, description: Optional[str] = None):
         """Update model.
         
         Updates a registered model.
@@ -3914,13 +3588,12 @@ class ModelRegistryAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = UpdateModelRequest(description=description, name=name)
-        body = request.as_dict()
+        body = {}
+        if description is not None: body['description'] = description
+        if name is not None: body['name'] = name
         self._api.do('PATCH', '/api/2.0/mlflow/registered-models/update', body=body)
 
-    def update_model_version(self, name: str, version: str, *, description: Optional[str] = None, **kwargs):
+    def update_model_version(self, name: str, version: str, *, description: Optional[str] = None):
         """Update model version.
         
         Updates the model version.
@@ -3934,10 +3607,10 @@ class ModelRegistryAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = UpdateModelVersionRequest(description=description, name=name, version=version)
-        body = request.as_dict()
+        body = {}
+        if description is not None: body['description'] = description
+        if name is not None: body['name'] = name
+        if version is not None: body['version'] = version
         self._api.do('PATCH', '/api/2.0/mlflow/model-versions/update', body=body)
 
     def update_webhook(self,
@@ -3947,8 +3620,7 @@ class ModelRegistryAPI:
                        events: Optional[List[RegistryWebhookEvent]] = None,
                        http_url_spec: Optional[HttpUrlSpec] = None,
                        job_spec: Optional[JobSpec] = None,
-                       status: Optional[RegistryWebhookStatus] = None,
-                       **kwargs):
+                       status: Optional[RegistryWebhookStatus] = None):
         """Update a webhook.
         
         **NOTE:** This endpoint is in Public Preview.
@@ -3995,13 +3667,11 @@ class ModelRegistryAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = UpdateRegistryWebhook(description=description,
-                                            events=events,
-                                            http_url_spec=http_url_spec,
-                                            id=id,
-                                            job_spec=job_spec,
-                                            status=status)
-        body = request.as_dict()
+        body = {}
+        if description is not None: body['description'] = description
+        if events is not None: body['events'] = [v for v in events]
+        if http_url_spec is not None: body['http_url_spec'] = http_url_spec.as_dict()
+        if id is not None: body['id'] = id
+        if job_spec is not None: body['job_spec'] = job_spec.as_dict()
+        if status is not None: body['status'] = status.value
         self._api.do('PATCH', '/api/2.0/mlflow/registry-webhooks/update', body=body)

--- a/databricks/sdk/service/oauth2.py
+++ b/databricks/sdk/service/oauth2.py
@@ -101,13 +101,6 @@ class CreatePublishedAppIntegrationOutput:
 
 
 @dataclass
-class CreateServicePrincipalSecretRequest:
-    """Create service principal secret"""
-
-    service_principal_id: int
-
-
-@dataclass
 class CreateServicePrincipalSecretResponse:
     create_time: Optional[str] = None
     id: Optional[str] = None
@@ -137,28 +130,6 @@ class CreateServicePrincipalSecretResponse:
 
 
 @dataclass
-class DeleteCustomAppIntegrationRequest:
-    """Delete Custom OAuth App Integration"""
-
-    integration_id: str
-
-
-@dataclass
-class DeletePublishedAppIntegrationRequest:
-    """Delete Published OAuth App Integration"""
-
-    integration_id: str
-
-
-@dataclass
-class DeleteServicePrincipalSecretRequest:
-    """Delete service principal secret"""
-
-    service_principal_id: int
-    secret_id: str
-
-
-@dataclass
 class GetCustomAppIntegrationOutput:
     client_id: Optional[str] = None
     confidential: Optional[bool] = None
@@ -185,13 +156,6 @@ class GetCustomAppIntegrationOutput:
                    name=d.get('name', None),
                    redirect_urls=d.get('redirect_urls', None),
                    token_access_policy=_from_dict(d, 'token_access_policy', TokenAccessPolicy))
-
-
-@dataclass
-class GetCustomAppIntegrationRequest:
-    """Get OAuth Custom App Integration"""
-
-    integration_id: str
 
 
 @dataclass
@@ -232,13 +196,6 @@ class GetPublishedAppIntegrationOutput:
 
 
 @dataclass
-class GetPublishedAppIntegrationRequest:
-    """Get OAuth Published App Integration"""
-
-    integration_id: str
-
-
-@dataclass
 class GetPublishedAppIntegrationsOutput:
     apps: Optional['List[GetPublishedAppIntegrationOutput]'] = None
 
@@ -250,13 +207,6 @@ class GetPublishedAppIntegrationsOutput:
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'GetPublishedAppIntegrationsOutput':
         return cls(apps=_repeated(d, 'apps', GetPublishedAppIntegrationOutput))
-
-
-@dataclass
-class ListServicePrincipalSecretsRequest:
-    """List service principal secrets"""
-
-    service_principal_id: int
 
 
 @dataclass
@@ -384,8 +334,7 @@ class CustomAppIntegrationAPI:
                redirect_urls: List[str],
                *,
                confidential: Optional[bool] = None,
-               token_access_policy: Optional[TokenAccessPolicy] = None,
-               **kwargs) -> CreateCustomAppIntegrationOutput:
+               token_access_policy: Optional[TokenAccessPolicy] = None) -> CreateCustomAppIntegrationOutput:
         """Create Custom OAuth App Integration.
         
         Create Custom OAuth App Integration.
@@ -403,20 +352,18 @@ class CustomAppIntegrationAPI:
         
         :returns: :class:`CreateCustomAppIntegrationOutput`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = CreateCustomAppIntegration(confidential=confidential,
-                                                 name=name,
-                                                 redirect_urls=redirect_urls,
-                                                 token_access_policy=token_access_policy)
-        body = request.as_dict()
+        body = {}
+        if confidential is not None: body['confidential'] = confidential
+        if name is not None: body['name'] = name
+        if redirect_urls is not None: body['redirect_urls'] = [v for v in redirect_urls]
+        if token_access_policy is not None: body['token_access_policy'] = token_access_policy.as_dict()
 
         json = self._api.do('POST',
                             f'/api/2.0/accounts/{self._api.account_id}/oauth2/custom-app-integrations',
                             body=body)
         return CreateCustomAppIntegrationOutput.from_dict(json)
 
-    def delete(self, integration_id: str, **kwargs):
+    def delete(self, integration_id: str):
         """Delete Custom OAuth App Integration.
         
         Delete an existing Custom OAuth App Integration. You can retrieve the custom oauth app integration via
@@ -427,16 +374,12 @@ class CustomAppIntegrationAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = DeleteCustomAppIntegrationRequest(integration_id=integration_id)
 
         self._api.do(
             'DELETE',
-            f'/api/2.0/accounts/{self._api.account_id}/oauth2/custom-app-integrations/{request.integration_id}'
-        )
+            f'/api/2.0/accounts/{self._api.account_id}/oauth2/custom-app-integrations/{integration_id}')
 
-    def get(self, integration_id: str, **kwargs) -> GetCustomAppIntegrationOutput:
+    def get(self, integration_id: str) -> GetCustomAppIntegrationOutput:
         """Get OAuth Custom App Integration.
         
         Gets the Custom OAuth App Integration for the given integration id.
@@ -446,14 +389,10 @@ class CustomAppIntegrationAPI:
         
         :returns: :class:`GetCustomAppIntegrationOutput`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = GetCustomAppIntegrationRequest(integration_id=integration_id)
 
         json = self._api.do(
             'GET',
-            f'/api/2.0/accounts/{self._api.account_id}/oauth2/custom-app-integrations/{request.integration_id}'
-        )
+            f'/api/2.0/accounts/{self._api.account_id}/oauth2/custom-app-integrations/{integration_id}')
         return GetCustomAppIntegrationOutput.from_dict(json)
 
     def list(self) -> Iterator[GetCustomAppIntegrationOutput]:
@@ -471,8 +410,7 @@ class CustomAppIntegrationAPI:
                integration_id: str,
                *,
                redirect_urls: Optional[List[str]] = None,
-               token_access_policy: Optional[TokenAccessPolicy] = None,
-               **kwargs):
+               token_access_policy: Optional[TokenAccessPolicy] = None):
         """Updates Custom OAuth App Integration.
         
         Updates an existing custom OAuth App Integration. You can retrieve the custom oauth app integration
@@ -487,15 +425,12 @@ class CustomAppIntegrationAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = UpdateCustomAppIntegration(integration_id=integration_id,
-                                                 redirect_urls=redirect_urls,
-                                                 token_access_policy=token_access_policy)
-        body = request.as_dict()
+        body = {}
+        if redirect_urls is not None: body['redirect_urls'] = [v for v in redirect_urls]
+        if token_access_policy is not None: body['token_access_policy'] = token_access_policy.as_dict()
         self._api.do(
             'PATCH',
-            f'/api/2.0/accounts/{self._api.account_id}/oauth2/custom-app-integrations/{request.integration_id}',
+            f'/api/2.0/accounts/{self._api.account_id}/oauth2/custom-app-integrations/{integration_id}',
             body=body)
 
 
@@ -509,7 +444,7 @@ class OAuthEnrollmentAPI:
     def __init__(self, api_client):
         self._api = api_client
 
-    def create(self, *, enable_all_published_apps: Optional[bool] = None, **kwargs):
+    def create(self, *, enable_all_published_apps: Optional[bool] = None):
         """Create OAuth Enrollment request.
         
         Create an OAuth Enrollment request to enroll OAuth for this account and optionally enable the OAuth
@@ -525,10 +460,9 @@ class OAuthEnrollmentAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = CreateOAuthEnrollment(enable_all_published_apps=enable_all_published_apps)
-        body = request.as_dict()
+        body = {}
+        if enable_all_published_apps is not None:
+            body['enable_all_published_apps'] = enable_all_published_apps
         self._api.do('POST', f'/api/2.0/accounts/{self._api.account_id}/oauth2/enrollment', body=body)
 
     def get(self) -> OAuthEnrollmentStatus:
@@ -556,11 +490,11 @@ class PublishedAppIntegrationAPI:
     def __init__(self, api_client):
         self._api = api_client
 
-    def create(self,
-               *,
-               app_id: Optional[str] = None,
-               token_access_policy: Optional[TokenAccessPolicy] = None,
-               **kwargs) -> CreatePublishedAppIntegrationOutput:
+    def create(
+            self,
+            *,
+            app_id: Optional[str] = None,
+            token_access_policy: Optional[TokenAccessPolicy] = None) -> CreatePublishedAppIntegrationOutput:
         """Create Published OAuth App Integration.
         
         Create Published OAuth App Integration.
@@ -574,17 +508,16 @@ class PublishedAppIntegrationAPI:
         
         :returns: :class:`CreatePublishedAppIntegrationOutput`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = CreatePublishedAppIntegration(app_id=app_id, token_access_policy=token_access_policy)
-        body = request.as_dict()
+        body = {}
+        if app_id is not None: body['app_id'] = app_id
+        if token_access_policy is not None: body['token_access_policy'] = token_access_policy.as_dict()
 
         json = self._api.do('POST',
                             f'/api/2.0/accounts/{self._api.account_id}/oauth2/published-app-integrations',
                             body=body)
         return CreatePublishedAppIntegrationOutput.from_dict(json)
 
-    def delete(self, integration_id: str, **kwargs):
+    def delete(self, integration_id: str):
         """Delete Published OAuth App Integration.
         
         Delete an existing Published OAuth App Integration. You can retrieve the published oauth app
@@ -595,16 +528,12 @@ class PublishedAppIntegrationAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = DeletePublishedAppIntegrationRequest(integration_id=integration_id)
 
         self._api.do(
             'DELETE',
-            f'/api/2.0/accounts/{self._api.account_id}/oauth2/published-app-integrations/{request.integration_id}'
-        )
+            f'/api/2.0/accounts/{self._api.account_id}/oauth2/published-app-integrations/{integration_id}')
 
-    def get(self, integration_id: str, **kwargs) -> GetPublishedAppIntegrationOutput:
+    def get(self, integration_id: str) -> GetPublishedAppIntegrationOutput:
         """Get OAuth Published App Integration.
         
         Gets the Published OAuth App Integration for the given integration id.
@@ -614,14 +543,10 @@ class PublishedAppIntegrationAPI:
         
         :returns: :class:`GetPublishedAppIntegrationOutput`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = GetPublishedAppIntegrationRequest(integration_id=integration_id)
 
         json = self._api.do(
             'GET',
-            f'/api/2.0/accounts/{self._api.account_id}/oauth2/published-app-integrations/{request.integration_id}'
-        )
+            f'/api/2.0/accounts/{self._api.account_id}/oauth2/published-app-integrations/{integration_id}')
         return GetPublishedAppIntegrationOutput.from_dict(json)
 
     def list(self) -> Iterator[GetPublishedAppIntegrationOutput]:
@@ -636,11 +561,7 @@ class PublishedAppIntegrationAPI:
                             f'/api/2.0/accounts/{self._api.account_id}/oauth2/published-app-integrations')
         return [GetPublishedAppIntegrationOutput.from_dict(v) for v in json.get('apps', [])]
 
-    def update(self,
-               integration_id: str,
-               *,
-               token_access_policy: Optional[TokenAccessPolicy] = None,
-               **kwargs):
+    def update(self, integration_id: str, *, token_access_policy: Optional[TokenAccessPolicy] = None):
         """Updates Published OAuth App Integration.
         
         Updates an existing published OAuth App Integration. You can retrieve the published oauth app
@@ -653,14 +574,11 @@ class PublishedAppIntegrationAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = UpdatePublishedAppIntegration(integration_id=integration_id,
-                                                    token_access_policy=token_access_policy)
-        body = request.as_dict()
+        body = {}
+        if token_access_policy is not None: body['token_access_policy'] = token_access_policy.as_dict()
         self._api.do(
             'PATCH',
-            f'/api/2.0/accounts/{self._api.account_id}/oauth2/published-app-integrations/{request.integration_id}',
+            f'/api/2.0/accounts/{self._api.account_id}/oauth2/published-app-integrations/{integration_id}',
             body=body)
 
 
@@ -680,7 +598,7 @@ class ServicePrincipalSecretsAPI:
     def __init__(self, api_client):
         self._api = api_client
 
-    def create(self, service_principal_id: int, **kwargs) -> CreateServicePrincipalSecretResponse:
+    def create(self, service_principal_id: int) -> CreateServicePrincipalSecretResponse:
         """Create service principal secret.
         
         Create a secret for the given service principal.
@@ -690,17 +608,14 @@ class ServicePrincipalSecretsAPI:
         
         :returns: :class:`CreateServicePrincipalSecretResponse`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = CreateServicePrincipalSecretRequest(service_principal_id=service_principal_id)
 
         json = self._api.do(
             'POST',
-            f'/api/2.0/accounts/{self._api.account_id}/servicePrincipals/{request.service_principal_id}/credentials/secrets'
+            f'/api/2.0/accounts/{self._api.account_id}/servicePrincipals/{service_principal_id}/credentials/secrets'
         )
         return CreateServicePrincipalSecretResponse.from_dict(json)
 
-    def delete(self, service_principal_id: int, secret_id: str, **kwargs):
+    def delete(self, service_principal_id: int, secret_id: str):
         """Delete service principal secret.
         
         Delete a secret from the given service principal.
@@ -712,17 +627,13 @@ class ServicePrincipalSecretsAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = DeleteServicePrincipalSecretRequest(secret_id=secret_id,
-                                                          service_principal_id=service_principal_id)
 
         self._api.do(
             'DELETE',
-            f'/api/2.0/accounts/{self._api.account_id}/servicePrincipals/{request.service_principal_id}/credentials/secrets/{request.secret_id},'
+            f'/api/2.0/accounts/{self._api.account_id}/servicePrincipals/{service_principal_id}/credentials/secrets/{secret_id},'
         )
 
-    def list(self, service_principal_id: int, **kwargs) -> Iterator[SecretInfo]:
+    def list(self, service_principal_id: int) -> Iterator[SecretInfo]:
         """List service principal secrets.
         
         List all secrets associated with the given service principal. This operation only returns information
@@ -733,12 +644,9 @@ class ServicePrincipalSecretsAPI:
         
         :returns: Iterator over :class:`SecretInfo`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = ListServicePrincipalSecretsRequest(service_principal_id=service_principal_id)
 
         json = self._api.do(
             'GET',
-            f'/api/2.0/accounts/{self._api.account_id}/servicePrincipals/{request.service_principal_id}/credentials/secrets'
+            f'/api/2.0/accounts/{self._api.account_id}/servicePrincipals/{service_principal_id}/credentials/secrets'
         )
         return [SecretInfo.from_dict(v) for v in json.get('secrets', [])]

--- a/databricks/sdk/service/pipelines.py
+++ b/databricks/sdk/service/pipelines.py
@@ -134,13 +134,6 @@ class DataPlaneId:
 
 
 @dataclass
-class DeletePipelineRequest:
-    """Delete a pipeline"""
-
-    pipeline_id: str
-
-
-@dataclass
 class EditPipeline:
     allow_duplicate_names: Optional[bool] = None
     catalog: Optional[str] = None
@@ -265,13 +258,6 @@ class Filters:
 
 
 @dataclass
-class GetPipelineRequest:
-    """Get a pipeline"""
-
-    pipeline_id: str
-
-
-@dataclass
 class GetPipelineResponse:
     cause: Optional[str] = None
     cluster_id: Optional[str] = None
@@ -323,14 +309,6 @@ class GetPipelineResponseHealth(Enum):
 
 
 @dataclass
-class GetUpdateRequest:
-    """Get a pipeline update"""
-
-    pipeline_id: str
-    update_id: str
-
-
-@dataclass
 class GetUpdateResponse:
     update: Optional['UpdateInfo'] = None
 
@@ -342,17 +320,6 @@ class GetUpdateResponse:
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'GetUpdateResponse':
         return cls(update=_from_dict(d, 'update', UpdateInfo))
-
-
-@dataclass
-class ListPipelineEventsRequest:
-    """List pipeline events"""
-
-    pipeline_id: str
-    filter: Optional[str] = None
-    max_results: Optional[int] = None
-    order_by: Optional['List[str]'] = None
-    page_token: Optional[str] = None
 
 
 @dataclass
@@ -376,16 +343,6 @@ class ListPipelineEventsResponse:
 
 
 @dataclass
-class ListPipelinesRequest:
-    """List pipelines"""
-
-    filter: Optional[str] = None
-    max_results: Optional[int] = None
-    order_by: Optional['List[str]'] = None
-    page_token: Optional[str] = None
-
-
-@dataclass
 class ListPipelinesResponse:
     next_page_token: Optional[str] = None
     statuses: Optional['List[PipelineStateInfo]'] = None
@@ -400,16 +357,6 @@ class ListPipelinesResponse:
     def from_dict(cls, d: Dict[str, any]) -> 'ListPipelinesResponse':
         return cls(next_page_token=d.get('next_page_token', None),
                    statuses=_repeated(d, 'statuses', PipelineStateInfo))
-
-
-@dataclass
-class ListUpdatesRequest:
-    """List pipeline updates"""
-
-    pipeline_id: str
-    max_results: Optional[int] = None
-    page_token: Optional[str] = None
-    until_update_id: Optional[str] = None
 
 
 @dataclass
@@ -763,13 +710,6 @@ class PipelineTrigger:
 
 
 @dataclass
-class ResetRequest:
-    """Reset a pipeline"""
-
-    pipeline_id: str
-
-
-@dataclass
 class Sequencing:
     control_plane_seq_no: Optional[int] = None
     data_plane_id: Optional['DataPlaneId'] = None
@@ -878,13 +818,6 @@ class StartUpdateResponse:
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'StartUpdateResponse':
         return cls(update_id=d.get('update_id', None))
-
-
-@dataclass
-class StopRequest:
-    """Stop a pipeline"""
-
-    pipeline_id: str
 
 
 @dataclass
@@ -1087,8 +1020,7 @@ class PipelinesAPI:
                serverless: Optional[bool] = None,
                storage: Optional[str] = None,
                target: Optional[str] = None,
-               trigger: Optional[PipelineTrigger] = None,
-               **kwargs) -> CreatePipelineResponse:
+               trigger: Optional[PipelineTrigger] = None) -> CreatePipelineResponse:
         """Create a pipeline.
         
         Creates a new data processing pipeline based on the requested configuration. If successful, this
@@ -1135,32 +1067,30 @@ class PipelinesAPI:
         
         :returns: :class:`CreatePipelineResponse`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = CreatePipeline(allow_duplicate_names=allow_duplicate_names,
-                                     catalog=catalog,
-                                     channel=channel,
-                                     clusters=clusters,
-                                     configuration=configuration,
-                                     continuous=continuous,
-                                     development=development,
-                                     dry_run=dry_run,
-                                     edition=edition,
-                                     filters=filters,
-                                     id=id,
-                                     libraries=libraries,
-                                     name=name,
-                                     photon=photon,
-                                     serverless=serverless,
-                                     storage=storage,
-                                     target=target,
-                                     trigger=trigger)
-        body = request.as_dict()
+        body = {}
+        if allow_duplicate_names is not None: body['allow_duplicate_names'] = allow_duplicate_names
+        if catalog is not None: body['catalog'] = catalog
+        if channel is not None: body['channel'] = channel
+        if clusters is not None: body['clusters'] = [v.as_dict() for v in clusters]
+        if configuration is not None: body['configuration'] = configuration
+        if continuous is not None: body['continuous'] = continuous
+        if development is not None: body['development'] = development
+        if dry_run is not None: body['dry_run'] = dry_run
+        if edition is not None: body['edition'] = edition
+        if filters is not None: body['filters'] = filters.as_dict()
+        if id is not None: body['id'] = id
+        if libraries is not None: body['libraries'] = [v.as_dict() for v in libraries]
+        if name is not None: body['name'] = name
+        if photon is not None: body['photon'] = photon
+        if serverless is not None: body['serverless'] = serverless
+        if storage is not None: body['storage'] = storage
+        if target is not None: body['target'] = target
+        if trigger is not None: body['trigger'] = trigger.as_dict()
 
         json = self._api.do('POST', '/api/2.0/pipelines', body=body)
         return CreatePipelineResponse.from_dict(json)
 
-    def delete(self, pipeline_id: str, **kwargs):
+    def delete(self, pipeline_id: str):
         """Delete a pipeline.
         
         Deletes a pipeline.
@@ -1169,27 +1099,21 @@ class PipelinesAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = DeletePipelineRequest(pipeline_id=pipeline_id)
 
-        self._api.do('DELETE', f'/api/2.0/pipelines/{request.pipeline_id}')
+        self._api.do('DELETE', f'/api/2.0/pipelines/{pipeline_id}')
 
-    def get(self, pipeline_id: str, **kwargs) -> GetPipelineResponse:
+    def get(self, pipeline_id: str) -> GetPipelineResponse:
         """Get a pipeline.
         
         :param pipeline_id: str
         
         :returns: :class:`GetPipelineResponse`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = GetPipelineRequest(pipeline_id=pipeline_id)
 
-        json = self._api.do('GET', f'/api/2.0/pipelines/{request.pipeline_id}')
+        json = self._api.do('GET', f'/api/2.0/pipelines/{pipeline_id}')
         return GetPipelineResponse.from_dict(json)
 
-    def get_update(self, pipeline_id: str, update_id: str, **kwargs) -> GetUpdateResponse:
+    def get_update(self, pipeline_id: str, update_id: str) -> GetUpdateResponse:
         """Get a pipeline update.
         
         Gets an update from an active pipeline.
@@ -1201,11 +1125,8 @@ class PipelinesAPI:
         
         :returns: :class:`GetUpdateResponse`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = GetUpdateRequest(pipeline_id=pipeline_id, update_id=update_id)
 
-        json = self._api.do('GET', f'/api/2.0/pipelines/{request.pipeline_id}/updates/{request.update_id}')
+        json = self._api.do('GET', f'/api/2.0/pipelines/{pipeline_id}/updates/{update_id}')
         return GetUpdateResponse.from_dict(json)
 
     def list_pipeline_events(self,
@@ -1214,8 +1135,7 @@ class PipelinesAPI:
                              filter: Optional[str] = None,
                              max_results: Optional[int] = None,
                              order_by: Optional[List[str]] = None,
-                             page_token: Optional[str] = None,
-                             **kwargs) -> Iterator[PipelineEvent]:
+                             page_token: Optional[str] = None) -> Iterator[PipelineEvent]:
         """List pipeline events.
         
         Retrieves events for a pipeline.
@@ -1242,22 +1162,15 @@ class PipelinesAPI:
         
         :returns: Iterator over :class:`PipelineEvent`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = ListPipelineEventsRequest(filter=filter,
-                                                max_results=max_results,
-                                                order_by=order_by,
-                                                page_token=page_token,
-                                                pipeline_id=pipeline_id)
 
         query = {}
-        if filter: query['filter'] = request.filter
-        if max_results: query['max_results'] = request.max_results
-        if order_by: query['order_by'] = [v for v in request.order_by]
-        if page_token: query['page_token'] = request.page_token
+        if filter is not None: query['filter'] = filter
+        if max_results is not None: query['max_results'] = max_results
+        if order_by is not None: query['order_by'] = [v for v in order_by]
+        if page_token is not None: query['page_token'] = page_token
 
         while True:
-            json = self._api.do('GET', f'/api/2.0/pipelines/{request.pipeline_id}/events', query=query)
+            json = self._api.do('GET', f'/api/2.0/pipelines/{pipeline_id}/events', query=query)
             if 'events' not in json or not json['events']:
                 return
             for v in json['events']:
@@ -1271,8 +1184,7 @@ class PipelinesAPI:
                        filter: Optional[str] = None,
                        max_results: Optional[int] = None,
                        order_by: Optional[List[str]] = None,
-                       page_token: Optional[str] = None,
-                       **kwargs) -> Iterator[PipelineStateInfo]:
+                       page_token: Optional[str] = None) -> Iterator[PipelineStateInfo]:
         """List pipelines.
         
         Lists pipelines defined in the Delta Live Tables system.
@@ -1298,18 +1210,12 @@ class PipelinesAPI:
         
         :returns: Iterator over :class:`PipelineStateInfo`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = ListPipelinesRequest(filter=filter,
-                                           max_results=max_results,
-                                           order_by=order_by,
-                                           page_token=page_token)
 
         query = {}
-        if filter: query['filter'] = request.filter
-        if max_results: query['max_results'] = request.max_results
-        if order_by: query['order_by'] = [v for v in request.order_by]
-        if page_token: query['page_token'] = request.page_token
+        if filter is not None: query['filter'] = filter
+        if max_results is not None: query['max_results'] = max_results
+        if order_by is not None: query['order_by'] = [v for v in order_by]
+        if page_token is not None: query['page_token'] = page_token
 
         while True:
             json = self._api.do('GET', '/api/2.0/pipelines', query=query)
@@ -1326,8 +1232,7 @@ class PipelinesAPI:
                      *,
                      max_results: Optional[int] = None,
                      page_token: Optional[str] = None,
-                     until_update_id: Optional[str] = None,
-                     **kwargs) -> ListUpdatesResponse:
+                     until_update_id: Optional[str] = None) -> ListUpdatesResponse:
         """List pipeline updates.
         
         List updates for an active pipeline.
@@ -1343,22 +1248,16 @@ class PipelinesAPI:
         
         :returns: :class:`ListUpdatesResponse`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = ListUpdatesRequest(max_results=max_results,
-                                         page_token=page_token,
-                                         pipeline_id=pipeline_id,
-                                         until_update_id=until_update_id)
 
         query = {}
-        if max_results: query['max_results'] = request.max_results
-        if page_token: query['page_token'] = request.page_token
-        if until_update_id: query['until_update_id'] = request.until_update_id
+        if max_results is not None: query['max_results'] = max_results
+        if page_token is not None: query['page_token'] = page_token
+        if until_update_id is not None: query['until_update_id'] = until_update_id
 
-        json = self._api.do('GET', f'/api/2.0/pipelines/{request.pipeline_id}/updates', query=query)
+        json = self._api.do('GET', f'/api/2.0/pipelines/{pipeline_id}/updates', query=query)
         return ListUpdatesResponse.from_dict(json)
 
-    def reset(self, pipeline_id: str, **kwargs) -> Wait[GetPipelineResponse]:
+    def reset(self, pipeline_id: str) -> Wait[GetPipelineResponse]:
         """Reset a pipeline.
         
         Resets a pipeline.
@@ -1369,12 +1268,9 @@ class PipelinesAPI:
           Long-running operation waiter for :class:`GetPipelineResponse`.
           See :method:wait_get_pipeline_running for more details.
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = ResetRequest(pipeline_id=pipeline_id)
 
-        self._api.do('POST', f'/api/2.0/pipelines/{request.pipeline_id}/reset')
-        return Wait(self.wait_get_pipeline_running, pipeline_id=request.pipeline_id)
+        self._api.do('POST', f'/api/2.0/pipelines/{pipeline_id}/reset')
+        return Wait(self.wait_get_pipeline_running, pipeline_id=pipeline_id)
 
     def reset_and_wait(self, pipeline_id: str, timeout=timedelta(minutes=20)) -> GetPipelineResponse:
         return self.reset(pipeline_id=pipeline_id).result(timeout=timeout)
@@ -1385,8 +1281,7 @@ class PipelinesAPI:
                      cause: Optional[StartUpdateCause] = None,
                      full_refresh: Optional[bool] = None,
                      full_refresh_selection: Optional[List[str]] = None,
-                     refresh_selection: Optional[List[str]] = None,
-                     **kwargs) -> StartUpdateResponse:
+                     refresh_selection: Optional[List[str]] = None) -> StartUpdateResponse:
         """Queue a pipeline update.
         
         Starts or queues a pipeline update.
@@ -1406,19 +1301,17 @@ class PipelinesAPI:
         
         :returns: :class:`StartUpdateResponse`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = StartUpdate(cause=cause,
-                                  full_refresh=full_refresh,
-                                  full_refresh_selection=full_refresh_selection,
-                                  pipeline_id=pipeline_id,
-                                  refresh_selection=refresh_selection)
-        body = request.as_dict()
+        body = {}
+        if cause is not None: body['cause'] = cause.value
+        if full_refresh is not None: body['full_refresh'] = full_refresh
+        if full_refresh_selection is not None:
+            body['full_refresh_selection'] = [v for v in full_refresh_selection]
+        if refresh_selection is not None: body['refresh_selection'] = [v for v in refresh_selection]
 
-        json = self._api.do('POST', f'/api/2.0/pipelines/{request.pipeline_id}/updates', body=body)
+        json = self._api.do('POST', f'/api/2.0/pipelines/{pipeline_id}/updates', body=body)
         return StartUpdateResponse.from_dict(json)
 
-    def stop(self, pipeline_id: str, **kwargs) -> Wait[GetPipelineResponse]:
+    def stop(self, pipeline_id: str) -> Wait[GetPipelineResponse]:
         """Stop a pipeline.
         
         Stops a pipeline.
@@ -1429,12 +1322,9 @@ class PipelinesAPI:
           Long-running operation waiter for :class:`GetPipelineResponse`.
           See :method:wait_get_pipeline_idle for more details.
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = StopRequest(pipeline_id=pipeline_id)
 
-        self._api.do('POST', f'/api/2.0/pipelines/{request.pipeline_id}/stop')
-        return Wait(self.wait_get_pipeline_idle, pipeline_id=request.pipeline_id)
+        self._api.do('POST', f'/api/2.0/pipelines/{pipeline_id}/stop')
+        return Wait(self.wait_get_pipeline_idle, pipeline_id=pipeline_id)
 
     def stop_and_wait(self, pipeline_id: str, timeout=timedelta(minutes=20)) -> GetPipelineResponse:
         return self.stop(pipeline_id=pipeline_id).result(timeout=timeout)
@@ -1459,8 +1349,7 @@ class PipelinesAPI:
                serverless: Optional[bool] = None,
                storage: Optional[str] = None,
                target: Optional[str] = None,
-               trigger: Optional[PipelineTrigger] = None,
-               **kwargs):
+               trigger: Optional[PipelineTrigger] = None):
         """Edit a pipeline.
         
         Updates a pipeline with the supplied configuration.
@@ -1510,26 +1399,23 @@ class PipelinesAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = EditPipeline(allow_duplicate_names=allow_duplicate_names,
-                                   catalog=catalog,
-                                   channel=channel,
-                                   clusters=clusters,
-                                   configuration=configuration,
-                                   continuous=continuous,
-                                   development=development,
-                                   edition=edition,
-                                   expected_last_modified=expected_last_modified,
-                                   filters=filters,
-                                   id=id,
-                                   libraries=libraries,
-                                   name=name,
-                                   photon=photon,
-                                   pipeline_id=pipeline_id,
-                                   serverless=serverless,
-                                   storage=storage,
-                                   target=target,
-                                   trigger=trigger)
-        body = request.as_dict()
-        self._api.do('PUT', f'/api/2.0/pipelines/{request.pipeline_id}', body=body)
+        body = {}
+        if allow_duplicate_names is not None: body['allow_duplicate_names'] = allow_duplicate_names
+        if catalog is not None: body['catalog'] = catalog
+        if channel is not None: body['channel'] = channel
+        if clusters is not None: body['clusters'] = [v.as_dict() for v in clusters]
+        if configuration is not None: body['configuration'] = configuration
+        if continuous is not None: body['continuous'] = continuous
+        if development is not None: body['development'] = development
+        if edition is not None: body['edition'] = edition
+        if expected_last_modified is not None: body['expected_last_modified'] = expected_last_modified
+        if filters is not None: body['filters'] = filters.as_dict()
+        if id is not None: body['id'] = id
+        if libraries is not None: body['libraries'] = [v.as_dict() for v in libraries]
+        if name is not None: body['name'] = name
+        if photon is not None: body['photon'] = photon
+        if serverless is not None: body['serverless'] = serverless
+        if storage is not None: body['storage'] = storage
+        if target is not None: body['target'] = target
+        if trigger is not None: body['trigger'] = trigger.as_dict()
+        self._api.do('PUT', f'/api/2.0/pipelines/{pipeline_id}', body=body)

--- a/databricks/sdk/service/provisioning.py
+++ b/databricks/sdk/service/provisioning.py
@@ -368,55 +368,6 @@ class CustomerManagedKey:
                    use_cases=d.get('use_cases', None))
 
 
-@dataclass
-class DeleteCredentialRequest:
-    """Delete credential configuration"""
-
-    credentials_id: str
-
-
-@dataclass
-class DeleteEncryptionKeyRequest:
-    """Delete encryption key configuration"""
-
-    customer_managed_key_id: str
-
-
-@dataclass
-class DeleteNetworkRequest:
-    """Delete a network configuration"""
-
-    network_id: str
-
-
-@dataclass
-class DeletePrivateAccesRequest:
-    """Delete a private access settings object"""
-
-    private_access_settings_id: str
-
-
-@dataclass
-class DeleteStorageRequest:
-    """Delete storage configuration"""
-
-    storage_configuration_id: str
-
-
-@dataclass
-class DeleteVpcEndpointRequest:
-    """Delete VPC endpoint configuration"""
-
-    vpc_endpoint_id: str
-
-
-@dataclass
-class DeleteWorkspaceRequest:
-    """Delete a workspace"""
-
-    workspace_id: int
-
-
 class EndpointUseCase(Enum):
     """This enumeration represents the type of Databricks VPC [endpoint service] that was used when
     creating this VPC endpoint.
@@ -551,55 +502,6 @@ class GcpVpcEndpointInfo:
                    psc_connection_id=d.get('psc_connection_id', None),
                    psc_endpoint_name=d.get('psc_endpoint_name', None),
                    service_attachment_id=d.get('service_attachment_id', None))
-
-
-@dataclass
-class GetCredentialRequest:
-    """Get credential configuration"""
-
-    credentials_id: str
-
-
-@dataclass
-class GetEncryptionKeyRequest:
-    """Get encryption key configuration"""
-
-    customer_managed_key_id: str
-
-
-@dataclass
-class GetNetworkRequest:
-    """Get a network configuration"""
-
-    network_id: str
-
-
-@dataclass
-class GetPrivateAccesRequest:
-    """Get a private access settings object"""
-
-    private_access_settings_id: str
-
-
-@dataclass
-class GetStorageRequest:
-    """Get storage configuration"""
-
-    storage_configuration_id: str
-
-
-@dataclass
-class GetVpcEndpointRequest:
-    """Get a VPC endpoint configuration"""
-
-    vpc_endpoint_id: str
-
-
-@dataclass
-class GetWorkspaceRequest:
-    """Get a workspace"""
-
-    workspace_id: int
 
 
 @dataclass
@@ -1093,8 +995,7 @@ class CredentialsAPI:
     def __init__(self, api_client):
         self._api = api_client
 
-    def create(self, credentials_name: str, aws_credentials: CreateCredentialAwsCredentials,
-               **kwargs) -> Credential:
+    def create(self, credentials_name: str, aws_credentials: CreateCredentialAwsCredentials) -> Credential:
         """Create credential configuration.
         
         Creates a Databricks credential configuration that represents cloud cross-account credentials for a
@@ -1116,16 +1017,14 @@ class CredentialsAPI:
         
         :returns: :class:`Credential`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = CreateCredentialRequest(aws_credentials=aws_credentials,
-                                              credentials_name=credentials_name)
-        body = request.as_dict()
+        body = {}
+        if aws_credentials is not None: body['aws_credentials'] = aws_credentials.as_dict()
+        if credentials_name is not None: body['credentials_name'] = credentials_name
 
         json = self._api.do('POST', f'/api/2.0/accounts/{self._api.account_id}/credentials', body=body)
         return Credential.from_dict(json)
 
-    def delete(self, credentials_id: str, **kwargs):
+    def delete(self, credentials_id: str):
         """Delete credential configuration.
         
         Deletes a Databricks credential configuration object for an account, both specified by ID. You cannot
@@ -1136,14 +1035,10 @@ class CredentialsAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = DeleteCredentialRequest(credentials_id=credentials_id)
 
-        self._api.do('DELETE',
-                     f'/api/2.0/accounts/{self._api.account_id}/credentials/{request.credentials_id}')
+        self._api.do('DELETE', f'/api/2.0/accounts/{self._api.account_id}/credentials/{credentials_id}')
 
-    def get(self, credentials_id: str, **kwargs) -> Credential:
+    def get(self, credentials_id: str) -> Credential:
         """Get credential configuration.
         
         Gets a Databricks credential configuration object for an account, both specified by ID.
@@ -1153,12 +1048,8 @@ class CredentialsAPI:
         
         :returns: :class:`Credential`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = GetCredentialRequest(credentials_id=credentials_id)
 
-        json = self._api.do('GET',
-                            f'/api/2.0/accounts/{self._api.account_id}/credentials/{request.credentials_id}')
+        json = self._api.do('GET', f'/api/2.0/accounts/{self._api.account_id}/credentials/{credentials_id}')
         return Credential.from_dict(json)
 
     def list(self) -> Iterator[Credential]:
@@ -1195,8 +1086,7 @@ class EncryptionKeysAPI:
                use_cases: List[KeyUseCase],
                *,
                aws_key_info: Optional[CreateAwsKeyInfo] = None,
-               gcp_key_info: Optional[CreateGcpKeyInfo] = None,
-               **kwargs) -> CustomerManagedKey:
+               gcp_key_info: Optional[CreateGcpKeyInfo] = None) -> CustomerManagedKey:
         """Create encryption key configuration.
         
         Creates a customer-managed key configuration object for an account, specified by ID. This operation
@@ -1220,19 +1110,17 @@ class EncryptionKeysAPI:
         
         :returns: :class:`CustomerManagedKey`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = CreateCustomerManagedKeyRequest(aws_key_info=aws_key_info,
-                                                      gcp_key_info=gcp_key_info,
-                                                      use_cases=use_cases)
-        body = request.as_dict()
+        body = {}
+        if aws_key_info is not None: body['aws_key_info'] = aws_key_info.as_dict()
+        if gcp_key_info is not None: body['gcp_key_info'] = gcp_key_info.as_dict()
+        if use_cases is not None: body['use_cases'] = [v for v in use_cases]
 
         json = self._api.do('POST',
                             f'/api/2.0/accounts/{self._api.account_id}/customer-managed-keys',
                             body=body)
         return CustomerManagedKey.from_dict(json)
 
-    def delete(self, customer_managed_key_id: str, **kwargs):
+    def delete(self, customer_managed_key_id: str):
         """Delete encryption key configuration.
         
         Deletes a customer-managed key configuration object for an account. You cannot delete a configuration
@@ -1243,16 +1131,12 @@ class EncryptionKeysAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = DeleteEncryptionKeyRequest(customer_managed_key_id=customer_managed_key_id)
 
         self._api.do(
             'DELETE',
-            f'/api/2.0/accounts/{self._api.account_id}/customer-managed-keys/{request.customer_managed_key_id}'
-        )
+            f'/api/2.0/accounts/{self._api.account_id}/customer-managed-keys/{customer_managed_key_id}')
 
-    def get(self, customer_managed_key_id: str, **kwargs) -> CustomerManagedKey:
+    def get(self, customer_managed_key_id: str) -> CustomerManagedKey:
         """Get encryption key configuration.
         
         Gets a customer-managed key configuration object for an account, specified by ID. This operation
@@ -1273,14 +1157,10 @@ class EncryptionKeysAPI:
         
         :returns: :class:`CustomerManagedKey`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = GetEncryptionKeyRequest(customer_managed_key_id=customer_managed_key_id)
 
         json = self._api.do(
             'GET',
-            f'/api/2.0/accounts/{self._api.account_id}/customer-managed-keys/{request.customer_managed_key_id}'
-        )
+            f'/api/2.0/accounts/{self._api.account_id}/customer-managed-keys/{customer_managed_key_id}')
         return CustomerManagedKey.from_dict(json)
 
     def list(self) -> Iterator[CustomerManagedKey]:
@@ -1318,8 +1198,7 @@ class NetworksAPI:
                security_group_ids: Optional[List[str]] = None,
                subnet_ids: Optional[List[str]] = None,
                vpc_endpoints: Optional[NetworkVpcEndpoints] = None,
-               vpc_id: Optional[str] = None,
-               **kwargs) -> Network:
+               vpc_id: Optional[str] = None) -> Network:
         """Create network configuration.
         
         Creates a Databricks network configuration that represents an VPC and its resources. The VPC will be
@@ -1347,20 +1226,18 @@ class NetworksAPI:
         
         :returns: :class:`Network`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = CreateNetworkRequest(gcp_network_info=gcp_network_info,
-                                           network_name=network_name,
-                                           security_group_ids=security_group_ids,
-                                           subnet_ids=subnet_ids,
-                                           vpc_endpoints=vpc_endpoints,
-                                           vpc_id=vpc_id)
-        body = request.as_dict()
+        body = {}
+        if gcp_network_info is not None: body['gcp_network_info'] = gcp_network_info.as_dict()
+        if network_name is not None: body['network_name'] = network_name
+        if security_group_ids is not None: body['security_group_ids'] = [v for v in security_group_ids]
+        if subnet_ids is not None: body['subnet_ids'] = [v for v in subnet_ids]
+        if vpc_endpoints is not None: body['vpc_endpoints'] = vpc_endpoints.as_dict()
+        if vpc_id is not None: body['vpc_id'] = vpc_id
 
         json = self._api.do('POST', f'/api/2.0/accounts/{self._api.account_id}/networks', body=body)
         return Network.from_dict(json)
 
-    def delete(self, network_id: str, **kwargs):
+    def delete(self, network_id: str):
         """Delete a network configuration.
         
         Deletes a Databricks network configuration, which represents a cloud VPC and its resources. You cannot
@@ -1373,13 +1250,10 @@ class NetworksAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = DeleteNetworkRequest(network_id=network_id)
 
-        self._api.do('DELETE', f'/api/2.0/accounts/{self._api.account_id}/networks/{request.network_id}')
+        self._api.do('DELETE', f'/api/2.0/accounts/{self._api.account_id}/networks/{network_id}')
 
-    def get(self, network_id: str, **kwargs) -> Network:
+    def get(self, network_id: str) -> Network:
         """Get a network configuration.
         
         Gets a Databricks network configuration, which represents a cloud VPC and its resources.
@@ -1389,11 +1263,8 @@ class NetworksAPI:
         
         :returns: :class:`Network`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = GetNetworkRequest(network_id=network_id)
 
-        json = self._api.do('GET', f'/api/2.0/accounts/{self._api.account_id}/networks/{request.network_id}')
+        json = self._api.do('GET', f'/api/2.0/accounts/{self._api.account_id}/networks/{network_id}')
         return Network.from_dict(json)
 
     def list(self) -> Iterator[Network]:
@@ -1422,8 +1293,7 @@ class PrivateAccessAPI:
                *,
                allowed_vpc_endpoint_ids: Optional[List[str]] = None,
                private_access_level: Optional[PrivateAccessLevel] = None,
-               public_access_enabled: Optional[bool] = None,
-               **kwargs) -> PrivateAccessSettings:
+               public_access_enabled: Optional[bool] = None) -> PrivateAccessSettings:
         """Create private access settings.
         
         Creates a private access settings object, which specifies how your workspace is accessed over [AWS
@@ -1469,22 +1339,21 @@ class PrivateAccessAPI:
         
         :returns: :class:`PrivateAccessSettings`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = UpsertPrivateAccessSettingsRequest(
-                allowed_vpc_endpoint_ids=allowed_vpc_endpoint_ids,
-                private_access_level=private_access_level,
-                private_access_settings_name=private_access_settings_name,
-                public_access_enabled=public_access_enabled,
-                region=region)
-        body = request.as_dict()
+        body = {}
+        if allowed_vpc_endpoint_ids is not None:
+            body['allowed_vpc_endpoint_ids'] = [v for v in allowed_vpc_endpoint_ids]
+        if private_access_level is not None: body['private_access_level'] = private_access_level.value
+        if private_access_settings_name is not None:
+            body['private_access_settings_name'] = private_access_settings_name
+        if public_access_enabled is not None: body['public_access_enabled'] = public_access_enabled
+        if region is not None: body['region'] = region
 
         json = self._api.do('POST',
                             f'/api/2.0/accounts/{self._api.account_id}/private-access-settings',
                             body=body)
         return PrivateAccessSettings.from_dict(json)
 
-    def delete(self, private_access_settings_id: str, **kwargs):
+    def delete(self, private_access_settings_id: str):
         """Delete a private access settings object.
         
         Deletes a private access settings object, which determines how your workspace is accessed over [AWS
@@ -1500,16 +1369,12 @@ class PrivateAccessAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = DeletePrivateAccesRequest(private_access_settings_id=private_access_settings_id)
 
         self._api.do(
             'DELETE',
-            f'/api/2.0/accounts/{self._api.account_id}/private-access-settings/{request.private_access_settings_id}'
-        )
+            f'/api/2.0/accounts/{self._api.account_id}/private-access-settings/{private_access_settings_id}')
 
-    def get(self, private_access_settings_id: str, **kwargs) -> PrivateAccessSettings:
+    def get(self, private_access_settings_id: str) -> PrivateAccessSettings:
         """Get a private access settings object.
         
         Gets a private access settings object, which specifies how your workspace is accessed over [AWS
@@ -1525,14 +1390,10 @@ class PrivateAccessAPI:
         
         :returns: :class:`PrivateAccessSettings`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = GetPrivateAccesRequest(private_access_settings_id=private_access_settings_id)
 
         json = self._api.do(
             'GET',
-            f'/api/2.0/accounts/{self._api.account_id}/private-access-settings/{request.private_access_settings_id}'
-        )
+            f'/api/2.0/accounts/{self._api.account_id}/private-access-settings/{private_access_settings_id}')
         return PrivateAccessSettings.from_dict(json)
 
     def list(self) -> Iterator[PrivateAccessSettings]:
@@ -1553,8 +1414,7 @@ class PrivateAccessAPI:
                 *,
                 allowed_vpc_endpoint_ids: Optional[List[str]] = None,
                 private_access_level: Optional[PrivateAccessLevel] = None,
-                public_access_enabled: Optional[bool] = None,
-                **kwargs):
+                public_access_enabled: Optional[bool] = None):
         """Replace private access settings.
         
         Updates an existing private access settings object, which specifies how your workspace is accessed
@@ -1607,19 +1467,17 @@ class PrivateAccessAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = UpsertPrivateAccessSettingsRequest(
-                allowed_vpc_endpoint_ids=allowed_vpc_endpoint_ids,
-                private_access_level=private_access_level,
-                private_access_settings_id=private_access_settings_id,
-                private_access_settings_name=private_access_settings_name,
-                public_access_enabled=public_access_enabled,
-                region=region)
-        body = request.as_dict()
+        body = {}
+        if allowed_vpc_endpoint_ids is not None:
+            body['allowed_vpc_endpoint_ids'] = [v for v in allowed_vpc_endpoint_ids]
+        if private_access_level is not None: body['private_access_level'] = private_access_level.value
+        if private_access_settings_name is not None:
+            body['private_access_settings_name'] = private_access_settings_name
+        if public_access_enabled is not None: body['public_access_enabled'] = public_access_enabled
+        if region is not None: body['region'] = region
         self._api.do(
             'PUT',
-            f'/api/2.0/accounts/{self._api.account_id}/private-access-settings/{request.private_access_settings_id}',
+            f'/api/2.0/accounts/{self._api.account_id}/private-access-settings/{private_access_settings_id}',
             body=body)
 
 
@@ -1632,8 +1490,8 @@ class StorageAPI:
     def __init__(self, api_client):
         self._api = api_client
 
-    def create(self, storage_configuration_name: str, root_bucket_info: RootBucketInfo,
-               **kwargs) -> StorageConfiguration:
+    def create(self, storage_configuration_name: str,
+               root_bucket_info: RootBucketInfo) -> StorageConfiguration:
         """Create new storage configuration.
         
         Creates new storage configuration for an account, specified by ID. Uploads a storage configuration
@@ -1653,18 +1511,17 @@ class StorageAPI:
         
         :returns: :class:`StorageConfiguration`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = CreateStorageConfigurationRequest(root_bucket_info=root_bucket_info,
-                                                        storage_configuration_name=storage_configuration_name)
-        body = request.as_dict()
+        body = {}
+        if root_bucket_info is not None: body['root_bucket_info'] = root_bucket_info.as_dict()
+        if storage_configuration_name is not None:
+            body['storage_configuration_name'] = storage_configuration_name
 
         json = self._api.do('POST',
                             f'/api/2.0/accounts/{self._api.account_id}/storage-configurations',
                             body=body)
         return StorageConfiguration.from_dict(json)
 
-    def delete(self, storage_configuration_id: str, **kwargs):
+    def delete(self, storage_configuration_id: str):
         """Delete storage configuration.
         
         Deletes a Databricks storage configuration. You cannot delete a storage configuration that is
@@ -1675,16 +1532,12 @@ class StorageAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = DeleteStorageRequest(storage_configuration_id=storage_configuration_id)
 
         self._api.do(
             'DELETE',
-            f'/api/2.0/accounts/{self._api.account_id}/storage-configurations/{request.storage_configuration_id}'
-        )
+            f'/api/2.0/accounts/{self._api.account_id}/storage-configurations/{storage_configuration_id}')
 
-    def get(self, storage_configuration_id: str, **kwargs) -> StorageConfiguration:
+    def get(self, storage_configuration_id: str) -> StorageConfiguration:
         """Get storage configuration.
         
         Gets a Databricks storage configuration for an account, both specified by ID.
@@ -1694,14 +1547,10 @@ class StorageAPI:
         
         :returns: :class:`StorageConfiguration`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = GetStorageRequest(storage_configuration_id=storage_configuration_id)
 
         json = self._api.do(
             'GET',
-            f'/api/2.0/accounts/{self._api.account_id}/storage-configurations/{request.storage_configuration_id}'
-        )
+            f'/api/2.0/accounts/{self._api.account_id}/storage-configurations/{storage_configuration_id}')
         return StorageConfiguration.from_dict(json)
 
     def list(self) -> Iterator[StorageConfiguration]:
@@ -1727,8 +1576,7 @@ class VpcEndpointsAPI:
                *,
                aws_vpc_endpoint_id: Optional[str] = None,
                gcp_vpc_endpoint_info: Optional[GcpVpcEndpointInfo] = None,
-               region: Optional[str] = None,
-               **kwargs) -> VpcEndpoint:
+               region: Optional[str] = None) -> VpcEndpoint:
         """Create VPC endpoint configuration.
         
         Creates a VPC endpoint configuration, which represents a [VPC endpoint] object in AWS used to
@@ -1755,18 +1603,16 @@ class VpcEndpointsAPI:
         
         :returns: :class:`VpcEndpoint`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = CreateVpcEndpointRequest(aws_vpc_endpoint_id=aws_vpc_endpoint_id,
-                                               gcp_vpc_endpoint_info=gcp_vpc_endpoint_info,
-                                               region=region,
-                                               vpc_endpoint_name=vpc_endpoint_name)
-        body = request.as_dict()
+        body = {}
+        if aws_vpc_endpoint_id is not None: body['aws_vpc_endpoint_id'] = aws_vpc_endpoint_id
+        if gcp_vpc_endpoint_info is not None: body['gcp_vpc_endpoint_info'] = gcp_vpc_endpoint_info.as_dict()
+        if region is not None: body['region'] = region
+        if vpc_endpoint_name is not None: body['vpc_endpoint_name'] = vpc_endpoint_name
 
         json = self._api.do('POST', f'/api/2.0/accounts/{self._api.account_id}/vpc-endpoints', body=body)
         return VpcEndpoint.from_dict(json)
 
-    def delete(self, vpc_endpoint_id: str, **kwargs):
+    def delete(self, vpc_endpoint_id: str):
         """Delete VPC endpoint configuration.
         
         Deletes a VPC endpoint configuration, which represents an [AWS VPC endpoint] that can communicate
@@ -1783,14 +1629,10 @@ class VpcEndpointsAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = DeleteVpcEndpointRequest(vpc_endpoint_id=vpc_endpoint_id)
 
-        self._api.do('DELETE',
-                     f'/api/2.0/accounts/{self._api.account_id}/vpc-endpoints/{request.vpc_endpoint_id}')
+        self._api.do('DELETE', f'/api/2.0/accounts/{self._api.account_id}/vpc-endpoints/{vpc_endpoint_id}')
 
-    def get(self, vpc_endpoint_id: str, **kwargs) -> VpcEndpoint:
+    def get(self, vpc_endpoint_id: str) -> VpcEndpoint:
         """Get a VPC endpoint configuration.
         
         Gets a VPC endpoint configuration, which represents a [VPC endpoint] object in AWS used to communicate
@@ -1804,12 +1646,9 @@ class VpcEndpointsAPI:
         
         :returns: :class:`VpcEndpoint`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = GetVpcEndpointRequest(vpc_endpoint_id=vpc_endpoint_id)
 
-        json = self._api.do(
-            'GET', f'/api/2.0/accounts/{self._api.account_id}/vpc-endpoints/{request.vpc_endpoint_id}')
+        json = self._api.do('GET',
+                            f'/api/2.0/accounts/{self._api.account_id}/vpc-endpoints/{vpc_endpoint_id}')
         return VpcEndpoint.from_dict(json)
 
     def list(self) -> Iterator[VpcEndpoint]:
@@ -1883,8 +1722,7 @@ class WorkspacesAPI:
                pricing_tier: Optional[PricingTier] = None,
                private_access_settings_id: Optional[str] = None,
                storage_configuration_id: Optional[str] = None,
-               storage_customer_managed_key_id: Optional[str] = None,
-               **kwargs) -> Wait[Workspace]:
+               storage_customer_managed_key_id: Optional[str] = None) -> Wait[Workspace]:
         """Create a new workspace.
         
         Creates a new workspace.
@@ -1964,23 +1802,24 @@ class WorkspacesAPI:
           Long-running operation waiter for :class:`Workspace`.
           See :method:wait_get_workspace_running for more details.
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = CreateWorkspaceRequest(
-                aws_region=aws_region,
-                cloud=cloud,
-                cloud_resource_container=cloud_resource_container,
-                credentials_id=credentials_id,
-                deployment_name=deployment_name,
-                location=location,
-                managed_services_customer_managed_key_id=managed_services_customer_managed_key_id,
-                network_id=network_id,
-                pricing_tier=pricing_tier,
-                private_access_settings_id=private_access_settings_id,
-                storage_configuration_id=storage_configuration_id,
-                storage_customer_managed_key_id=storage_customer_managed_key_id,
-                workspace_name=workspace_name)
-        body = request.as_dict()
+        body = {}
+        if aws_region is not None: body['aws_region'] = aws_region
+        if cloud is not None: body['cloud'] = cloud
+        if cloud_resource_container is not None:
+            body['cloud_resource_container'] = cloud_resource_container.as_dict()
+        if credentials_id is not None: body['credentials_id'] = credentials_id
+        if deployment_name is not None: body['deployment_name'] = deployment_name
+        if location is not None: body['location'] = location
+        if managed_services_customer_managed_key_id is not None:
+            body['managed_services_customer_managed_key_id'] = managed_services_customer_managed_key_id
+        if network_id is not None: body['network_id'] = network_id
+        if pricing_tier is not None: body['pricing_tier'] = pricing_tier.value
+        if private_access_settings_id is not None:
+            body['private_access_settings_id'] = private_access_settings_id
+        if storage_configuration_id is not None: body['storage_configuration_id'] = storage_configuration_id
+        if storage_customer_managed_key_id is not None:
+            body['storage_customer_managed_key_id'] = storage_customer_managed_key_id
+        if workspace_name is not None: body['workspace_name'] = workspace_name
         op_response = self._api.do('POST', f'/api/2.0/accounts/{self._api.account_id}/workspaces', body=body)
         return Wait(self.wait_get_workspace_running,
                     response=Workspace.from_dict(op_response),
@@ -2017,7 +1856,7 @@ class WorkspacesAPI:
                            storage_customer_managed_key_id=storage_customer_managed_key_id,
                            workspace_name=workspace_name).result(timeout=timeout)
 
-    def delete(self, workspace_id: int, **kwargs):
+    def delete(self, workspace_id: int):
         """Delete a workspace.
         
         Terminates and deletes a Databricks workspace. From an API perspective, deletion is immediate.
@@ -2032,13 +1871,10 @@ class WorkspacesAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = DeleteWorkspaceRequest(workspace_id=workspace_id)
 
-        self._api.do('DELETE', f'/api/2.0/accounts/{self._api.account_id}/workspaces/{request.workspace_id}')
+        self._api.do('DELETE', f'/api/2.0/accounts/{self._api.account_id}/workspaces/{workspace_id}')
 
-    def get(self, workspace_id: int, **kwargs) -> Workspace:
+    def get(self, workspace_id: int) -> Workspace:
         """Get a workspace.
         
         Gets information including status for a Databricks workspace, specified by ID. In the response, the
@@ -2059,12 +1895,8 @@ class WorkspacesAPI:
         
         :returns: :class:`Workspace`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = GetWorkspaceRequest(workspace_id=workspace_id)
 
-        json = self._api.do('GET',
-                            f'/api/2.0/accounts/{self._api.account_id}/workspaces/{request.workspace_id}')
+        json = self._api.do('GET', f'/api/2.0/accounts/{self._api.account_id}/workspaces/{workspace_id}')
         return Workspace.from_dict(json)
 
     def list(self) -> Iterator[Workspace]:
@@ -2089,8 +1921,7 @@ class WorkspacesAPI:
                managed_services_customer_managed_key_id: Optional[str] = None,
                network_id: Optional[str] = None,
                storage_configuration_id: Optional[str] = None,
-               storage_customer_managed_key_id: Optional[str] = None,
-               **kwargs) -> Wait[Workspace]:
+               storage_customer_managed_key_id: Optional[str] = None) -> Wait[Workspace]:
         """Update workspace configuration.
         
         Updates a workspace configuration for either a running workspace or a failed workspace. The elements
@@ -2210,21 +2041,19 @@ class WorkspacesAPI:
           Long-running operation waiter for :class:`Workspace`.
           See :method:wait_get_workspace_running for more details.
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = UpdateWorkspaceRequest(
-                aws_region=aws_region,
-                credentials_id=credentials_id,
-                managed_services_customer_managed_key_id=managed_services_customer_managed_key_id,
-                network_id=network_id,
-                storage_configuration_id=storage_configuration_id,
-                storage_customer_managed_key_id=storage_customer_managed_key_id,
-                workspace_id=workspace_id)
-        body = request.as_dict()
+        body = {}
+        if aws_region is not None: body['aws_region'] = aws_region
+        if credentials_id is not None: body['credentials_id'] = credentials_id
+        if managed_services_customer_managed_key_id is not None:
+            body['managed_services_customer_managed_key_id'] = managed_services_customer_managed_key_id
+        if network_id is not None: body['network_id'] = network_id
+        if storage_configuration_id is not None: body['storage_configuration_id'] = storage_configuration_id
+        if storage_customer_managed_key_id is not None:
+            body['storage_customer_managed_key_id'] = storage_customer_managed_key_id
         self._api.do('PATCH',
-                     f'/api/2.0/accounts/{self._api.account_id}/workspaces/{request.workspace_id}',
+                     f'/api/2.0/accounts/{self._api.account_id}/workspaces/{workspace_id}',
                      body=body)
-        return Wait(self.wait_get_workspace_running, workspace_id=request.workspace_id)
+        return Wait(self.wait_get_workspace_running, workspace_id=workspace_id)
 
     def update_and_wait(
         self,

--- a/databricks/sdk/service/sql.py
+++ b/databricks/sdk/service/sql.py
@@ -171,13 +171,6 @@ class AlertState(Enum):
 
 
 @dataclass
-class CancelExecutionRequest:
-    """Cancel statement execution"""
-
-    statement_id: str
-
-
-@dataclass
 class Channel:
     dbsql_version: Optional[str] = None
     name: Optional['ChannelName'] = None
@@ -212,7 +205,6 @@ class ChannelInfo:
 
 
 class ChannelName(Enum):
-    """Name of the channel"""
 
     CHANNEL_NAME_CURRENT = 'CHANNEL_NAME_CURRENT'
     CHANNEL_NAME_CUSTOM = 'CHANNEL_NAME_CUSTOM'
@@ -334,31 +326,6 @@ class CreateAlert:
                    parent=d.get('parent', None),
                    query_id=d.get('query_id', None),
                    rearm=d.get('rearm', None))
-
-
-@dataclass
-class CreateDashboardRequest:
-    """Create a dashboard object"""
-
-    is_favorite: Optional[bool] = None
-    name: Optional[str] = None
-    parent: Optional[str] = None
-    tags: Optional['List[str]'] = None
-
-    def as_dict(self) -> dict:
-        body = {}
-        if self.is_favorite is not None: body['is_favorite'] = self.is_favorite
-        if self.name is not None: body['name'] = self.name
-        if self.parent is not None: body['parent'] = self.parent
-        if self.tags: body['tags'] = [v for v in self.tags]
-        return body
-
-    @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> 'CreateDashboardRequest':
-        return cls(is_favorite=d.get('is_favorite', None),
-                   name=d.get('name', None),
-                   parent=d.get('parent', None),
-                   tags=d.get('tags', None))
 
 
 @dataclass
@@ -553,34 +520,6 @@ class DataSource:
                    type=d.get('type', None),
                    view_only=d.get('view_only', None),
                    warehouse_id=d.get('warehouse_id', None))
-
-
-@dataclass
-class DeleteAlertRequest:
-    """Delete an alert"""
-
-    alert_id: str
-
-
-@dataclass
-class DeleteDashboardRequest:
-    """Remove a dashboard"""
-
-    dashboard_id: str
-
-
-@dataclass
-class DeleteQueryRequest:
-    """Delete a query"""
-
-    query_id: str
-
-
-@dataclass
-class DeleteWarehouseRequest:
-    """Delete a warehouse"""
-
-    id: str
 
 
 class Disposition(Enum):
@@ -992,35 +931,6 @@ class Format(Enum):
 
 
 @dataclass
-class GetAlertRequest:
-    """Get an alert"""
-
-    alert_id: str
-
-
-@dataclass
-class GetDashboardRequest:
-    """Retrieve a definition"""
-
-    dashboard_id: str
-
-
-@dataclass
-class GetDbsqlPermissionRequest:
-    """Get object ACL"""
-
-    object_type: 'ObjectTypePlural'
-    object_id: str
-
-
-@dataclass
-class GetQueryRequest:
-    """Get a query definition."""
-
-    query_id: str
-
-
-@dataclass
 class GetResponse:
     access_control_list: Optional['List[AccessControl]'] = None
     object_id: Optional[str] = None
@@ -1039,13 +949,6 @@ class GetResponse:
         return cls(access_control_list=_repeated(d, 'access_control_list', AccessControl),
                    object_id=d.get('object_id', None),
                    object_type=_enum(d, 'object_type', ObjectType))
-
-
-@dataclass
-class GetStatementRequest:
-    """Get status, manifest, and result first chunk"""
-
-    statement_id: str
 
 
 @dataclass
@@ -1069,21 +972,6 @@ class GetStatementResponse:
                    result=_from_dict(d, 'result', ResultData),
                    statement_id=d.get('statement_id', None),
                    status=_from_dict(d, 'status', StatementStatus))
-
-
-@dataclass
-class GetStatementResultChunkNRequest:
-    """Get result chunk by index"""
-
-    statement_id: str
-    chunk_index: int
-
-
-@dataclass
-class GetWarehouseRequest:
-    """Get warehouse info"""
-
-    id: str
 
 
 @dataclass
@@ -1220,30 +1108,10 @@ class GetWorkspaceWarehouseConfigResponseSecurityPolicy(Enum):
     PASSTHROUGH = 'PASSTHROUGH'
 
 
-@dataclass
-class ListDashboardsRequest:
-    """Get dashboard objects"""
-
-    order: Optional['ListOrder'] = None
-    page: Optional[int] = None
-    page_size: Optional[int] = None
-    q: Optional[str] = None
-
-
 class ListOrder(Enum):
 
     CREATED_AT = 'created_at'
     NAME = 'name'
-
-
-@dataclass
-class ListQueriesRequest:
-    """Get a list of queries"""
-
-    order: Optional[str] = None
-    page: Optional[int] = None
-    page_size: Optional[int] = None
-    q: Optional[str] = None
 
 
 @dataclass
@@ -1267,16 +1135,6 @@ class ListQueriesResponse:
 
 
 @dataclass
-class ListQueryHistoryRequest:
-    """List Queries"""
-
-    filter_by: Optional['QueryFilter'] = None
-    include_metrics: Optional[bool] = None
-    max_results: Optional[int] = None
-    page_token: Optional[str] = None
-
-
-@dataclass
 class ListResponse:
     count: Optional[int] = None
     page: Optional[int] = None
@@ -1297,13 +1155,6 @@ class ListResponse:
                    page=d.get('page', None),
                    page_size=d.get('page_size', None),
                    results=_repeated(d, 'results', Dashboard))
-
-
-@dataclass
-class ListWarehousesRequest:
-    """List warehouses"""
-
-    run_as_user_id: Optional[int] = None
 
 
 @dataclass
@@ -1834,20 +1685,6 @@ class RepeatedEndpointConfPairs:
 
 
 @dataclass
-class RestoreDashboardRequest:
-    """Restore a dashboard"""
-
-    dashboard_id: str
-
-
-@dataclass
-class RestoreQueryRequest:
-    """Restore a query"""
-
-    query_id: str
-
-
-@dataclass
 class ResultData:
     """Result data chunks are delivered in either the `chunk` field when using `INLINE` disposition, or
     in the `external_link` field when using `EXTERNAL_LINKS` disposition. Exactly one of these will
@@ -1971,29 +1808,6 @@ class ServiceErrorCode(Enum):
 
 
 @dataclass
-class SetRequest:
-    """Set object ACL"""
-
-    object_type: 'ObjectTypePlural'
-    object_id: str
-    access_control_list: Optional['List[AccessControl]'] = None
-
-    def as_dict(self) -> dict:
-        body = {}
-        if self.access_control_list:
-            body['access_control_list'] = [v.as_dict() for v in self.access_control_list]
-        if self.object_id is not None: body['objectId'] = self.object_id
-        if self.object_type is not None: body['objectType'] = self.object_type.value
-        return body
-
-    @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> 'SetRequest':
-        return cls(access_control_list=_repeated(d, 'access_control_list', AccessControl),
-                   object_id=d.get('objectId', None),
-                   object_type=_enum(d, 'objectType', ObjectTypePlural))
-
-
-@dataclass
 class SetResponse:
     access_control_list: Optional['List[AccessControl]'] = None
     object_id: Optional[str] = None
@@ -2074,13 +1888,6 @@ class SpotInstancePolicy(Enum):
     RELIABILITY_OPTIMIZED = 'RELIABILITY_OPTIMIZED'
 
 
-@dataclass
-class StartRequest:
-    """Start a warehouse"""
-
-    id: str
-
-
 class State(Enum):
     """State of the warehouse"""
 
@@ -2132,13 +1939,6 @@ class Status(Enum):
     FAILED = 'FAILED'
     HEALTHY = 'HEALTHY'
     STATUS_UNSPECIFIED = 'STATUS_UNSPECIFIED'
-
-
-@dataclass
-class StopRequest:
-    """Stop a warehouse"""
-
-    id: str
 
 
 @dataclass
@@ -2318,28 +2118,6 @@ class TransferOwnershipObjectId:
 
 
 @dataclass
-class TransferOwnershipRequest:
-    """Transfer object ownership"""
-
-    object_type: 'OwnableObjectType'
-    object_id: 'TransferOwnershipObjectId'
-    new_owner: Optional[str] = None
-
-    def as_dict(self) -> dict:
-        body = {}
-        if self.new_owner is not None: body['new_owner'] = self.new_owner
-        if self.object_id: body['objectId'] = self.object_id.as_dict()
-        if self.object_type is not None: body['objectType'] = self.object_type.value
-        return body
-
-    @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> 'TransferOwnershipRequest':
-        return cls(new_owner=d.get('new_owner', None),
-                   object_id=_from_dict(d, 'objectId', TransferOwnershipObjectId),
-                   object_type=_enum(d, 'objectType', OwnableObjectType))
-
-
-@dataclass
 class User:
     email: Optional[str] = None
     id: Optional[int] = None
@@ -2489,8 +2267,7 @@ class AlertsAPI:
                query_id: str,
                *,
                parent: Optional[str] = None,
-               rearm: Optional[int] = None,
-               **kwargs) -> Alert:
+               rearm: Optional[int] = None) -> Alert:
         """Create an alert.
         
         Creates an alert. An alert is a Databricks SQL object that periodically runs a query, evaluates a
@@ -2510,15 +2287,17 @@ class AlertsAPI:
         
         :returns: :class:`Alert`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = CreateAlert(name=name, options=options, parent=parent, query_id=query_id, rearm=rearm)
-        body = request.as_dict()
+        body = {}
+        if name is not None: body['name'] = name
+        if options is not None: body['options'] = options.as_dict()
+        if parent is not None: body['parent'] = parent
+        if query_id is not None: body['query_id'] = query_id
+        if rearm is not None: body['rearm'] = rearm
 
         json = self._api.do('POST', '/api/2.0/preview/sql/alerts', body=body)
         return Alert.from_dict(json)
 
-    def delete(self, alert_id: str, **kwargs):
+    def delete(self, alert_id: str):
         """Delete an alert.
         
         Deletes an alert. Deleted alerts are no longer accessible and cannot be restored. **Note:** Unlike
@@ -2528,13 +2307,10 @@ class AlertsAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = DeleteAlertRequest(alert_id=alert_id)
 
-        self._api.do('DELETE', f'/api/2.0/preview/sql/alerts/{request.alert_id}')
+        self._api.do('DELETE', f'/api/2.0/preview/sql/alerts/{alert_id}')
 
-    def get(self, alert_id: str, **kwargs) -> Alert:
+    def get(self, alert_id: str) -> Alert:
         """Get an alert.
         
         Gets an alert.
@@ -2543,11 +2319,8 @@ class AlertsAPI:
         
         :returns: :class:`Alert`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = GetAlertRequest(alert_id=alert_id)
 
-        json = self._api.do('GET', f'/api/2.0/preview/sql/alerts/{request.alert_id}')
+        json = self._api.do('GET', f'/api/2.0/preview/sql/alerts/{alert_id}')
         return Alert.from_dict(json)
 
     def list(self) -> Iterator[Alert]:
@@ -2567,8 +2340,7 @@ class AlertsAPI:
                query_id: str,
                alert_id: str,
                *,
-               rearm: Optional[int] = None,
-               **kwargs):
+               rearm: Optional[int] = None):
         """Update an alert.
         
         Updates an alert.
@@ -2586,11 +2358,12 @@ class AlertsAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = EditAlert(alert_id=alert_id, name=name, options=options, query_id=query_id, rearm=rearm)
-        body = request.as_dict()
-        self._api.do('PUT', f'/api/2.0/preview/sql/alerts/{request.alert_id}', body=body)
+        body = {}
+        if name is not None: body['name'] = name
+        if options is not None: body['options'] = options.as_dict()
+        if query_id is not None: body['query_id'] = query_id
+        if rearm is not None: body['rearm'] = rearm
+        self._api.do('PUT', f'/api/2.0/preview/sql/alerts/{alert_id}', body=body)
 
 
 class DashboardsAPI:
@@ -2608,8 +2381,7 @@ class DashboardsAPI:
                is_favorite: Optional[bool] = None,
                name: Optional[str] = None,
                parent: Optional[str] = None,
-               tags: Optional[List[str]] = None,
-               **kwargs) -> Dashboard:
+               tags: Optional[List[str]] = None) -> Dashboard:
         """Create a dashboard object.
         
         :param is_favorite: bool (optional)
@@ -2623,15 +2395,16 @@ class DashboardsAPI:
         
         :returns: :class:`Dashboard`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = CreateDashboardRequest(is_favorite=is_favorite, name=name, parent=parent, tags=tags)
-        body = request.as_dict()
+        body = {}
+        if is_favorite is not None: body['is_favorite'] = is_favorite
+        if name is not None: body['name'] = name
+        if parent is not None: body['parent'] = parent
+        if tags is not None: body['tags'] = [v for v in tags]
 
         json = self._api.do('POST', '/api/2.0/preview/sql/dashboards', body=body)
         return Dashboard.from_dict(json)
 
-    def delete(self, dashboard_id: str, **kwargs):
+    def delete(self, dashboard_id: str):
         """Remove a dashboard.
         
         Moves a dashboard to the trash. Trashed dashboards do not appear in list views or searches, and cannot
@@ -2641,13 +2414,10 @@ class DashboardsAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = DeleteDashboardRequest(dashboard_id=dashboard_id)
 
-        self._api.do('DELETE', f'/api/2.0/preview/sql/dashboards/{request.dashboard_id}')
+        self._api.do('DELETE', f'/api/2.0/preview/sql/dashboards/{dashboard_id}')
 
-    def get(self, dashboard_id: str, **kwargs) -> Dashboard:
+    def get(self, dashboard_id: str) -> Dashboard:
         """Retrieve a definition.
         
         Returns a JSON representation of a dashboard object, including its visualization and query objects.
@@ -2656,11 +2426,8 @@ class DashboardsAPI:
         
         :returns: :class:`Dashboard`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = GetDashboardRequest(dashboard_id=dashboard_id)
 
-        json = self._api.do('GET', f'/api/2.0/preview/sql/dashboards/{request.dashboard_id}')
+        json = self._api.do('GET', f'/api/2.0/preview/sql/dashboards/{dashboard_id}')
         return Dashboard.from_dict(json)
 
     def list(self,
@@ -2668,8 +2435,7 @@ class DashboardsAPI:
              order: Optional[ListOrder] = None,
              page: Optional[int] = None,
              page_size: Optional[int] = None,
-             q: Optional[str] = None,
-             **kwargs) -> Iterator[Dashboard]:
+             q: Optional[str] = None) -> Iterator[Dashboard]:
         """Get dashboard objects.
         
         Fetch a paginated list of dashboard objects.
@@ -2685,15 +2451,12 @@ class DashboardsAPI:
         
         :returns: Iterator over :class:`Dashboard`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = ListDashboardsRequest(order=order, page=page, page_size=page_size, q=q)
 
         query = {}
-        if order: query['order'] = request.order.value
-        if page: query['page'] = request.page
-        if page_size: query['page_size'] = request.page_size
-        if q: query['q'] = request.q
+        if order is not None: query['order'] = order.value
+        if page is not None: query['page'] = page
+        if page_size is not None: query['page_size'] = page_size
+        if q is not None: query['q'] = q
 
         # deduplicate items that may have been added during iteration
         seen = set()
@@ -2710,7 +2473,7 @@ class DashboardsAPI:
                 yield Dashboard.from_dict(v)
             query['page'] += 1
 
-    def restore(self, dashboard_id: str, **kwargs):
+    def restore(self, dashboard_id: str):
         """Restore a dashboard.
         
         A restored dashboard appears in list views and searches and can be shared.
@@ -2719,11 +2482,8 @@ class DashboardsAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = RestoreDashboardRequest(dashboard_id=dashboard_id)
 
-        self._api.do('POST', f'/api/2.0/preview/sql/dashboards/trash/{request.dashboard_id}')
+        self._api.do('POST', f'/api/2.0/preview/sql/dashboards/trash/{dashboard_id}')
 
 
 class DataSourcesAPI:
@@ -2768,7 +2528,7 @@ class DbsqlPermissionsAPI:
     def __init__(self, api_client):
         self._api = api_client
 
-    def get(self, object_type: ObjectTypePlural, object_id: str, **kwargs) -> GetResponse:
+    def get(self, object_type: ObjectTypePlural, object_id: str) -> GetResponse:
         """Get object ACL.
         
         Gets a JSON representation of the access control list (ACL) for a specified object.
@@ -2780,20 +2540,15 @@ class DbsqlPermissionsAPI:
         
         :returns: :class:`GetResponse`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = GetDbsqlPermissionRequest(object_id=object_id, object_type=object_type)
 
-        json = self._api.do(
-            'GET', f'/api/2.0/preview/sql/permissions/{request.object_type.value}/{request.object_id}')
+        json = self._api.do('GET', f'/api/2.0/preview/sql/permissions/{object_type.value}/{object_id}')
         return GetResponse.from_dict(json)
 
     def set(self,
             object_type: ObjectTypePlural,
             object_id: str,
             *,
-            access_control_list: Optional[List[AccessControl]] = None,
-            **kwargs) -> SetResponse:
+            access_control_list: Optional[List[AccessControl]] = None) -> SetResponse:
         """Set object ACL.
         
         Sets the access control list (ACL) for a specified object. This operation will complete rewrite the
@@ -2807,25 +2562,20 @@ class DbsqlPermissionsAPI:
         
         :returns: :class:`SetResponse`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = SetRequest(access_control_list=access_control_list,
-                                 object_id=object_id,
-                                 object_type=object_type)
-        body = request.as_dict()
+        body = {}
+        if access_control_list is not None:
+            body['access_control_list'] = [v.as_dict() for v in access_control_list]
 
-        json = self._api.do(
-            'POST',
-            f'/api/2.0/preview/sql/permissions/{request.object_type.value}/{request.object_id}',
-            body=body)
+        json = self._api.do('POST',
+                            f'/api/2.0/preview/sql/permissions/{object_type.value}/{object_id}',
+                            body=body)
         return SetResponse.from_dict(json)
 
     def transfer_ownership(self,
                            object_type: OwnableObjectType,
                            object_id: TransferOwnershipObjectId,
                            *,
-                           new_owner: Optional[str] = None,
-                           **kwargs) -> Success:
+                           new_owner: Optional[str] = None) -> Success:
         """Transfer object ownership.
         
         Transfers ownership of a dashboard, query, or alert to an active user. Requires an admin API key.
@@ -2839,17 +2589,12 @@ class DbsqlPermissionsAPI:
         
         :returns: :class:`Success`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = TransferOwnershipRequest(new_owner=new_owner,
-                                               object_id=object_id,
-                                               object_type=object_type)
-        body = request.as_dict()
+        body = {}
+        if new_owner is not None: body['new_owner'] = new_owner
 
-        json = self._api.do(
-            'POST',
-            f'/api/2.0/preview/sql/permissions/{request.object_type.value}/{request.object_id}/transfer',
-            body=body)
+        json = self._api.do('POST',
+                            f'/api/2.0/preview/sql/permissions/{object_type.value}/{object_id}/transfer',
+                            body=body)
         return Success.from_dict(json)
 
 
@@ -2868,8 +2613,7 @@ class QueriesAPI:
                name: Optional[str] = None,
                options: Optional[Any] = None,
                parent: Optional[str] = None,
-               query: Optional[str] = None,
-               **kwargs) -> Query:
+               query: Optional[str] = None) -> Query:
         """Create a new query definition.
         
         Creates a new query definition. Queries created with this endpoint belong to the authenticated user
@@ -2898,20 +2642,18 @@ class QueriesAPI:
         
         :returns: :class:`Query`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = QueryPostContent(data_source_id=data_source_id,
-                                       description=description,
-                                       name=name,
-                                       options=options,
-                                       parent=parent,
-                                       query=query)
-        body = request.as_dict()
+        body = {}
+        if data_source_id is not None: body['data_source_id'] = data_source_id
+        if description is not None: body['description'] = description
+        if name is not None: body['name'] = name
+        if options is not None: body['options'] = options
+        if parent is not None: body['parent'] = parent
+        if query is not None: body['query'] = query
 
         json = self._api.do('POST', '/api/2.0/preview/sql/queries', body=body)
         return Query.from_dict(json)
 
-    def delete(self, query_id: str, **kwargs):
+    def delete(self, query_id: str):
         """Delete a query.
         
         Moves a query to the trash. Trashed queries immediately disappear from searches and list views, and
@@ -2921,13 +2663,10 @@ class QueriesAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = DeleteQueryRequest(query_id=query_id)
 
-        self._api.do('DELETE', f'/api/2.0/preview/sql/queries/{request.query_id}')
+        self._api.do('DELETE', f'/api/2.0/preview/sql/queries/{query_id}')
 
-    def get(self, query_id: str, **kwargs) -> Query:
+    def get(self, query_id: str) -> Query:
         """Get a query definition.
         
         Retrieve a query object definition along with contextual permissions information about the currently
@@ -2937,11 +2676,8 @@ class QueriesAPI:
         
         :returns: :class:`Query`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = GetQueryRequest(query_id=query_id)
 
-        json = self._api.do('GET', f'/api/2.0/preview/sql/queries/{request.query_id}')
+        json = self._api.do('GET', f'/api/2.0/preview/sql/queries/{query_id}')
         return Query.from_dict(json)
 
     def list(self,
@@ -2949,8 +2685,7 @@ class QueriesAPI:
              order: Optional[str] = None,
              page: Optional[int] = None,
              page_size: Optional[int] = None,
-             q: Optional[str] = None,
-             **kwargs) -> Iterator[Query]:
+             q: Optional[str] = None) -> Iterator[Query]:
         """Get a list of queries.
         
         Gets a list of queries. Optionally, this list can be filtered by a search term.
@@ -2978,15 +2713,12 @@ class QueriesAPI:
         
         :returns: Iterator over :class:`Query`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = ListQueriesRequest(order=order, page=page, page_size=page_size, q=q)
 
         query = {}
-        if order: query['order'] = request.order
-        if page: query['page'] = request.page
-        if page_size: query['page_size'] = request.page_size
-        if q: query['q'] = request.q
+        if order is not None: query['order'] = order
+        if page is not None: query['page'] = page
+        if page_size is not None: query['page_size'] = page_size
+        if q is not None: query['q'] = q
 
         # deduplicate items that may have been added during iteration
         seen = set()
@@ -3003,7 +2735,7 @@ class QueriesAPI:
                 yield Query.from_dict(v)
             query['page'] += 1
 
-    def restore(self, query_id: str, **kwargs):
+    def restore(self, query_id: str):
         """Restore a query.
         
         Restore a query that has been moved to the trash. A restored query appears in list views and searches.
@@ -3013,11 +2745,8 @@ class QueriesAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = RestoreQueryRequest(query_id=query_id)
 
-        self._api.do('POST', f'/api/2.0/preview/sql/queries/trash/{request.query_id}')
+        self._api.do('POST', f'/api/2.0/preview/sql/queries/trash/{query_id}')
 
     def update(self,
                query_id: str,
@@ -3026,8 +2755,7 @@ class QueriesAPI:
                description: Optional[str] = None,
                name: Optional[str] = None,
                options: Optional[Any] = None,
-               query: Optional[str] = None,
-               **kwargs) -> Query:
+               query: Optional[str] = None) -> Query:
         """Change a query definition.
         
         Modify this query definition.
@@ -3050,17 +2778,14 @@ class QueriesAPI:
         
         :returns: :class:`Query`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = QueryEditContent(data_source_id=data_source_id,
-                                       description=description,
-                                       name=name,
-                                       options=options,
-                                       query=query,
-                                       query_id=query_id)
-        body = request.as_dict()
+        body = {}
+        if data_source_id is not None: body['data_source_id'] = data_source_id
+        if description is not None: body['description'] = description
+        if name is not None: body['name'] = name
+        if options is not None: body['options'] = options
+        if query is not None: body['query'] = query
 
-        json = self._api.do('POST', f'/api/2.0/preview/sql/queries/{request.query_id}', body=body)
+        json = self._api.do('POST', f'/api/2.0/preview/sql/queries/{query_id}', body=body)
         return Query.from_dict(json)
 
 
@@ -3075,8 +2800,7 @@ class QueryHistoryAPI:
              filter_by: Optional[QueryFilter] = None,
              include_metrics: Optional[bool] = None,
              max_results: Optional[int] = None,
-             page_token: Optional[str] = None,
-             **kwargs) -> Iterator[QueryInfo]:
+             page_token: Optional[str] = None) -> Iterator[QueryInfo]:
         """List Queries.
         
         List the history of queries through SQL warehouses.
@@ -3094,18 +2818,12 @@ class QueryHistoryAPI:
         
         :returns: Iterator over :class:`QueryInfo`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = ListQueryHistoryRequest(filter_by=filter_by,
-                                              include_metrics=include_metrics,
-                                              max_results=max_results,
-                                              page_token=page_token)
 
         query = {}
-        if filter_by: query['filter_by'] = request.filter_by.as_dict()
-        if include_metrics: query['include_metrics'] = request.include_metrics
-        if max_results: query['max_results'] = request.max_results
-        if page_token: query['page_token'] = request.page_token
+        if filter_by is not None: query['filter_by'] = filter_by.as_dict()
+        if include_metrics is not None: query['include_metrics'] = include_metrics
+        if max_results is not None: query['max_results'] = max_results
+        if page_token is not None: query['page_token'] = page_token
 
         while True:
             json = self._api.do('GET', '/api/2.0/sql/history/queries', query=query)
@@ -3278,7 +2996,7 @@ class StatementExecutionAPI:
     def __init__(self, api_client):
         self._api = api_client
 
-    def cancel_execution(self, statement_id: str, **kwargs):
+    def cancel_execution(self, statement_id: str):
         """Cancel statement execution.
         
         Requests that an executing statement be canceled. Callers must poll for status to see the terminal
@@ -3288,11 +3006,8 @@ class StatementExecutionAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = CancelExecutionRequest(statement_id=statement_id)
 
-        self._api.do('POST', f'/api/2.0/sql/statements/{request.statement_id}/cancel')
+        self._api.do('POST', f'/api/2.0/sql/statements/{statement_id}/cancel')
 
     def execute_statement(self,
                           *,
@@ -3304,8 +3019,7 @@ class StatementExecutionAPI:
                           schema: Optional[str] = None,
                           statement: Optional[str] = None,
                           wait_timeout: Optional[str] = None,
-                          warehouse_id: Optional[str] = None,
-                          **kwargs) -> ExecuteStatementResponse:
+                          warehouse_id: Optional[str] = None) -> ExecuteStatementResponse:
         """Execute a SQL statement.
         
         Execute a SQL statement, and if flagged as such, await its result for a specified time.
@@ -3398,23 +3112,21 @@ class StatementExecutionAPI:
         
         :returns: :class:`ExecuteStatementResponse`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = ExecuteStatementRequest(byte_limit=byte_limit,
-                                              catalog=catalog,
-                                              disposition=disposition,
-                                              format=format,
-                                              on_wait_timeout=on_wait_timeout,
-                                              schema=schema,
-                                              statement=statement,
-                                              wait_timeout=wait_timeout,
-                                              warehouse_id=warehouse_id)
-        body = request.as_dict()
+        body = {}
+        if byte_limit is not None: body['byte_limit'] = byte_limit
+        if catalog is not None: body['catalog'] = catalog
+        if disposition is not None: body['disposition'] = disposition.value
+        if format is not None: body['format'] = format.value
+        if on_wait_timeout is not None: body['on_wait_timeout'] = on_wait_timeout.value
+        if schema is not None: body['schema'] = schema
+        if statement is not None: body['statement'] = statement
+        if wait_timeout is not None: body['wait_timeout'] = wait_timeout
+        if warehouse_id is not None: body['warehouse_id'] = warehouse_id
 
         json = self._api.do('POST', '/api/2.0/sql/statements/', body=body)
         return ExecuteStatementResponse.from_dict(json)
 
-    def get_statement(self, statement_id: str, **kwargs) -> GetStatementResponse:
+    def get_statement(self, statement_id: str) -> GetStatementResponse:
         """Get status, manifest, and result first chunk.
         
         This request can be used to poll for the statement's status. When the `status.state` field is
@@ -3429,14 +3141,11 @@ class StatementExecutionAPI:
         
         :returns: :class:`GetStatementResponse`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = GetStatementRequest(statement_id=statement_id)
 
-        json = self._api.do('GET', f'/api/2.0/sql/statements/{request.statement_id}')
+        json = self._api.do('GET', f'/api/2.0/sql/statements/{statement_id}')
         return GetStatementResponse.from_dict(json)
 
-    def get_statement_result_chunk_n(self, statement_id: str, chunk_index: int, **kwargs) -> ResultData:
+    def get_statement_result_chunk_n(self, statement_id: str, chunk_index: int) -> ResultData:
         """Get result chunk by index.
         
         After the statement execution has `SUCCEEDED`, the result data can be fetched by chunks. Whereas the
@@ -3450,12 +3159,8 @@ class StatementExecutionAPI:
         
         :returns: :class:`ResultData`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = GetStatementResultChunkNRequest(chunk_index=chunk_index, statement_id=statement_id)
 
-        json = self._api.do(
-            'GET', f'/api/2.0/sql/statements/{request.statement_id}/result/chunks/{request.chunk_index}')
+        json = self._api.do('GET', f'/api/2.0/sql/statements/{statement_id}/result/chunks/{chunk_index}')
         return ResultData.from_dict(json)
 
 
@@ -3528,22 +3233,23 @@ class WarehousesAPI:
             attempt += 1
         raise TimeoutError(f'timed out after {timeout}: {status_message}')
 
-    def create(self,
-               *,
-               auto_stop_mins: Optional[int] = None,
-               channel: Optional[Channel] = None,
-               cluster_size: Optional[str] = None,
-               creator_name: Optional[str] = None,
-               enable_photon: Optional[bool] = None,
-               enable_serverless_compute: Optional[bool] = None,
-               instance_profile_arn: Optional[str] = None,
-               max_num_clusters: Optional[int] = None,
-               min_num_clusters: Optional[int] = None,
-               name: Optional[str] = None,
-               spot_instance_policy: Optional[SpotInstancePolicy] = None,
-               tags: Optional[EndpointTags] = None,
-               warehouse_type: Optional[CreateWarehouseRequestWarehouseType] = None,
-               **kwargs) -> Wait[GetWarehouseResponse]:
+    def create(
+            self,
+            *,
+            auto_stop_mins: Optional[int] = None,
+            channel: Optional[Channel] = None,
+            cluster_size: Optional[str] = None,
+            creator_name: Optional[str] = None,
+            enable_photon: Optional[bool] = None,
+            enable_serverless_compute: Optional[bool] = None,
+            instance_profile_arn: Optional[str] = None,
+            max_num_clusters: Optional[int] = None,
+            min_num_clusters: Optional[int] = None,
+            name: Optional[str] = None,
+            spot_instance_policy: Optional[SpotInstancePolicy] = None,
+            tags: Optional[EndpointTags] = None,
+            warehouse_type: Optional[CreateWarehouseRequestWarehouseType] = None
+    ) -> Wait[GetWarehouseResponse]:
         """Create a warehouse.
         
         Creates a new SQL warehouse.
@@ -3607,22 +3313,21 @@ class WarehousesAPI:
           Long-running operation waiter for :class:`GetWarehouseResponse`.
           See :method:wait_get_warehouse_running for more details.
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = CreateWarehouseRequest(auto_stop_mins=auto_stop_mins,
-                                             channel=channel,
-                                             cluster_size=cluster_size,
-                                             creator_name=creator_name,
-                                             enable_photon=enable_photon,
-                                             enable_serverless_compute=enable_serverless_compute,
-                                             instance_profile_arn=instance_profile_arn,
-                                             max_num_clusters=max_num_clusters,
-                                             min_num_clusters=min_num_clusters,
-                                             name=name,
-                                             spot_instance_policy=spot_instance_policy,
-                                             tags=tags,
-                                             warehouse_type=warehouse_type)
-        body = request.as_dict()
+        body = {}
+        if auto_stop_mins is not None: body['auto_stop_mins'] = auto_stop_mins
+        if channel is not None: body['channel'] = channel.as_dict()
+        if cluster_size is not None: body['cluster_size'] = cluster_size
+        if creator_name is not None: body['creator_name'] = creator_name
+        if enable_photon is not None: body['enable_photon'] = enable_photon
+        if enable_serverless_compute is not None:
+            body['enable_serverless_compute'] = enable_serverless_compute
+        if instance_profile_arn is not None: body['instance_profile_arn'] = instance_profile_arn
+        if max_num_clusters is not None: body['max_num_clusters'] = max_num_clusters
+        if min_num_clusters is not None: body['min_num_clusters'] = min_num_clusters
+        if name is not None: body['name'] = name
+        if spot_instance_policy is not None: body['spot_instance_policy'] = spot_instance_policy.value
+        if tags is not None: body['tags'] = tags.as_dict()
+        if warehouse_type is not None: body['warehouse_type'] = warehouse_type.value
         op_response = self._api.do('POST', '/api/2.0/sql/warehouses', body=body)
         return Wait(self.wait_get_warehouse_running,
                     response=CreateWarehouseResponse.from_dict(op_response),
@@ -3660,7 +3365,7 @@ class WarehousesAPI:
                            tags=tags,
                            warehouse_type=warehouse_type).result(timeout=timeout)
 
-    def delete(self, id: str, **kwargs):
+    def delete(self, id: str):
         """Delete a warehouse.
         
         Deletes a SQL warehouse.
@@ -3670,29 +3375,26 @@ class WarehousesAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = DeleteWarehouseRequest(id=id)
 
-        self._api.do('DELETE', f'/api/2.0/sql/warehouses/{request.id}')
+        self._api.do('DELETE', f'/api/2.0/sql/warehouses/{id}')
 
-    def edit(self,
-             id: str,
-             *,
-             auto_stop_mins: Optional[int] = None,
-             channel: Optional[Channel] = None,
-             cluster_size: Optional[str] = None,
-             creator_name: Optional[str] = None,
-             enable_photon: Optional[bool] = None,
-             enable_serverless_compute: Optional[bool] = None,
-             instance_profile_arn: Optional[str] = None,
-             max_num_clusters: Optional[int] = None,
-             min_num_clusters: Optional[int] = None,
-             name: Optional[str] = None,
-             spot_instance_policy: Optional[SpotInstancePolicy] = None,
-             tags: Optional[EndpointTags] = None,
-             warehouse_type: Optional[EditWarehouseRequestWarehouseType] = None,
-             **kwargs) -> Wait[GetWarehouseResponse]:
+    def edit(
+            self,
+            id: str,
+            *,
+            auto_stop_mins: Optional[int] = None,
+            channel: Optional[Channel] = None,
+            cluster_size: Optional[str] = None,
+            creator_name: Optional[str] = None,
+            enable_photon: Optional[bool] = None,
+            enable_serverless_compute: Optional[bool] = None,
+            instance_profile_arn: Optional[str] = None,
+            max_num_clusters: Optional[int] = None,
+            min_num_clusters: Optional[int] = None,
+            name: Optional[str] = None,
+            spot_instance_policy: Optional[SpotInstancePolicy] = None,
+            tags: Optional[EndpointTags] = None,
+            warehouse_type: Optional[EditWarehouseRequestWarehouseType] = None) -> Wait[GetWarehouseResponse]:
         """Update a warehouse.
         
         Updates the configuration for a SQL warehouse.
@@ -3758,25 +3460,23 @@ class WarehousesAPI:
           Long-running operation waiter for :class:`GetWarehouseResponse`.
           See :method:wait_get_warehouse_running for more details.
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = EditWarehouseRequest(auto_stop_mins=auto_stop_mins,
-                                           channel=channel,
-                                           cluster_size=cluster_size,
-                                           creator_name=creator_name,
-                                           enable_photon=enable_photon,
-                                           enable_serverless_compute=enable_serverless_compute,
-                                           id=id,
-                                           instance_profile_arn=instance_profile_arn,
-                                           max_num_clusters=max_num_clusters,
-                                           min_num_clusters=min_num_clusters,
-                                           name=name,
-                                           spot_instance_policy=spot_instance_policy,
-                                           tags=tags,
-                                           warehouse_type=warehouse_type)
-        body = request.as_dict()
-        self._api.do('POST', f'/api/2.0/sql/warehouses/{request.id}/edit', body=body)
-        return Wait(self.wait_get_warehouse_running, id=request.id)
+        body = {}
+        if auto_stop_mins is not None: body['auto_stop_mins'] = auto_stop_mins
+        if channel is not None: body['channel'] = channel.as_dict()
+        if cluster_size is not None: body['cluster_size'] = cluster_size
+        if creator_name is not None: body['creator_name'] = creator_name
+        if enable_photon is not None: body['enable_photon'] = enable_photon
+        if enable_serverless_compute is not None:
+            body['enable_serverless_compute'] = enable_serverless_compute
+        if instance_profile_arn is not None: body['instance_profile_arn'] = instance_profile_arn
+        if max_num_clusters is not None: body['max_num_clusters'] = max_num_clusters
+        if min_num_clusters is not None: body['min_num_clusters'] = min_num_clusters
+        if name is not None: body['name'] = name
+        if spot_instance_policy is not None: body['spot_instance_policy'] = spot_instance_policy.value
+        if tags is not None: body['tags'] = tags.as_dict()
+        if warehouse_type is not None: body['warehouse_type'] = warehouse_type.value
+        self._api.do('POST', f'/api/2.0/sql/warehouses/{id}/edit', body=body)
+        return Wait(self.wait_get_warehouse_running, id=id)
 
     def edit_and_wait(
         self,
@@ -3812,7 +3512,7 @@ class WarehousesAPI:
                          tags=tags,
                          warehouse_type=warehouse_type).result(timeout=timeout)
 
-    def get(self, id: str, **kwargs) -> GetWarehouseResponse:
+    def get(self, id: str) -> GetWarehouseResponse:
         """Get warehouse info.
         
         Gets the information for a single SQL warehouse.
@@ -3822,11 +3522,8 @@ class WarehousesAPI:
         
         :returns: :class:`GetWarehouseResponse`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = GetWarehouseRequest(id=id)
 
-        json = self._api.do('GET', f'/api/2.0/sql/warehouses/{request.id}')
+        json = self._api.do('GET', f'/api/2.0/sql/warehouses/{id}')
         return GetWarehouseResponse.from_dict(json)
 
     def get_workspace_warehouse_config(self) -> GetWorkspaceWarehouseConfigResponse:
@@ -3840,7 +3537,7 @@ class WarehousesAPI:
         json = self._api.do('GET', '/api/2.0/sql/config/warehouses')
         return GetWorkspaceWarehouseConfigResponse.from_dict(json)
 
-    def list(self, *, run_as_user_id: Optional[int] = None, **kwargs) -> Iterator[EndpointInfo]:
+    def list(self, *, run_as_user_id: Optional[int] = None) -> Iterator[EndpointInfo]:
         """List warehouses.
         
         Lists all SQL warehouses that a user has manager permissions on.
@@ -3851,12 +3548,9 @@ class WarehousesAPI:
         
         :returns: Iterator over :class:`EndpointInfo`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = ListWarehousesRequest(run_as_user_id=run_as_user_id)
 
         query = {}
-        if run_as_user_id: query['run_as_user_id'] = request.run_as_user_id
+        if run_as_user_id is not None: query['run_as_user_id'] = run_as_user_id
 
         json = self._api.do('GET', '/api/2.0/sql/warehouses', query=query)
         return [EndpointInfo.from_dict(v) for v in json.get('warehouses', [])]
@@ -3872,8 +3566,7 @@ class WarehousesAPI:
             google_service_account: Optional[str] = None,
             instance_profile_arn: Optional[str] = None,
             security_policy: Optional[SetWorkspaceWarehouseConfigRequestSecurityPolicy] = None,
-            sql_configuration_parameters: Optional[RepeatedEndpointConfPairs] = None,
-            **kwargs):
+            sql_configuration_parameters: Optional[RepeatedEndpointConfPairs] = None):
         """Set the workspace configuration.
         
         Sets the workspace level configuration that is shared by all SQL warehouses in a workspace.
@@ -3903,22 +3596,22 @@ class WarehousesAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = SetWorkspaceWarehouseConfigRequest(
-                channel=channel,
-                config_param=config_param,
-                data_access_config=data_access_config,
-                enabled_warehouse_types=enabled_warehouse_types,
-                global_param=global_param,
-                google_service_account=google_service_account,
-                instance_profile_arn=instance_profile_arn,
-                security_policy=security_policy,
-                sql_configuration_parameters=sql_configuration_parameters)
-        body = request.as_dict()
+        body = {}
+        if channel is not None: body['channel'] = channel.as_dict()
+        if config_param is not None: body['config_param'] = config_param.as_dict()
+        if data_access_config is not None:
+            body['data_access_config'] = [v.as_dict() for v in data_access_config]
+        if enabled_warehouse_types is not None:
+            body['enabled_warehouse_types'] = [v.as_dict() for v in enabled_warehouse_types]
+        if global_param is not None: body['global_param'] = global_param.as_dict()
+        if google_service_account is not None: body['google_service_account'] = google_service_account
+        if instance_profile_arn is not None: body['instance_profile_arn'] = instance_profile_arn
+        if security_policy is not None: body['security_policy'] = security_policy.value
+        if sql_configuration_parameters is not None:
+            body['sql_configuration_parameters'] = sql_configuration_parameters.as_dict()
         self._api.do('PUT', '/api/2.0/sql/config/warehouses', body=body)
 
-    def start(self, id: str, **kwargs) -> Wait[GetWarehouseResponse]:
+    def start(self, id: str) -> Wait[GetWarehouseResponse]:
         """Start a warehouse.
         
         Starts a SQL warehouse.
@@ -3930,17 +3623,14 @@ class WarehousesAPI:
           Long-running operation waiter for :class:`GetWarehouseResponse`.
           See :method:wait_get_warehouse_running for more details.
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = StartRequest(id=id)
 
-        self._api.do('POST', f'/api/2.0/sql/warehouses/{request.id}/start')
-        return Wait(self.wait_get_warehouse_running, id=request.id)
+        self._api.do('POST', f'/api/2.0/sql/warehouses/{id}/start')
+        return Wait(self.wait_get_warehouse_running, id=id)
 
     def start_and_wait(self, id: str, timeout=timedelta(minutes=20)) -> GetWarehouseResponse:
         return self.start(id=id).result(timeout=timeout)
 
-    def stop(self, id: str, **kwargs) -> Wait[GetWarehouseResponse]:
+    def stop(self, id: str) -> Wait[GetWarehouseResponse]:
         """Stop a warehouse.
         
         Stops a SQL warehouse.
@@ -3952,12 +3642,9 @@ class WarehousesAPI:
           Long-running operation waiter for :class:`GetWarehouseResponse`.
           See :method:wait_get_warehouse_stopped for more details.
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = StopRequest(id=id)
 
-        self._api.do('POST', f'/api/2.0/sql/warehouses/{request.id}/stop')
-        return Wait(self.wait_get_warehouse_stopped, id=request.id)
+        self._api.do('POST', f'/api/2.0/sql/warehouses/{id}/stop')
+        return Wait(self.wait_get_warehouse_stopped, id=id)
 
     def stop_and_wait(self, id: str, timeout=timedelta(minutes=20)) -> GetWarehouseResponse:
         return self.stop(id=id).result(timeout=timeout)

--- a/databricks/sdk/service/workspace.py
+++ b/databricks/sdk/service/workspace.py
@@ -192,20 +192,6 @@ class DeleteAcl:
 
 
 @dataclass
-class DeleteGitCredentialRequest:
-    """Delete a credential"""
-
-    credential_id: int
-
-
-@dataclass
-class DeleteRepoRequest:
-    """Delete a repo"""
-
-    repo_id: int
-
-
-@dataclass
 class DeleteScope:
     scope: str
 
@@ -245,14 +231,6 @@ class ExportFormat(Enum):
 
 
 @dataclass
-class ExportRequest:
-    """Export a workspace object"""
-
-    path: str
-    format: Optional['ExportFormat'] = None
-
-
-@dataclass
 class ExportResponse:
     content: Optional[str] = None
 
@@ -267,14 +245,6 @@ class ExportResponse:
 
 
 @dataclass
-class GetAclRequest:
-    """Get secret ACL details"""
-
-    scope: str
-    principal: str
-
-
-@dataclass
 class GetCredentialsResponse:
     credentials: Optional['List[CredentialInfo]'] = None
 
@@ -286,27 +256,6 @@ class GetCredentialsResponse:
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'GetCredentialsResponse':
         return cls(credentials=_repeated(d, 'credentials', CredentialInfo))
-
-
-@dataclass
-class GetGitCredentialRequest:
-    """Get a credential entry"""
-
-    credential_id: int
-
-
-@dataclass
-class GetRepoRequest:
-    """Get a repo"""
-
-    repo_id: int
-
-
-@dataclass
-class GetStatusRequest:
-    """Get status"""
-
-    path: str
 
 
 @dataclass
@@ -365,13 +314,6 @@ class Language(Enum):
 
 
 @dataclass
-class ListAclsRequest:
-    """Lists ACLs"""
-
-    scope: str
-
-
-@dataclass
 class ListAclsResponse:
     items: Optional['List[AclItem]'] = None
 
@@ -383,14 +325,6 @@ class ListAclsResponse:
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'ListAclsResponse':
         return cls(items=_repeated(d, 'items', AclItem))
-
-
-@dataclass
-class ListReposRequest:
-    """Get repos"""
-
-    next_page_token: Optional[str] = None
-    path_prefix: Optional[str] = None
 
 
 @dataclass
@@ -438,13 +372,6 @@ class ListScopesResponse:
 
 
 @dataclass
-class ListSecretsRequest:
-    """List secret keys"""
-
-    scope: str
-
-
-@dataclass
 class ListSecretsResponse:
     secrets: Optional['List[SecretMetadata]'] = None
 
@@ -456,14 +383,6 @@ class ListSecretsResponse:
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'ListSecretsResponse':
         return cls(secrets=_repeated(d, 'secrets', SecretMetadata))
-
-
-@dataclass
-class ListWorkspaceRequest:
-    """List contents"""
-
-    path: str
-    notebooks_modified_after: Optional[int] = None
 
 
 @dataclass
@@ -731,8 +650,7 @@ class GitCredentialsAPI:
                git_provider: str,
                *,
                git_username: Optional[str] = None,
-               personal_access_token: Optional[str] = None,
-               **kwargs) -> CreateCredentialsResponse:
+               personal_access_token: Optional[str] = None) -> CreateCredentialsResponse:
         """Create a credential entry.
         
         Creates a Git credential entry for the user. Only one Git credential per user is supported, so any
@@ -750,17 +668,15 @@ class GitCredentialsAPI:
         
         :returns: :class:`CreateCredentialsResponse`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = CreateCredentials(git_provider=git_provider,
-                                        git_username=git_username,
-                                        personal_access_token=personal_access_token)
-        body = request.as_dict()
+        body = {}
+        if git_provider is not None: body['git_provider'] = git_provider
+        if git_username is not None: body['git_username'] = git_username
+        if personal_access_token is not None: body['personal_access_token'] = personal_access_token
 
         json = self._api.do('POST', '/api/2.0/git-credentials', body=body)
         return CreateCredentialsResponse.from_dict(json)
 
-    def delete(self, credential_id: int, **kwargs):
+    def delete(self, credential_id: int):
         """Delete a credential.
         
         Deletes the specified Git credential.
@@ -770,13 +686,10 @@ class GitCredentialsAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = DeleteGitCredentialRequest(credential_id=credential_id)
 
-        self._api.do('DELETE', f'/api/2.0/git-credentials/{request.credential_id}')
+        self._api.do('DELETE', f'/api/2.0/git-credentials/{credential_id}')
 
-    def get(self, credential_id: int, **kwargs) -> CredentialInfo:
+    def get(self, credential_id: int) -> CredentialInfo:
         """Get a credential entry.
         
         Gets the Git credential with the specified credential ID.
@@ -786,11 +699,8 @@ class GitCredentialsAPI:
         
         :returns: :class:`CredentialInfo`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = GetGitCredentialRequest(credential_id=credential_id)
 
-        json = self._api.do('GET', f'/api/2.0/git-credentials/{request.credential_id}')
+        json = self._api.do('GET', f'/api/2.0/git-credentials/{credential_id}')
         return CredentialInfo.from_dict(json)
 
     def list(self) -> Iterator[CredentialInfo]:
@@ -809,8 +719,7 @@ class GitCredentialsAPI:
                *,
                git_provider: Optional[str] = None,
                git_username: Optional[str] = None,
-               personal_access_token: Optional[str] = None,
-               **kwargs):
+               personal_access_token: Optional[str] = None):
         """Update a credential.
         
         Updates the specified Git credential.
@@ -828,14 +737,11 @@ class GitCredentialsAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = UpdateCredentials(credential_id=credential_id,
-                                        git_provider=git_provider,
-                                        git_username=git_username,
-                                        personal_access_token=personal_access_token)
-        body = request.as_dict()
-        self._api.do('PATCH', f'/api/2.0/git-credentials/{request.credential_id}', body=body)
+        body = {}
+        if git_provider is not None: body['git_provider'] = git_provider
+        if git_username is not None: body['git_username'] = git_username
+        if personal_access_token is not None: body['personal_access_token'] = personal_access_token
+        self._api.do('PATCH', f'/api/2.0/git-credentials/{credential_id}', body=body)
 
 
 class ReposAPI:
@@ -857,8 +763,7 @@ class ReposAPI:
                provider: str,
                *,
                path: Optional[str] = None,
-               sparse_checkout: Optional[SparseCheckout] = None,
-               **kwargs) -> RepoInfo:
+               sparse_checkout: Optional[SparseCheckout] = None) -> RepoInfo:
         """Create a repo.
         
         Creates a repo in the workspace and links it to the remote Git repo specified. Note that repos created
@@ -878,15 +783,16 @@ class ReposAPI:
         
         :returns: :class:`RepoInfo`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = CreateRepo(path=path, provider=provider, sparse_checkout=sparse_checkout, url=url)
-        body = request.as_dict()
+        body = {}
+        if path is not None: body['path'] = path
+        if provider is not None: body['provider'] = provider
+        if sparse_checkout is not None: body['sparse_checkout'] = sparse_checkout.as_dict()
+        if url is not None: body['url'] = url
 
         json = self._api.do('POST', '/api/2.0/repos', body=body)
         return RepoInfo.from_dict(json)
 
-    def delete(self, repo_id: int, **kwargs):
+    def delete(self, repo_id: int):
         """Delete a repo.
         
         Deletes the specified repo.
@@ -896,13 +802,10 @@ class ReposAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = DeleteRepoRequest(repo_id=repo_id)
 
-        self._api.do('DELETE', f'/api/2.0/repos/{request.repo_id}')
+        self._api.do('DELETE', f'/api/2.0/repos/{repo_id}')
 
-    def get(self, repo_id: int, **kwargs) -> RepoInfo:
+    def get(self, repo_id: int) -> RepoInfo:
         """Get a repo.
         
         Returns the repo with the given repo ID.
@@ -912,18 +815,14 @@ class ReposAPI:
         
         :returns: :class:`RepoInfo`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = GetRepoRequest(repo_id=repo_id)
 
-        json = self._api.do('GET', f'/api/2.0/repos/{request.repo_id}')
+        json = self._api.do('GET', f'/api/2.0/repos/{repo_id}')
         return RepoInfo.from_dict(json)
 
     def list(self,
              *,
              next_page_token: Optional[str] = None,
-             path_prefix: Optional[str] = None,
-             **kwargs) -> Iterator[RepoInfo]:
+             path_prefix: Optional[str] = None) -> Iterator[RepoInfo]:
         """Get repos.
         
         Returns repos that the calling user has Manage permissions on. Results are paginated with each page
@@ -937,13 +836,10 @@ class ReposAPI:
         
         :returns: Iterator over :class:`RepoInfo`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = ListReposRequest(next_page_token=next_page_token, path_prefix=path_prefix)
 
         query = {}
-        if next_page_token: query['next_page_token'] = request.next_page_token
-        if path_prefix: query['path_prefix'] = request.path_prefix
+        if next_page_token is not None: query['next_page_token'] = next_page_token
+        if path_prefix is not None: query['path_prefix'] = path_prefix
 
         while True:
             json = self._api.do('GET', '/api/2.0/repos', query=query)
@@ -960,8 +856,7 @@ class ReposAPI:
                *,
                branch: Optional[str] = None,
                sparse_checkout: Optional[SparseCheckoutUpdate] = None,
-               tag: Optional[str] = None,
-               **kwargs):
+               tag: Optional[str] = None):
         """Update a repo.
         
         Updates the repo to a different branch or tag, or updates the repo to the latest commit on the same
@@ -981,11 +876,11 @@ class ReposAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = UpdateRepo(branch=branch, repo_id=repo_id, sparse_checkout=sparse_checkout, tag=tag)
-        body = request.as_dict()
-        self._api.do('PATCH', f'/api/2.0/repos/{request.repo_id}', body=body)
+        body = {}
+        if branch is not None: body['branch'] = branch
+        if sparse_checkout is not None: body['sparse_checkout'] = sparse_checkout.as_dict()
+        if tag is not None: body['tag'] = tag
+        self._api.do('PATCH', f'/api/2.0/repos/{repo_id}', body=body)
 
 
 class SecretsAPI:
@@ -1007,8 +902,7 @@ class SecretsAPI:
                      *,
                      backend_azure_keyvault: Optional[AzureKeyVaultSecretScopeMetadata] = None,
                      initial_manage_principal: Optional[str] = None,
-                     scope_backend_type: Optional[ScopeBackendType] = None,
-                     **kwargs):
+                     scope_backend_type: Optional[ScopeBackendType] = None):
         """Create a new secret scope.
         
         The scope name must consist of alphanumeric characters, dashes, underscores, and periods, and may not
@@ -1025,16 +919,15 @@ class SecretsAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = CreateScope(backend_azure_keyvault=backend_azure_keyvault,
-                                  initial_manage_principal=initial_manage_principal,
-                                  scope=scope,
-                                  scope_backend_type=scope_backend_type)
-        body = request.as_dict()
+        body = {}
+        if backend_azure_keyvault is not None:
+            body['backend_azure_keyvault'] = backend_azure_keyvault.as_dict()
+        if initial_manage_principal is not None: body['initial_manage_principal'] = initial_manage_principal
+        if scope is not None: body['scope'] = scope
+        if scope_backend_type is not None: body['scope_backend_type'] = scope_backend_type.value
         self._api.do('POST', '/api/2.0/secrets/scopes/create', body=body)
 
-    def delete_acl(self, scope: str, principal: str, **kwargs):
+    def delete_acl(self, scope: str, principal: str):
         """Delete an ACL.
         
         Deletes the given ACL on the given scope.
@@ -1050,13 +943,12 @@ class SecretsAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = DeleteAcl(principal=principal, scope=scope)
-        body = request.as_dict()
+        body = {}
+        if principal is not None: body['principal'] = principal
+        if scope is not None: body['scope'] = scope
         self._api.do('POST', '/api/2.0/secrets/acls/delete', body=body)
 
-    def delete_scope(self, scope: str, **kwargs):
+    def delete_scope(self, scope: str):
         """Delete a secret scope.
         
         Deletes a secret scope.
@@ -1069,13 +961,11 @@ class SecretsAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = DeleteScope(scope=scope)
-        body = request.as_dict()
+        body = {}
+        if scope is not None: body['scope'] = scope
         self._api.do('POST', '/api/2.0/secrets/scopes/delete', body=body)
 
-    def delete_secret(self, scope: str, key: str, **kwargs):
+    def delete_secret(self, scope: str, key: str):
         """Delete a secret.
         
         Deletes the secret stored in this secret scope. You must have `WRITE` or `MANAGE` permission on the
@@ -1091,13 +981,12 @@ class SecretsAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = DeleteSecret(key=key, scope=scope)
-        body = request.as_dict()
+        body = {}
+        if key is not None: body['key'] = key
+        if scope is not None: body['scope'] = scope
         self._api.do('POST', '/api/2.0/secrets/delete', body=body)
 
-    def get_acl(self, scope: str, principal: str, **kwargs) -> AclItem:
+    def get_acl(self, scope: str, principal: str) -> AclItem:
         """Get secret ACL details.
         
         Gets the details about the given ACL, such as the group and permission. Users must have the `MANAGE`
@@ -1113,18 +1002,15 @@ class SecretsAPI:
         
         :returns: :class:`AclItem`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = GetAclRequest(principal=principal, scope=scope)
 
         query = {}
-        if principal: query['principal'] = request.principal
-        if scope: query['scope'] = request.scope
+        if principal is not None: query['principal'] = principal
+        if scope is not None: query['scope'] = scope
 
         json = self._api.do('GET', '/api/2.0/secrets/acls/get', query=query)
         return AclItem.from_dict(json)
 
-    def list_acls(self, scope: str, **kwargs) -> Iterator[AclItem]:
+    def list_acls(self, scope: str) -> Iterator[AclItem]:
         """Lists ACLs.
         
         List the ACLs for a given secret scope. Users must have the `MANAGE` permission to invoke this API.
@@ -1137,12 +1023,9 @@ class SecretsAPI:
         
         :returns: Iterator over :class:`AclItem`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = ListAclsRequest(scope=scope)
 
         query = {}
-        if scope: query['scope'] = request.scope
+        if scope is not None: query['scope'] = scope
 
         json = self._api.do('GET', '/api/2.0/secrets/acls/list', query=query)
         return [AclItem.from_dict(v) for v in json.get('items', [])]
@@ -1160,7 +1043,7 @@ class SecretsAPI:
         json = self._api.do('GET', '/api/2.0/secrets/scopes/list')
         return [SecretScope.from_dict(v) for v in json.get('scopes', [])]
 
-    def list_secrets(self, scope: str, **kwargs) -> Iterator[SecretMetadata]:
+    def list_secrets(self, scope: str) -> Iterator[SecretMetadata]:
         """List secret keys.
         
         Lists the secret keys that are stored at this scope. This is a metadata-only operation; secret data
@@ -1175,17 +1058,14 @@ class SecretsAPI:
         
         :returns: Iterator over :class:`SecretMetadata`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = ListSecretsRequest(scope=scope)
 
         query = {}
-        if scope: query['scope'] = request.scope
+        if scope is not None: query['scope'] = scope
 
         json = self._api.do('GET', '/api/2.0/secrets/list', query=query)
         return [SecretMetadata.from_dict(v) for v in json.get('secrets', [])]
 
-    def put_acl(self, scope: str, principal: str, permission: AclPermission, **kwargs):
+    def put_acl(self, scope: str, principal: str, permission: AclPermission):
         """Create/update an ACL.
         
         Creates or overwrites the Access Control List (ACL) associated with the given principal (user or
@@ -1222,10 +1102,10 @@ class SecretsAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = PutAcl(permission=permission, principal=principal, scope=scope)
-        body = request.as_dict()
+        body = {}
+        if permission is not None: body['permission'] = permission.value
+        if principal is not None: body['principal'] = principal
+        if scope is not None: body['scope'] = scope
         self._api.do('POST', '/api/2.0/secrets/acls/put', body=body)
 
     def put_secret(self,
@@ -1233,8 +1113,7 @@ class SecretsAPI:
                    key: str,
                    *,
                    bytes_value: Optional[str] = None,
-                   string_value: Optional[str] = None,
-                   **kwargs):
+                   string_value: Optional[str] = None):
         """Add a secret.
         
         Inserts a secret under the provided scope with the given name. If a secret already exists with the
@@ -1264,10 +1143,11 @@ class SecretsAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = PutSecret(bytes_value=bytes_value, key=key, scope=scope, string_value=string_value)
-        body = request.as_dict()
+        body = {}
+        if bytes_value is not None: body['bytes_value'] = bytes_value
+        if key is not None: body['key'] = key
+        if scope is not None: body['scope'] = scope
+        if string_value is not None: body['string_value'] = string_value
         self._api.do('POST', '/api/2.0/secrets/put', body=body)
 
 
@@ -1280,7 +1160,7 @@ class WorkspaceAPI:
     def __init__(self, api_client):
         self._api = api_client
 
-    def delete(self, path: str, *, recursive: Optional[bool] = None, **kwargs):
+    def delete(self, path: str, *, recursive: Optional[bool] = None):
         """Delete a workspace object.
         
         Deletes an object or a directory (and optionally recursively deletes all objects in the directory). *
@@ -1299,13 +1179,12 @@ class WorkspaceAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = Delete(path=path, recursive=recursive)
-        body = request.as_dict()
+        body = {}
+        if path is not None: body['path'] = path
+        if recursive is not None: body['recursive'] = recursive
         self._api.do('POST', '/api/2.0/workspace/delete', body=body)
 
-    def export(self, path: str, *, format: Optional[ExportFormat] = None, **kwargs) -> ExportResponse:
+    def export(self, path: str, *, format: Optional[ExportFormat] = None) -> ExportResponse:
         """Export a workspace object.
         
         Exports an object or the contents of an entire directory.
@@ -1330,18 +1209,15 @@ class WorkspaceAPI:
         
         :returns: :class:`ExportResponse`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = ExportRequest(format=format, path=path)
 
         query = {}
-        if format: query['format'] = request.format.value
-        if path: query['path'] = request.path
+        if format is not None: query['format'] = format.value
+        if path is not None: query['path'] = path
 
         json = self._api.do('GET', '/api/2.0/workspace/export', query=query)
         return ExportResponse.from_dict(json)
 
-    def get_status(self, path: str, **kwargs) -> ObjectInfo:
+    def get_status(self, path: str) -> ObjectInfo:
         """Get status.
         
         Gets the status of an object or a directory. If `path` does not exist, this call returns an error
@@ -1352,12 +1228,9 @@ class WorkspaceAPI:
         
         :returns: :class:`ObjectInfo`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = GetStatusRequest(path=path)
 
         query = {}
-        if path: query['path'] = request.path
+        if path is not None: query['path'] = path
 
         json = self._api.do('GET', '/api/2.0/workspace/get-status', query=query)
         return ObjectInfo.from_dict(json)
@@ -1368,8 +1241,7 @@ class WorkspaceAPI:
                 content: Optional[str] = None,
                 format: Optional[ImportFormat] = None,
                 language: Optional[Language] = None,
-                overwrite: Optional[bool] = None,
-                **kwargs):
+                overwrite: Optional[bool] = None):
         """Import a workspace object.
         
         Imports a workspace object (for example, a notebook or file) or the contents of an entire directory.
@@ -1403,21 +1275,15 @@ class WorkspaceAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = Import(content=content,
-                             format=format,
-                             language=language,
-                             overwrite=overwrite,
-                             path=path)
-        body = request.as_dict()
+        body = {}
+        if content is not None: body['content'] = content
+        if format is not None: body['format'] = format.value
+        if language is not None: body['language'] = language.value
+        if overwrite is not None: body['overwrite'] = overwrite
+        if path is not None: body['path'] = path
         self._api.do('POST', '/api/2.0/workspace/import', body=body)
 
-    def list(self,
-             path: str,
-             *,
-             notebooks_modified_after: Optional[int] = None,
-             **kwargs) -> Iterator[ObjectInfo]:
+    def list(self, path: str, *, notebooks_modified_after: Optional[int] = None) -> Iterator[ObjectInfo]:
         """List contents.
         
         Lists the contents of a directory, or the object if it is not a directory. If the input path does not
@@ -1430,18 +1296,15 @@ class WorkspaceAPI:
         
         :returns: Iterator over :class:`ObjectInfo`
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = ListWorkspaceRequest(notebooks_modified_after=notebooks_modified_after, path=path)
 
         query = {}
-        if notebooks_modified_after: query['notebooks_modified_after'] = request.notebooks_modified_after
-        if path: query['path'] = request.path
+        if notebooks_modified_after is not None: query['notebooks_modified_after'] = notebooks_modified_after
+        if path is not None: query['path'] = path
 
         json = self._api.do('GET', '/api/2.0/workspace/list', query=query)
         return [ObjectInfo.from_dict(v) for v in json.get('objects', [])]
 
-    def mkdirs(self, path: str, **kwargs):
+    def mkdirs(self, path: str):
         """Create a directory.
         
         Creates the specified directory (and necessary parent directories if they do not exist). If there is
@@ -1457,8 +1320,6 @@ class WorkspaceAPI:
         
         
         """
-        request = kwargs.get('request', None)
-        if not request: # request is not given through keyed args
-            request = Mkdirs(path=path)
-        body = request.as_dict()
+        body = {}
+        if path is not None: body['path'] = path
         self._api.do('POST', '/api/2.0/workspace/mkdirs', body=body)

--- a/docs/workspace/permissions.rst
+++ b/docs/workspace/permissions.rst
@@ -86,12 +86,12 @@ Permissions
             
             obj = w.workspace.get_status(path=notebook_path)
             
-            _ = w.permissions.set(request_object_type="notebooks",
-                                  request_object_id="%d" % (obj.object_id),
-                                  access_control_list=[
-                                      iam.AccessControlRequest(group_name=group.display_name,
-                                                               permission_level=iam.PermissionLevel.CAN_RUN)
-                                  ])
+            w.permissions.set(request_object_type="notebooks",
+                              request_object_id="%d" % (obj.object_id),
+                              access_control_list=[
+                                  iam.AccessControlRequest(group_name=group.display_name,
+                                                           permission_level=iam.PermissionLevel.CAN_RUN)
+                              ])
             
             # cleanup
             w.groups.delete(id=group.id)

--- a/examples/permissions/set_generic_permissions.py
+++ b/examples/permissions/set_generic_permissions.py
@@ -11,12 +11,12 @@ group = w.groups.create(display_name=f'sdk-{time.time_ns()}')
 
 obj = w.workspace.get_status(path=notebook_path)
 
-_ = w.permissions.set(request_object_type="notebooks",
-                      request_object_id="%d" % (obj.object_id),
-                      access_control_list=[
-                          iam.AccessControlRequest(group_name=group.display_name,
-                                                   permission_level=iam.PermissionLevel.CAN_RUN)
-                      ])
+w.permissions.set(request_object_type="notebooks",
+                  request_object_id="%d" % (obj.object_id),
+                  access_control_list=[
+                      iam.AccessControlRequest(group_name=group.display_name,
+                                               permission_level=iam.PermissionLevel.CAN_RUN)
+                  ])
 
 # cleanup
 w.groups.delete(id=group.id)

--- a/tests/integration/test_clusters.py
+++ b/tests/integration/test_clusters.py
@@ -35,8 +35,7 @@ def test_create_cluster(w, env_or_skip, random):
                              spark_version=w.clusters.select_spark_version(long_term_support=True),
                              instance_pool_id=env_or_skip('TEST_INSTANCE_POOL_ID'),
                              autotermination_minutes=10,
-                             num_workers=1,
-                             timeout=timedelta(minutes=10))
+                             num_workers=1).result(timeout=timedelta(minutes=10))
     logging.info(f'Created: {info}')
 
 


### PR DESCRIPTION
This PR removes `XxxRequest` classes that are referenced only as requests, effectively removing the undocumented `request=(XxxRequest(foo=1))` API. This will enforce validation on the field names and make error messages more clear.

