### PR TITLE
Remove low-level fields from methods that return iterators

### DIFF
--- a/.codegen/service.py.tmpl
+++ b/.codegen/service.py.tmpl
@@ -152,12 +152,11 @@ class {{.Name}}API:{{if .Description}}
     {{end}}
 
     {{range .Methods}}
-    def {{.SnakeName}}{{if .IsNameReserved}}_{{end}}(self{{if .Request}}
-      {{range .Request.RequiredFields}}, {{.SnakeName}}: {{template "type-nq" .Entity}}{{end}}
-      {{if .Request.NonRequiredFields}}, *
-        {{range .Request.NonRequiredFields}}, {{.SnakeName}}: Optional[{{template "type-nq" .Entity}}] = None{{end}}
-      {{- end}}
-    {{- end}}){{template "method-return-type" .}}:
+    def {{.SnakeName}}{{if .IsNameReserved}}_{{end}}(self{{if .ListingRequest -}}
+        {{template "arguments-serialize" .ListingRequest}}
+      {{- else if .Request -}}
+        {{template "arguments-serialize" .Request}}
+      {{- end}}){{template "method-return-type" .}}:
         {{if .Description}}"""{{.Comment "        " 110 | trimSuffix "\"" }}
         {{with .Request}}{{range .RequiredFields}}
         :param {{.SnakeName}}: {{template "type-doc" .Entity}}{{if .Description}}
@@ -179,8 +178,10 @@ class {{.Name}}API:{{if .Description}}
           {{template "type-doc" .Response}}
         {{- end}}{{end}}
         """{{end}}
-        {{if .Request -}}
-        {{template "method-serialize" .}}
+        {{if .ListingRequest -}}
+          {{template "method-serialize" .ListingRequest}}
+        {{- else if .Request -}}
+          {{template "method-serialize" .Request}}
         {{- end}}
         {{template "method-call" .}}
 
@@ -193,11 +194,18 @@ class {{.Name}}API:{{if .Description}}
     {{end -}}
 {{- end}}
 
+{{define "arguments-serialize" -}}
+  {{range .RequiredFields}}, {{.SnakeName}}: {{template "type-nq" .Entity}}{{end}}
+  {{if .NonRequiredFields}}, *
+    {{range .NonRequiredFields}}, {{.SnakeName}}: Optional[{{template "type-nq" .Entity}}] = None{{end}}
+  {{- end}}
+{{- end}}
+
 {{define "method-serialize" -}}
-        {{if or .Request.HasJsonField .Request.HasQueryField -}}
-        {{if .Request.HasJsonField}}body = {}{{end}}{{if .Request.HasQueryField}}
+        {{if or .HasJsonField .HasQueryField -}}
+        {{if .HasJsonField}}body = {}{{end}}{{if .HasQueryField}}
         query = {}{{end}}
-        {{- range .Request.Fields}}{{if not .IsPath}}
+        {{- range .Fields}}{{if not .IsPath}}
         if {{.SnakeName}} is not None: {{if .IsQuery}}query{{else}}body{{end}}['{{.Name}}'] = {{template "method-param-bind" .}}{{end}}{{end}}
         {{- end}}
 {{- end}}

--- a/databricks/sdk/service/catalog.py
+++ b/databricks/sdk/service/catalog.py
@@ -1481,6 +1481,16 @@ class ListStorageCredentialsResponse:
 
 
 @dataclass
+class ListSummariesRequest:
+    """List table summaries"""
+
+    catalog_name: str
+    max_results: Optional[int] = None
+    schema_name_pattern: Optional[str] = None
+    table_name_pattern: Optional[str] = None
+
+
+@dataclass
 class ListSystemSchemasResponse:
     schemas: Optional['List[SystemSchemaInfo]'] = None
 
@@ -1509,6 +1519,16 @@ class ListTableSummariesResponse:
     def from_dict(cls, d: Dict[str, any]) -> 'ListTableSummariesResponse':
         return cls(next_page_token=d.get('next_page_token', None),
                    tables=_repeated(d, 'tables', TableSummary))
+
+
+@dataclass
+class ListTablesRequest:
+    """List tables"""
+
+    catalog_name: str
+    schema_name: str
+    include_delta_metadata: Optional[bool] = None
+    max_results: Optional[int] = None
 
 
 @dataclass
