### PR TITLE
Added `connection_pool_size` configuration property (preview)

### DIFF
--- a/databricks/sdk/core.py
+++ b/databricks/sdk/core.py
@@ -491,8 +491,8 @@ class Config:
     metadata_service_url = ConfigAttribute(env='DATABRICKS_METADATA_SERVICE_URL',
                                            auth='metadata-service',
                                            sensitive=True)
-    connection_pool_size: int = ConfigAttribute()
-    connection_pool_max_size: int = ConfigAttribute()
+    max_connection_pools: int = ConfigAttribute()
+    max_connections_per_pool: int = ConfigAttribute()
 
     def __init__(self,
                  *,
@@ -898,15 +898,15 @@ class ApiClient:
 
         # Number of urllib3 connection pools to cache before discarding the least
         # recently used pool. Python requests default value is 10.
-        pool_connections = cfg.connection_pool_size
+        pool_connections = cfg.max_connection_pools
         if pool_connections is None:
             pool_connections = 20
 
         # The maximum number of connections to save in the pool. Improves performance
         # in multithreaded situations. For now, we're setting it to the same value
         # as connection_pool_size.
-        pool_maxsize = cfg.connection_pool_max_size
-        if cfg.connection_pool_max_size is None:
+        pool_maxsize = cfg.max_connections_per_pool
+        if cfg.max_connections_per_pool is None:
             pool_maxsize = pool_connections
 
         # If pool_block is False, then more connections will are created,

--- a/databricks/sdk/core.py
+++ b/databricks/sdk/core.py
@@ -492,6 +492,7 @@ class Config:
                                            auth='metadata-service',
                                            sensitive=True)
     connection_pool_size: int = ConfigAttribute()
+    connection_pool_max_size: int = ConfigAttribute()
 
     def __init__(self,
                  *,
@@ -904,7 +905,9 @@ class ApiClient:
         # The maximum number of connections to save in the pool. Improves performance
         # in multithreaded situations. For now, we're setting it to the same value
         # as connection_pool_size.
-        pool_maxsize = pool_connections
+        pool_maxsize = cfg.connection_pool_max_size
+        if cfg.connection_pool_max_size is None:
+            pool_maxsize = pool_connections
 
         # If pool_block is False, then more connections will are created,
         # but not saved after the first use. Blocks when no free connections are available.

--- a/databricks/sdk/core.py
+++ b/databricks/sdk/core.py
@@ -18,7 +18,7 @@ from typing import Any, Callable, Dict, Iterable, List, Optional, Union
 
 import requests
 import requests.auth
-from requests.adapters import HTTPAdapter, DEFAULT_POOLSIZE
+from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
 from .azure import ARM_DATABRICKS_RESOURCE_ID, ENVIRONMENTS, AzureEnvironment


### PR DESCRIPTION
We have three things that are configurable from `requests` connection pooling perspective:

* `pool_connections` - Number of urllib3 connection pools to cache before discarding the least recently used pool. Python requests default value is 10. This PR increases it to 20.
* `pool_maxsize` - The maximum number of connections to save in the pool. Improves performance in multithreaded situations. For now, we're setting it to the same value as connection_pool_size.
* `pool_block` - If pool_block is False, then more connections will are created, but not saved after the first use. Block when no free connections are available. urllib3 ensures that no more than pool_maxsize connections are used at a time. Prevents platform from flooding. By default, requests library doesn't block. We start with blocking.

This PR introduces two new configuration properties:
- `connection_pool_size` configuration property, which sets `pool_connections`. Defaults to 20.
- `connection_pool_max_size`, which sets `pool_maxsize`. Defaults to the same value as `connection_pool_size`.
