### PR TITLE
Check workspaceUrl explicitly in runtime repl auth

### DIFF
--- a/databricks/sdk/runtime/__init__.py
+++ b/databricks/sdk/runtime/__init__.py
@@ -33,6 +33,9 @@ def init_runtime_repl_auth():
         if ctx is None:
             logger.debug('Empty REPL context returned, skipping runtime auth')
             return None, None
+        if ctx.workspaceUrl is None:
+            logger.debug('Workspace URL is not available, skipping runtime auth')
+            return None, None
         host = f'https://{ctx.workspaceUrl}'
 
         def inner() -> Dict[str, str]:


### PR DESCRIPTION
## Changes
In runtime repl auth, it can be the case that the returned context object is not None, but the workspaceUrl is None. This results in the SDK being configured to use a workspace with URL `https://None`. This check allows runtime native auth to fall back to "legacy" auth.

## Tests
- [x] Built the library, uploaded to a 12.2 LTS cluster in GCP, listed clusters.

- [ ] `make test` run locally
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

