### PR TITLE
Set necessary headers when authenticating via Azure CLI

### DIFF
--- a/databricks/sdk/azure.py
+++ b/databricks/sdk/azure.py
@@ -29,3 +29,9 @@ ENVIRONMENTS = dict(
                            resource_manager_endpoint="https://management.chinacloudapi.cn/",
                            active_directory_endpoint="https://login.chinacloudapi.cn/"),
 )
+
+
+def add_workspace_id_header(cfg: 'Config', headers: dict[str, str]) -> dict[str, str]:
+    if cfg.azure_workspace_resource_id:
+        headers["X-Databricks-Azure-Workspace-Resource-Id"] = cfg.azure_workspace_resource_id
+    return headers

--- a/databricks/sdk/azure.py
+++ b/databricks/sdk/azure.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from typing import Dict
+
 from .oauth import Refreshable
 
 

--- a/databricks/sdk/azure.py
+++ b/databricks/sdk/azure.py
@@ -1,4 +1,6 @@
 from dataclasses import dataclass
+from typing import Dict
+from .oauth import Refreshable
 
 
 @dataclass
@@ -31,13 +33,13 @@ ENVIRONMENTS = dict(
 )
 
 
-def add_workspace_id_header(cfg: 'Config', headers: dict[str, str]) -> dict[str, str]:
+def add_workspace_id_header(cfg: 'Config', headers: Dict[str, str]) -> Dict[str, str]:
     if cfg.azure_workspace_resource_id:
         headers["X-Databricks-Azure-Workspace-Resource-Id"] = cfg.azure_workspace_resource_id
     return headers
 
 
-def add_sp_management_token(token_source: 'Refreshable', headers: dict[str, str]) -> dict[str, str]:
+def add_sp_management_token(token_source: 'Refreshable', headers: Dict[str, str]) -> Dict[str, str]:
     mgmt_token = token_source.token()
     headers['X-Databricks-Azure-SP-Management-Token'] = mgmt_token.access_token
     return headers

--- a/databricks/sdk/azure.py
+++ b/databricks/sdk/azure.py
@@ -35,3 +35,9 @@ def add_workspace_id_header(cfg: 'Config', headers: dict[str, str]) -> dict[str,
     if cfg.azure_workspace_resource_id:
         headers["X-Databricks-Azure-Workspace-Resource-Id"] = cfg.azure_workspace_resource_id
     return headers
+
+
+def add_sp_management_token(token_source: 'Refreshable', headers: dict[str, str]) -> dict[str, str]:
+    mgmt_token = token_source.token()
+    headers['X-Databricks-Azure-SP-Management-Token'] = mgmt_token.access_token
+    return headers

--- a/databricks/sdk/azure.py
+++ b/databricks/sdk/azure.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from typing import Dict
 
-from .oauth import Refreshable
+from .oauth import TokenSource
 
 
 @dataclass
@@ -34,13 +34,11 @@ ENVIRONMENTS = dict(
 )
 
 
-def add_workspace_id_header(cfg: 'Config', headers: Dict[str, str]) -> Dict[str, str]:
+def add_workspace_id_header(cfg: 'Config', headers: Dict[str, str]):
     if cfg.azure_workspace_resource_id:
         headers["X-Databricks-Azure-Workspace-Resource-Id"] = cfg.azure_workspace_resource_id
-    return headers
 
 
-def add_sp_management_token(token_source: 'Refreshable', headers: Dict[str, str]) -> Dict[str, str]:
+def add_sp_management_token(token_source: 'TokenSource', headers: Dict[str, str]):
     mgmt_token = token_source.token()
     headers['X-Databricks-Azure-SP-Management-Token'] = mgmt_token.access_token
-    return headers

--- a/databricks/sdk/core.py
+++ b/databricks/sdk/core.py
@@ -21,7 +21,7 @@ import requests.auth
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
-from .azure import ARM_DATABRICKS_RESOURCE_ID, ENVIRONMENTS, AzureEnvironment
+from .azure import ARM_DATABRICKS_RESOURCE_ID, ENVIRONMENTS, AzureEnvironment, add_workspace_id_header
 from .oauth import (ClientCredentials, OAuthClient, OidcEndpoints, Refreshable,
                     Token, TokenCache, TokenSource)
 from .version import __version__
@@ -210,9 +210,7 @@ def azure_service_principal(cfg: 'Config') -> HeaderFactory:
             'Authorization': f"Bearer {inner.token().access_token}",
             'X-Databricks-Azure-SP-Management-Token': cloud.token().access_token,
         }