@@ -4474,8 +4494,7 @@ class TablesAPI:
              schema_name: str,
              *,
              include_delta_metadata: Optional[bool] = None,
-             max_results: Optional[int] = None,
-             page_token: Optional[str] = None) -> Iterator[TableInfo]:
+             max_results: Optional[int] = None) -> Iterator[TableInfo]:
         """List tables.
         
         Gets an array of all tables for the current metastore under the parent catalog and schema. The caller
@@ -4506,7 +4525,6 @@ class TablesAPI:
         if catalog_name is not None: query['catalog_name'] = catalog_name
         if include_delta_metadata is not None: query['include_delta_metadata'] = include_delta_metadata
         if max_results is not None: query['max_results'] = max_results
-        if page_token is not None: query['page_token'] = page_token
         if schema_name is not None: query['schema_name'] = schema_name
 
         while True:
@@ -4523,7 +4541,6 @@ class TablesAPI:
                        catalog_name: str,
                        *,
                        max_results: Optional[int] = None,
-                       page_token: Optional[str] = None,
                        schema_name_pattern: Optional[str] = None,
                        table_name_pattern: Optional[str] = None) -> Iterator[TableSummary]:
         """List table summaries.
@@ -4556,7 +4573,6 @@ class TablesAPI:
         query = {}
         if catalog_name is not None: query['catalog_name'] = catalog_name
         if max_results is not None: query['max_results'] = max_results
-        if page_token is not None: query['page_token'] = page_token
         if schema_name_pattern is not None: query['schema_name_pattern'] = schema_name_pattern
         if table_name_pattern is not None: query['table_name_pattern'] = table_name_pattern
 

--- a/databricks/sdk/service/compute.py
+++ b/databricks/sdk/service/compute.py
@@ -2793,6 +2793,13 @@ class ListPoliciesResponse:
 
 
 @dataclass
+class ListPolicyFamiliesRequest:
+    """List policy families"""
+
+    max_results: Optional[int] = None
+
+
+@dataclass
 class ListPolicyFamiliesResponse:
     policy_families: 'List[PolicyFamily]'
     next_page_token: Optional[str] = None
@@ -5735,10 +5742,7 @@ class PolicyFamiliesAPI:
         json = self._api.do('GET', f'/api/2.0/policy-families/{policy_family_id}')
         return PolicyFamily.from_dict(json)
 
-    def list(self,
-             *,
-             max_results: Optional[int] = None,
-             page_token: Optional[str] = None) -> Iterator[PolicyFamily]:
+    def list(self, *, max_results: Optional[int] = None) -> Iterator[PolicyFamily]:
         """List policy families.
         
         Retrieve a list of policy families. This API is paginated.
@@ -5753,7 +5757,6 @@ class PolicyFamiliesAPI:
 
         query = {}
         if max_results is not None: query['max_results'] = max_results
-        if page_token is not None: query['page_token'] = page_token
 
         while True:
             json = self._api.do('GET', '/api/2.0/policy-families', query=query)

--- a/databricks/sdk/service/jobs.py
+++ b/databricks/sdk/service/jobs.py
@@ -998,6 +998,15 @@ class JobsHealthRules:
 
 
 @dataclass
+class ListJobsRequest:
+    """List jobs"""
+
+    expand_tasks: Optional[bool] = None
+    name: Optional[str] = None
+    offset: Optional[int] = None
+
+
+@dataclass
 class ListJobsResponse:
     has_more: Optional[bool] = None
     jobs: Optional['List[BaseJob]'] = None
@@ -1018,6 +1027,20 @@ class ListJobsResponse:
                    jobs=_repeated(d, 'jobs', BaseJob),
                    next_page_token=d.get('next_page_token', None),
                    prev_page_token=d.get('prev_page_token', None))
+
+
+@dataclass
+class ListRunsRequest:
+    """List job runs"""
+
+    active_only: Optional[bool] = None
+    completed_only: Optional[bool] = None
+    expand_tasks: Optional[bool] = None
+    job_id: Optional[int] = None
+    offset: Optional[int] = None
+    run_type: Optional['ListRunsRunType'] = None
+    start_time_from: Optional[int] = None
+    start_time_to: Optional[int] = None
 
 
 @dataclass
@@ -3028,10 +3051,8 @@ class JobsAPI:
     def list(self,
              *,
              expand_tasks: Optional[bool] = None,
-             limit: Optional[int] = None,
              name: Optional[str] = None,
-             offset: Optional[int] = None,
-             page_token: Optional[str] = None) -> Iterator[BaseJob]:
+             offset: Optional[int] = None) -> Iterator[BaseJob]:
         """List jobs.
         
         Retrieves a list of jobs.
