### PR TITLE
Fixed OAuth M2M corner case in `WorkspaceClient` where `DATABRICKS_ACCOUNT_ID` is present in the environment

### DIFF
--- a/databricks/sdk/core.py
+++ b/databricks/sdk/core.py
@@ -640,7 +640,7 @@ class Config:
                 return None
             return OidcEndpoints(authorization_endpoint=real_auth_url,
                                  token_endpoint=real_auth_url.replace('/authorize', '/token'))
-        if self.account_id:
+        if self.is_account_client and self.account_id:
             prefix = f'{self.host}/oidc/accounts/{self.account_id}'
             return OidcEndpoints(authorization_endpoint=f'{prefix}/v1/authorize',
                                  token_endpoint=f'{prefix}/v1/token')


### PR DESCRIPTION
## Changes

Also check for account client configuration when resolving OIDC endpoints. Now logic is the same as in Go SDK: https://github.com/databricks/databricks-sdk-go/blame/dd2802a246d8a2ac0689031cc93e15d97b486df8/config/auth_m2m.go#L45-L56

## Tests

Tested on a local change