### PR TITLE
[DECO-2229] Handle GZIP'ed streaming responses

### DIFF
--- a/databricks/sdk/core.py
+++ b/databricks/sdk/core.py
@@ -15,8 +15,8 @@ import urllib.parse
 from datetime import datetime
 from json import JSONDecodeError
 from types import TracebackType
-from typing import (Any, BinaryIO, Callable, Dict, Iterable, Iterator,
-                    List, Optional, Type, Union)
+from typing import (Any, BinaryIO, Callable, Dict, Iterable, Iterator, List,
+                    Optional, Type, Union)
 
 import requests
 import requests.auth

--- a/databricks/sdk/core.py
+++ b/databricks/sdk/core.py
@@ -15,7 +15,7 @@ import urllib.parse
 from datetime import datetime
 from json import JSONDecodeError
 from types import TracebackType
-from typing import (Any, AnyStr, BinaryIO, Callable, Dict, Iterable, Iterator,
+from typing import (Any, BinaryIO, Callable, Dict, Iterable, Iterator,
                     List, Optional, Type, Union)
 
 import requests
@@ -1164,10 +1164,10 @@ class StreamingResponse(BinaryIO):
     def readable(self) -> bool:
         return self._content is not None
 
-    def readline(self, __limit: int = ...) -> AnyStr:
+    def readline(self, __limit: int = ...) -> bytes:
         raise NotImplementedError()
 
-    def readlines(self, __hint: int = ...) -> List[AnyStr]:
+    def readlines(self, __hint: int = ...) -> List[bytes]:
         raise NotImplementedError()
 
     def seek(self, __offset: int, __whence: int = ...) -> int:
@@ -1185,16 +1185,16 @@ class StreamingResponse(BinaryIO):
     def writable(self) -> bool:
         return False
 
-    def write(self, s: AnyStr) -> int:
+    def write(self, s: bytes) -> int:
         raise NotImplementedError()
 
-    def writelines(self, lines: Iterable[AnyStr]) -> None:
+    def writelines(self, lines: Iterable[bytes]) -> None:
         raise NotImplementedError()
 
-    def __next__(self) -> AnyStr:
+    def __next__(self) -> bytes:
         return self.read(1)
 
-    def __iter__(self) -> Iterator[AnyStr]:
+    def __iter__(self) -> Iterator[bytes]:
         return self._content
 
     def __exit__(self, t: Union[Type[BaseException], None], value: Union[BaseException, None],

--- a/databricks/sdk/core.py
+++ b/databricks/sdk/core.py
@@ -1125,11 +1125,12 @@ class ApiClient:
 class StreamingResponse(BinaryIO):
     _response: requests.Response
     _buffer: bytes
-    _content: Iterator[any]
+    _content: Iterator[bytes]
 
     def __init__(self, response: requests.Response):
         self._response = response
         self._buffer = b''
+        self._content = None
 
     def __enter__(self) -> BinaryIO:
         self._content = self._response.iter_content()
@@ -1141,7 +1142,9 @@ class StreamingResponse(BinaryIO):
     def isatty(self) -> bool:
         return False
 
-    def read(self, n: int = -1) -> AnyStr:
+    def read(self, n: int = -1) -> bytes:
+        if self._content is None:
+            self._content = self._response.iter_content()
         read_everything = n < 0
         remaining_bytes = n
         res = b''
@@ -1189,7 +1192,7 @@ class StreamingResponse(BinaryIO):
         raise NotImplementedError()
 
     def __next__(self) -> AnyStr:
-        pass
+        return self.read(1)
 
     def __iter__(self) -> Iterator[AnyStr]:
         return self._content

--- a/tests/integration/test_workspace.py
+++ b/tests/integration/test_workspace.py
@@ -21,6 +21,22 @@ def test_workspace_upload_download_notebooks(w, random):
     w.workspace.delete(notebook)
 
 
+def test_workspace_unzip_notebooks(w, random):
+    notebook = f'/Users/{w.current_user.me().user_name}/notebook-{random(12)}.py'
+
+    # Big notebooks can be gzipped during transfer by the API (out of our control)
+    # Creating some large content to trigger this behaviour
+    notebook_content = ('print(1)\n' * 1000).strip('\n')
+
+    w.workspace.upload(notebook, io.BytesIO(bytes(notebook_content, 'utf-8')))
+    with w.workspace.download(notebook) as f:
+        content = f.read()
+        expected_content = bytes(f'# Databricks notebook source\n{notebook_content}', 'utf-8')
+        assert content == expected_content
+
+    w.workspace.delete(notebook)
+
+
 def test_workspace_upload_download_files(w, random):
     py_file = f'/Users/{w.current_user.me().user_name}/file-{random(12)}.py'
 

--- a/tests/integration/test_workspace.py
+++ b/tests/integration/test_workspace.py
@@ -37,6 +37,19 @@ def test_workspace_unzip_notebooks(w, random):
     w.workspace.delete(notebook)
 
 
+def test_workspace_download_connection_closed(w, random):
+    notebook = f'/Users/{w.current_user.me().user_name}/notebook-{random(12)}.py'
+
+    w.workspace.upload(notebook, io.BytesIO(b'print(1)'))
+
+    for n in range(30):
+        with w.workspace.download(notebook) as f:
+            content = f.read()
+            assert content == b'# Databricks notebook source\nprint(1)'
+
+    w.workspace.delete(notebook)
+
+
 def test_workspace_upload_download_files(w, random):
     py_file = f'/Users/{w.current_user.me().user_name}/file-{random(12)}.py'
 


### PR DESCRIPTION
## Changes
Handle GZIP'ed streaming responses by using iter_content method instead of the raw response.

Relevant documentation:
[https://requests.readthedocs.io/en/latest/user/quickstart](https://requests.readthedocs.io/en/latest/user/quickstart/#:~:text=iter_content%20will%20automatically%20decode%20the,they%20were%20returned%2C%20use%20Response)

## Tests

- [X] `make test` run locally
- [X] `make fmt` applied
- [X] relevant integration tests applied: `test_files.py` and `test_workspace.py`