@@ -3056,10 +3077,8 @@ class JobsAPI:
 
         query = {}
         if expand_tasks is not None: query['expand_tasks'] = expand_tasks
-        if limit is not None: query['limit'] = limit
         if name is not None: query['name'] = name
         if offset is not None: query['offset'] = offset
-        if page_token is not None: query['page_token'] = page_token
 
         while True:
             json = self._api.do('GET', '/api/2.1/jobs/list', query=query)
@@ -3077,9 +3096,7 @@ class JobsAPI:
                   completed_only: Optional[bool] = None,
                   expand_tasks: Optional[bool] = None,
                   job_id: Optional[int] = None,
-                  limit: Optional[int] = None,
                   offset: Optional[int] = None,
-                  page_token: Optional[str] = None,
                   run_type: Optional[ListRunsRunType] = None,
                   start_time_from: Optional[int] = None,
                   start_time_to: Optional[int] = None) -> Iterator[BaseRun]:
@@ -3125,9 +3142,7 @@ class JobsAPI:
         if completed_only is not None: query['completed_only'] = completed_only
         if expand_tasks is not None: query['expand_tasks'] = expand_tasks
         if job_id is not None: query['job_id'] = job_id
-        if limit is not None: query['limit'] = limit
         if offset is not None: query['offset'] = offset
-        if page_token is not None: query['page_token'] = page_token
         if run_type is not None: query['run_type'] = run_type.value
         if start_time_from is not None: query['start_time_from'] = start_time_from
         if start_time_to is not None: query['start_time_to'] = start_time_to

--- a/databricks/sdk/service/ml.py
+++ b/databricks/sdk/service/ml.py
@@ -950,6 +950,15 @@ class JobSpecWithoutSecret:
 
 
 @dataclass
+class ListArtifactsRequest:
+    """Get all artifacts"""
+
+    path: Optional[str] = None
+    run_id: Optional[str] = None
+    run_uuid: Optional[str] = None
+
+
+@dataclass
 class ListArtifactsResponse:
     files: Optional['List[FileInfo]'] = None
     next_page_token: Optional[str] = None
@@ -970,6 +979,14 @@ class ListArtifactsResponse:
 
 
 @dataclass
+class ListExperimentsRequest:
+    """List experiments"""
+
+    max_results: Optional[int] = None
+    view_type: Optional[str] = None
+
+
+@dataclass
 class ListExperimentsResponse:
     experiments: Optional['List[Experiment]'] = None
     next_page_token: Optional[str] = None
@@ -984,6 +1001,13 @@ class ListExperimentsResponse:
     def from_dict(cls, d: Dict[str, any]) -> 'ListExperimentsResponse':
         return cls(experiments=_repeated(d, 'experiments', Experiment),
                    next_page_token=d.get('next_page_token', None))
+
+
+@dataclass
+class ListModelsRequest:
+    """List models"""
+
+    max_results: Optional[int] = None
 
 
 @dataclass
@@ -1032,6 +1056,14 @@ class ListTransitionRequestsResponse:
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'ListTransitionRequestsResponse':
         return cls(requests=_repeated(d, 'requests', Activity))
+
+
+@dataclass
+class ListWebhooksRequest:
+    """List registry webhooks"""
+
+    events: Optional['List[RegistryWebhookEvent]'] = None
+    model_name: Optional[str] = None
 
 
 @dataclass
@@ -1828,7 +1860,6 @@ class SearchExperiments:
     filter: Optional[str] = None
     max_results: Optional[int] = None
     order_by: Optional['List[str]'] = None
-    page_token: Optional[str] = None
     view_type: Optional['SearchExperimentsViewType'] = None
 
     def as_dict(self) -> dict:
@@ -1836,7 +1867,6 @@ class SearchExperiments:
         if self.filter is not None: body['filter'] = self.filter
         if self.max_results is not None: body['max_results'] = self.max_results
         if self.order_by: body['order_by'] = [v for v in self.order_by]
-        if self.page_token is not None: body['page_token'] = self.page_token
         if self.view_type is not None: body['view_type'] = self.view_type.value
         return body
 
