### PR TITLE
[WIP] Handle GZIP'ed streaming responses

### DIFF
--- a/databricks/sdk/core.py
+++ b/databricks/sdk/core.py
@@ -14,7 +14,7 @@ import sys
 import urllib.parse
 from datetime import datetime
 from json import JSONDecodeError
-from typing import Any, Callable, Dict, Iterable, List, Optional, Union
+from typing import Any, Callable, Dict, Iterable, List, Optional, Union, Generator
 
 import requests
 import requests.auth
@@ -984,7 +984,7 @@ class ApiClient:
            body: dict = None,
            raw: bool = False,
            files=None,
-           data=None) -> dict:
+           data=None) -> dict | Generator[bytes, None, None]:
         headers = {'Accept': 'application/json', 'User-Agent': self._user_agent_base}
         response = self._session.request(method,
                                          f"{self._cfg.host}{path}",
@@ -1002,7 +1002,7 @@ class ApiClient:
                 payload = response.json()
                 raise self._make_nicer_error(status_code=response.status_code, **payload) from None
             if raw:
-                return response.raw
+                return response.raw.stream(None)
             if not len(response.content):
                 return {}
             return response.json()

--- a/databricks/sdk/mixins/files.py
+++ b/databricks/sdk/mixins/files.py
@@ -6,7 +6,7 @@ import shutil
 import sys
 from abc import ABC, abstractmethod
 from types import TracebackType
-from typing import TYPE_CHECKING, AnyStr, BinaryIO, Iterable, Iterator, Type
+from typing import TYPE_CHECKING, AnyStr, BinaryIO, Iterable, Iterator, Type, Generator
 
 from databricks.sdk.core import ApiClient, DatabricksError
 
@@ -407,7 +407,7 @@ class FilesMixin:
     def upload(self, path: str, src: BinaryIO):
         self._api.do('PUT', f'/api/2.0/fs/files{path}', data=src)
 
-    def download(self, path: str) -> BinaryIO:
+    def download(self, path: str) -> Generator[bytes, None, None]:
         return self._api.do('GET', f'/api/2.0/fs/files{path}', raw=True)
 
     def delete(self, path: str):


### PR DESCRIPTION
## Changes
The `raw` field of the `requests.Response` class returns the bytes directly as received on the wire. This is incorrect as it does not take into account the Content-Encoding (e.g. whether response body was gzip'ed, deflate'd, etc.). Using `stream` from `urllib3` handles this, but it also changes the response type to `Generator`.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

