### PR TITLE
Changed all occurrences of .execute to .execute_statement

### DIFF
--- a/examples/grants/get_effective_tables.py
+++ b/examples/grants/get_effective_tables.py
@@ -12,7 +12,7 @@ created_catalog = w.catalogs.create(name=f'sdk-{time.time_ns()}')
 
 created_schema = w.schemas.create(name=f'sdk-{time.time_ns()}', catalog_name=created_catalog.name)
 
-_ = w.statement_execution.execute(warehouse_id=os.environ["TEST_DEFAULT_WAREHOUSE_ID"],
+_ = w.statement_execution.execute_statement(warehouse_id=os.environ["TEST_DEFAULT_WAREHOUSE_ID"],
                                   catalog=created_catalog.name,
                                   schema=created_schema.name,
                                   statement="CREATE TABLE %s AS SELECT 2+2 as four" % (table_name)).result()

--- a/examples/grants/update_tables.py
+++ b/examples/grants/update_tables.py
@@ -12,7 +12,7 @@ created_catalog = w.catalogs.create(name=f'sdk-{time.time_ns()}')
 
 created_schema = w.schemas.create(name=f'sdk-{time.time_ns()}', catalog_name=created_catalog.name)
 
-_ = w.statement_execution.execute(warehouse_id=os.environ["TEST_DEFAULT_WAREHOUSE_ID"],
+_ = w.statement_execution.execute_statement(warehouse_id=os.environ["TEST_DEFAULT_WAREHOUSE_ID"],
                                   catalog=created_catalog.name,
                                   schema=created_schema.name,
                                   statement="CREATE TABLE %s AS SELECT 2+2 as four" % (table_name)).result()

--- a/examples/shares/update_shares.py
+++ b/examples/shares/update_shares.py
@@ -12,7 +12,7 @@ created_catalog = w.catalogs.create(name=f'sdk-{time.time_ns()}')
 
 created_schema = w.schemas.create(name=f'sdk-{time.time_ns()}', catalog_name=created_catalog.name)
 
-_ = w.statement_execution.execute(warehouse_id=os.environ["TEST_DEFAULT_WAREHOUSE_ID"],
+_ = w.statement_execution.execute_statement(warehouse_id=os.environ["TEST_DEFAULT_WAREHOUSE_ID"],
                                   catalog=created_catalog.name,
                                   schema=created_schema.name,
                                   statement="CREATE TABLE %s AS SELECT 2+2 as four" % (table_name)).result()

--- a/examples/statement_execution/execute_shares.py
+++ b/examples/statement_execution/execute_shares.py
@@ -11,7 +11,7 @@ created_catalog = w.catalogs.create(name=f'sdk-{time.time_ns()}')
 
 created_schema = w.schemas.create(name=f'sdk-{time.time_ns()}', catalog_name=created_catalog.name)
 
-_ = w.statement_execution.execute(warehouse_id=os.environ["TEST_DEFAULT_WAREHOUSE_ID"],
+_ = w.statement_execution.execute_statement(warehouse_id=os.environ["TEST_DEFAULT_WAREHOUSE_ID"],
                                   catalog=created_catalog.name,
                                   schema=created_schema.name,
                                   statement="CREATE TABLE %s AS SELECT 2+2 as four" % (table_name)).result()

--- a/examples/statement_execution/execute_tables.py
+++ b/examples/statement_execution/execute_tables.py
@@ -11,7 +11,7 @@ created_catalog = w.catalogs.create(name=f'sdk-{time.time_ns()}')
 
 created_schema = w.schemas.create(name=f'sdk-{time.time_ns()}', catalog_name=created_catalog.name)
 
-_ = w.statement_execution.execute(warehouse_id=os.environ["TEST_DEFAULT_WAREHOUSE_ID"],
+_ = w.statement_execution.execute_statement(warehouse_id=os.environ["TEST_DEFAULT_WAREHOUSE_ID"],
                                   catalog=created_catalog.name,
                                   schema=created_schema.name,
                                   statement="CREATE TABLE %s AS SELECT 2+2 as four" % (table_name)).result()

--- a/examples/tables/get_tables.py
+++ b/examples/tables/get_tables.py
@@ -11,7 +11,7 @@ created_catalog = w.catalogs.create(name=f'sdk-{time.time_ns()}')
 
 created_schema = w.schemas.create(name=f'sdk-{time.time_ns()}', catalog_name=created_catalog.name)
 
-_ = w.statement_execution.execute(warehouse_id=os.environ["TEST_DEFAULT_WAREHOUSE_ID"],
+_ = w.statement_execution.execute_statement(warehouse_id=os.environ["TEST_DEFAULT_WAREHOUSE_ID"],
                                   catalog=created_catalog.name,
                                   schema=created_schema.name,
                                   statement="CREATE TABLE %s AS SELECT 2+2 as four" % (table_name)).result()


### PR DESCRIPTION
## Changes
Replaced the .execute calls to the .execute_statement call as present in the StatementExecutionAPI

Replacements have been made in the following files:
- grants/get_effective_tables.py
- shares/update_shares.py
- shares/update_tables.py
- statement_execution/execute_shares.py
- statement_execution/execute_tables.py
- tables/get_tables.py