@@ -1845,7 +1875,6 @@ class SearchExperiments:
         return cls(filter=d.get('filter', None),
                    max_results=d.get('max_results', None),
                    order_by=d.get('order_by', None),
-                   page_token=d.get('page_token', None),
                    view_type=_enum(d, 'view_type', SearchExperimentsViewType))
 
 
@@ -1876,6 +1905,15 @@ class SearchExperimentsViewType(Enum):
 
 
 @dataclass
+class SearchModelVersionsRequest:
+    """Searches model versions"""
+
+    filter: Optional[str] = None
+    max_results: Optional[int] = None
+    order_by: Optional['List[str]'] = None
+
+
+@dataclass
 class SearchModelVersionsResponse:
     model_versions: Optional['List[ModelVersion]'] = None
     next_page_token: Optional[str] = None
@@ -1890,6 +1928,15 @@ class SearchModelVersionsResponse:
     def from_dict(cls, d: Dict[str, any]) -> 'SearchModelVersionsResponse':
         return cls(model_versions=_repeated(d, 'model_versions', ModelVersion),
                    next_page_token=d.get('next_page_token', None))
+
+
+@dataclass
+class SearchModelsRequest:
+    """Search models"""
+
+    filter: Optional[str] = None
+    max_results: Optional[int] = None
+    order_by: Optional['List[str]'] = None
 
 
 @dataclass
@@ -1915,7 +1962,6 @@ class SearchRuns:
     filter: Optional[str] = None
     max_results: Optional[int] = None
     order_by: Optional['List[str]'] = None
-    page_token: Optional[str] = None
     run_view_type: Optional['SearchRunsRunViewType'] = None
 
     def as_dict(self) -> dict:
@@ -1924,7 +1970,6 @@ class SearchRuns:
         if self.filter is not None: body['filter'] = self.filter
         if self.max_results is not None: body['max_results'] = self.max_results
         if self.order_by: body['order_by'] = [v for v in self.order_by]
-        if self.page_token is not None: body['page_token'] = self.page_token
         if self.run_view_type is not None: body['run_view_type'] = self.run_view_type.value
         return body
 
@@ -1934,7 +1979,6 @@ class SearchRuns:
                    filter=d.get('filter', None),
                    max_results=d.get('max_results', None),
                    order_by=d.get('order_by', None),
-                   page_token=d.get('page_token', None),
                    run_view_type=_enum(d, 'run_view_type', SearchRunsRunViewType))
 
 
@@ -2594,7 +2638,6 @@ class ExperimentsAPI:
 
     def list_artifacts(self,
                        *,
-                       page_token: Optional[str] = None,
                        path: Optional[str] = None,
                        run_id: Optional[str] = None,
                        run_uuid: Optional[str] = None) -> Iterator[FileInfo]:
@@ -2617,7 +2660,6 @@ class ExperimentsAPI:
         """
 
         query = {}
-        if page_token is not None: query['page_token'] = page_token
         if path is not None: query['path'] = path
         if run_id is not None: query['run_id'] = run_id
         if run_uuid is not None: query['run_uuid'] = run_uuid
@@ -2635,7 +2677,6 @@ class ExperimentsAPI:
     def list_experiments(self,
                          *,
                          max_results: Optional[int] = None,
-                         page_token: Optional[str] = None,
                          view_type: Optional[str] = None) -> Iterator[Experiment]:
         """List experiments.
         
@@ -2655,7 +2696,6 @@ class ExperimentsAPI:
 
         query = {}
         if max_results is not None: query['max_results'] = max_results
-        if page_token is not None: query['page_token'] = page_token
         if view_type is not None: query['view_type'] = view_type
 
         while True:
@@ -2873,7 +2913,6 @@ class ExperimentsAPI:
                            filter: Optional[str] = None,
                            max_results: Optional[int] = None,
                            order_by: Optional[List[str]] = None,
