### PR TITLE
Apply attribute transformer when reading in attributes from the environment

### DIFF
--- a/databricks/sdk/core.py
+++ b/databricks/sdk/core.py
@@ -747,8 +747,7 @@ class Config:
                 continue
             if keyword_args.get(attr.name, None) is None:
                 continue
-            # make sure that args are of correct type
-            self._inner[attr.name] = attr.transform(keyword_args[attr.name])
+            self.__setattr__(attr.name, keyword_args[attr.name])
 
     def _load_from_env(self):
         found = False
@@ -760,7 +759,7 @@ class Config:
             value = os.environ.get(attr.env)
             if not value:
                 continue
-            self._inner[attr.name] = attr.transform(value)
+            self.__setattr__(attr.name, value)
             found = True
         if found:
             logger.debug('Loaded from environment')

--- a/databricks/sdk/core.py
+++ b/databricks/sdk/core.py
@@ -751,7 +751,7 @@ class Config:
 
     def _load_from_env(self):
         found = False
-        for attr in Config.attributes():
+        for attr in self.attributes():
             if not attr.env:
                 continue
             if attr.name in self._inner:

--- a/databricks/sdk/core.py
+++ b/databricks/sdk/core.py
@@ -760,7 +760,7 @@ class Config:
             value = os.environ.get(attr.env)
             if not value:
                 continue
-            self._inner[attr.name] = value
+            self._inner[attr.name] = attr.transform(value)
             found = True
         if found:
             logger.debug('Loaded from environment')

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -11,6 +11,8 @@ from databricks.sdk.core import (Config, CredentialsProvider,
                                  databricks_cli)
 from databricks.sdk.version import __version__
 
+from .conftest import noop_credentials
+
 
 def test_parse_dsn():
     cfg = Config.parse_dsn('databricks://user:pass@foo.databricks.com?retry_timeout_seconds=600')
@@ -218,3 +220,9 @@ def test_config_can_be_subclassed():
 
     with pytest.raises(ValueError): # As opposed to `KeyError`.
         DatabricksConfig()
+
+
+def test_config_parsing_non_string_env_vars(monkeypatch):
+    monkeypatch.setenv('DATABRICKS_DEBUG_TRUNCATE_BYTES', '100')
+    c = Config(host='http://localhost', credentials_provider=noop_credentials)
+    assert c.debug_truncate_bytes == 100


### PR DESCRIPTION
## Changes
Attributes read from the environment are not currently parsed before being stored in the `_inner` field of `Config`. As a result, the type of the attribute will be different depending on whether the attribute is read from the environment or passed to the constructor. This PR changes all argument parsing to use `__setattr__` which converts the argument to the expected type.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