-        if cfg.azure_workspace_resource_id:
-            headers["X-Databricks-Azure-Workspace-Resource-Id"] = cfg.azure_workspace_resource_id
-        return headers
+        return add_workspace_id_header(cfg, headers)
 
     return refreshed_headers
 
@@ -281,7 +279,8 @@ def azure_cli(cfg: 'Config') -> Optional[HeaderFactory]:
 
     def inner() -> Dict[str, str]:
         token = token_source.token()
-        return {'Authorization': f'{token.token_type} {token.access_token}'}
+        headers = {'Authorization': f'{token.token_type} {token.access_token}'}
+        return add_workspace_id_header(cfg, headers)
 
     return inner
 

--- a/databricks/sdk/core.py
+++ b/databricks/sdk/core.py
@@ -21,7 +21,8 @@ import requests.auth
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
-from .azure import ARM_DATABRICKS_RESOURCE_ID, ENVIRONMENTS, AzureEnvironment, add_workspace_id_header, add_sp_management_token
+from .azure import (ARM_DATABRICKS_RESOURCE_ID, ENVIRONMENTS, AzureEnvironment,
+                    add_sp_management_token, add_workspace_id_header)
 from .oauth import (ClientCredentials, OAuthClient, OidcEndpoints, Refreshable,
                     Token, TokenCache, TokenSource)
 from .version import __version__
@@ -206,9 +207,7 @@ def azure_service_principal(cfg: 'Config') -> HeaderFactory:
     cloud = token_source_for(cfg.arm_environment.service_management_endpoint)
 
     def refreshed_headers() -> Dict[str, str]:
-        headers = {
-            'Authorization': f"Bearer {inner.token().access_token}",
-        }
+        headers = {'Authorization': f"Bearer {inner.token().access_token}", }
         add_workspace_id_header(cfg, headers)
         add_sp_management_token(cloud, headers)
         return headers
@@ -278,7 +277,8 @@ def azure_cli(cfg: 'Config') -> Optional[HeaderFactory]:
     try:
         mgmt_token_source.token()
     except Exception:
-        logger.debug(f'User does not have access to {cfg.arm_environment.service_management_endpoint}, continuing')
+        logger.debug(
+            f'User does not have access to {cfg.arm_environment.service_management_endpoint}, continuing')
         mgmt_token_source = None
 
     _ensure_host_present(cfg, lambda resource: AzureCliTokenSource(resource))

--- a/databricks/sdk/core.py
+++ b/databricks/sdk/core.py
@@ -276,9 +276,8 @@ def azure_cli(cfg: 'Config') -> Optional[HeaderFactory]:
         return None
     try:
         mgmt_token_source.token()
-    except Exception:
-        logger.debug(
-            f'User does not have access to {cfg.arm_environment.service_management_endpoint}, continuing')
+    except Exception as e:
+        logger.debug(f'Not including service management token in headers', exc_info=e)
         mgmt_token_source = None
 
     _ensure_host_present(cfg, lambda resource: AzureCliTokenSource(resource))

--- a/tests/test_auth_manual_tests.py
+++ b/tests/test_auth_manual_tests.py
@@ -27,4 +27,3 @@ def test_azure_cli_user_no_management_access(monkeypatch):
     resource_id = '/subscriptions/123/resourceGroups/abc/providers/Microsoft.Databricks/workspaces/abc123'
     cfg = Config(auth_type='azure-cli', host='x', azure_workspace_resource_id=resource_id)
     assert 'X-Databricks-Azure-SP-Management-Token' not in cfg.authenticate()
-