-                           page_token: Optional[str] = None,
                            view_type: Optional[SearchExperimentsViewType] = None) -> Iterator[Experiment]:
         """Search experiments.
         
@@ -2898,7 +2937,6 @@ class ExperimentsAPI:
         if filter is not None: body['filter'] = filter
         if max_results is not None: body['max_results'] = max_results
         if order_by is not None: body['order_by'] = [v for v in order_by]
-        if page_token is not None: body['page_token'] = page_token
         if view_type is not None: body['view_type'] = view_type.value
 
         while True:
@@ -2917,7 +2955,6 @@ class ExperimentsAPI:
                     filter: Optional[str] = None,
                     max_results: Optional[int] = None,
                     order_by: Optional[List[str]] = None,
-                    page_token: Optional[str] = None,
                     run_view_type: Optional[SearchRunsRunViewType] = None) -> Iterator[Run]:
         """Search for runs.
         
@@ -2958,7 +2995,6 @@ class ExperimentsAPI:
         if filter is not None: body['filter'] = filter
         if max_results is not None: body['max_results'] = max_results
         if order_by is not None: body['order_by'] = [v for v in order_by]
-        if page_token is not None: body['page_token'] = page_token
         if run_view_type is not None: body['run_view_type'] = run_view_type.value
 
         while True:
@@ -3616,10 +3652,7 @@ class ModelRegistryAPI:
         json = self._api.do('GET', f'/api/2.0/permissions/registered-models/{registered_model_id}')
         return RegisteredModelPermissions.from_dict(json)
 
-    def list_models(self,
-                    *,
-                    max_results: Optional[int] = None,
-                    page_token: Optional[str] = None) -> Iterator[Model]:
+    def list_models(self, *, max_results: Optional[int] = None) -> Iterator[Model]:
         """List models.
         
         Lists all available registered models, up to the limit specified in __max_results__.
@@ -3634,7 +3667,6 @@ class ModelRegistryAPI:
 
         query = {}
         if max_results is not None: query['max_results'] = max_results
-        if page_token is not None: query['page_token'] = page_token
 
         while True:
             json = self._api.do('GET', '/api/2.0/mlflow/registered-models/list', query=query)
@@ -3669,8 +3701,7 @@ class ModelRegistryAPI:
     def list_webhooks(self,
                       *,
                       events: Optional[List[RegistryWebhookEvent]] = None,
-                      model_name: Optional[str] = None,
-                      page_token: Optional[str] = None) -> Iterator[RegistryWebhook]:
+                      model_name: Optional[str] = None) -> Iterator[RegistryWebhook]:
         """List registry webhooks.
         
         **NOTE:** This endpoint is in Public Preview.
@@ -3692,7 +3723,6 @@ class ModelRegistryAPI:
         query = {}
         if events is not None: query['events'] = [v.value for v in events]
         if model_name is not None: query['model_name'] = model_name
-        if page_token is not None: query['page_token'] = page_token
 
         while True:
             json = self._api.do('GET', '/api/2.0/mlflow/registry-webhooks/list', query=query)
@@ -3765,8 +3795,7 @@ class ModelRegistryAPI:
                               *,
                               filter: Optional[str] = None,
                               max_results: Optional[int] = None,
-                              order_by: Optional[List[str]] = None,
-                              page_token: Optional[str] = None) -> Iterator[ModelVersion]:
+                              order_by: Optional[List[str]] = None) -> Iterator[ModelVersion]:
         """Searches model versions.
         
         Searches for specific model versions based on the supplied __filter__.
@@ -3790,7 +3819,6 @@ class ModelRegistryAPI:
         if filter is not None: query['filter'] = filter
         if max_results is not None: query['max_results'] = max_results
         if order_by is not None: query['order_by'] = [v for v in order_by]
-        if page_token is not None: query['page_token'] = page_token
 
         while True:
             json = self._api.do('GET', '/api/2.0/mlflow/model-versions/search', query=query)
@@ -3806,8 +3834,7 @@ class ModelRegistryAPI:
                       *,
                       filter: Optional[str] = None,
                       max_results: Optional[int] = None,
-                      order_by: Optional[List[str]] = None,
-                      page_token: Optional[str] = None) -> Iterator[Model]:
+                      order_by: Optional[List[str]] = None) -> Iterator[Model]:
         """Search models.
         
         Search for registered models based on the specified __filter__.
@@ -3832,7 +3859,6 @@ class ModelRegistryAPI:
         if filter is not None: query['filter'] = filter
         if max_results is not None: query['max_results'] = max_results
         if order_by is not None: query['order_by'] = [v for v in order_by]
-        if page_token is not None: query['page_token'] = page_token
 
         while True:
             json = self._api.do('GET', '/api/2.0/mlflow/registered-models/search', query=query)

--- a/databricks/sdk/service/pipelines.py
+++ b/databricks/sdk/service/pipelines.py
@@ -337,6 +337,16 @@ class GetUpdateResponse:
 
 
 @dataclass
+class ListPipelineEventsRequest:
+    """List pipeline events"""
+
+    pipeline_id: str
+    filter: Optional[str] = None
+    max_results: Optional[int] = None
+    order_by: Optional['List[str]'] = None
+
+
+@dataclass
 class ListPipelineEventsResponse:
     events: Optional['List[PipelineEvent]'] = None
     next_page_token: Optional[str] = None
@@ -354,6 +364,15 @@ class ListPipelineEventsResponse:
         return cls(events=_repeated(d, 'events', PipelineEvent),
                    next_page_token=d.get('next_page_token', None),
                    prev_page_token=d.get('prev_page_token', None))
+
+
+@dataclass
+class ListPipelinesRequest:
+    """List pipelines"""
+
+    filter: Optional[str] = None
+    max_results: Optional[int] = None
+    order_by: Optional['List[str]'] = None
 
 
 @dataclass
@@ -1312,8 +1331,7 @@ class PipelinesAPI:
                              *,
                              filter: Optional[str] = None,
                              max_results: Optional[int] = None,
-                             order_by: Optional[List[str]] = None,
-                             page_token: Optional[str] = None) -> Iterator[PipelineEvent]:
+                             order_by: Optional[List[str]] = None) -> Iterator[PipelineEvent]:
         """List pipeline events.
         
         Retrieves events for a pipeline.
@@ -1345,7 +1363,6 @@ class PipelinesAPI:
         if filter is not None: query['filter'] = filter
         if max_results is not None: query['max_results'] = max_results
         if order_by is not None: query['order_by'] = [v for v in order_by]
-        if page_token is not None: query['page_token'] = page_token
 
         while True:
             json = self._api.do('GET', f'/api/2.0/pipelines/{pipeline_id}/events', query=query)
@@ -1361,8 +1378,7 @@ class PipelinesAPI:
                        *,
                        filter: Optional[str] = None,
                        max_results: Optional[int] = None,
-                       order_by: Optional[List[str]] = None,
-                       page_token: Optional[str] = None) -> Iterator[PipelineStateInfo]:
+                       order_by: Optional[List[str]] = None) -> Iterator[PipelineStateInfo]:
         """List pipelines.
         
         Lists pipelines defined in the Delta Live Tables system.
@@ -1393,7 +1409,6 @@ class PipelinesAPI:
         if filter is not None: query['filter'] = filter
         if max_results is not None: query['max_results'] = max_results
         if order_by is not None: query['order_by'] = [v for v in order_by]
-        if page_token is not None: query['page_token'] = page_token
 
         while True:
             json = self._api.do('GET', '/api/2.0/pipelines', query=query)

--- a/databricks/sdk/service/workspace.py
+++ b/databricks/sdk/service/workspace.py
@@ -356,6 +356,13 @@ class ListAclsResponse:
 
 
 @dataclass
+class ListReposRequest:
+    """Get repos"""
+
+    path_prefix: Optional[str] = None
+
+
+@dataclass
 class ListReposResponse:
     next_page_token: Optional[str] = None
     repos: Optional['List[RepoInfo]'] = None
@@ -1152,10 +1159,7 @@ class ReposAPI:
         json = self._api.do('GET', f'/api/2.0/permissions/repos/{repo_id}')
         return RepoPermissions.from_dict(json)
 
-    def list(self,
-             *,
-             next_page_token: Optional[str] = None,
-             path_prefix: Optional[str] = None) -> Iterator[RepoInfo]:
+    def list(self, *, path_prefix: Optional[str] = None) -> Iterator[RepoInfo]:
         """Get repos.
         
         Returns repos that the calling user has Manage permissions on. Results are paginated with each page
@@ -1171,7 +1175,6 @@ class ReposAPI:
         """
 
         query = {}
-        if next_page_token is not None: query['next_page_token'] = next_page_token
         if path_prefix is not None: query['path_prefix'] = path_prefix
 
         while True:


### PR DESCRIPTION
Follow up to https://github.com/databricks/databricks-sdk-go/pull/569 and https://github.com/databricks/cli/issues/647

TBD: we need a bit better way to tell that request is a request class.