--- a/tests/test_auth_manual_tests.py
+++ b/tests/test_auth_manual_tests.py
@@ -2,6 +2,7 @@ from databricks.sdk.core import Config
 
 from .conftest import __tests__
 
+
 def test_azure_cli_workspace_header_present(monkeypatch):
     monkeypatch.setenv('HOME', __tests__ + '/testdata/azure')
     monkeypatch.setenv('PATH', __tests__ + '/testdata:/bin')
@@ -9,4 +10,21 @@ def test_azure_cli_workspace_header_present(monkeypatch):
     cfg = Config(auth_type='azure-cli', host='x', azure_workspace_resource_id=resource_id)
     assert 'X-Databricks-Azure-Workspace-Resource-Id' in cfg.authenticate()
     assert cfg.authenticate()['X-Databricks-Azure-Workspace-Resource-Id'] == resource_id
+
+
+def test_azure_cli_user_with_management_access(monkeypatch):
+    monkeypatch.setenv('HOME', __tests__ + '/testdata/azure')
+    monkeypatch.setenv('PATH', __tests__ + '/testdata:/bin')
+    resource_id = '/subscriptions/123/resourceGroups/abc/providers/Microsoft.Databricks/workspaces/abc123'
+    cfg = Config(auth_type='azure-cli', host='x', azure_workspace_resource_id=resource_id)
+    assert 'X-Databricks-Azure-SP-Management-Token' in cfg.authenticate()
+
+
+def test_azure_cli_user_no_management_access(monkeypatch):
+    monkeypatch.setenv('HOME', __tests__ + '/testdata/azure')
+    monkeypatch.setenv('PATH', __tests__ + '/testdata:/bin')
+    monkeypatch.setenv('FAIL_IF', 'https://management.core.windows.net/')
+    resource_id = '/subscriptions/123/resourceGroups/abc/providers/Microsoft.Databricks/workspaces/abc123'
+    cfg = Config(auth_type='azure-cli', host='x', azure_workspace_resource_id=resource_id)
+    assert 'X-Databricks-Azure-SP-Management-Token' not in cfg.authenticate()
 

--- a/tests/test_auth_manual_tests.py
+++ b/tests/test_auth_manual_tests.py
@@ -1,0 +1,12 @@
+from databricks.sdk.core import Config
+
+from .conftest import __tests__
+
+def test_azure_cli_workspace_header_present(monkeypatch):
+    monkeypatch.setenv('HOME', __tests__ + '/testdata/azure')
+    monkeypatch.setenv('PATH', __tests__ + '/testdata:/bin')
+    resource_id = '/subscriptions/123/resourceGroups/abc/providers/Microsoft.Databricks/workspaces/abc123'
+    cfg = Config(auth_type='azure-cli', host='x', azure_workspace_resource_id=resource_id)
+    assert 'X-Databricks-Azure-Workspace-Resource-Id' in cfg.authenticate()
+    assert cfg.authenticate()['X-Databricks-Azure-Workspace-Resource-Id'] == resource_id
+

--- a/tests/testdata/az
+++ b/tests/testdata/az
@@ -15,6 +15,13 @@ if [ "corrupt" == "$FAIL" ]; then
     exit
 fi
 
+for arg in "$@"; do
+    if [[ "$arg" == "$FAIL_IF" ]]; then
+        echo "Failed"
+        exit 1
+    fi
+done
+
 # Macos
 EXP="$(/bin/date -v+${EXPIRE:=10S} +'%F %T' 2>/dev/null)"
 if [ -z "${EXP}" ]; then


### PR DESCRIPTION
## Changes
The Python SDK request authentication logic is inconsistent between the Azure login types: for service principal auth, the SDK correctly adds the X-Databricks-Azure-Workspace-Resource-Id when configured, but this is missed for Azure CLI auth.

This PR fixes this by defining the logic to attach this header in a common function that is used by all Azure-specific authentication types.

See https://github.com/databricks/databricks-sdk-go/pull/584 for the same change in Go SDK.

## Tests
- [x] Added a unit test to ensure the header is being set for Azure CLI login

- [ ] `make test` run locally
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

