### PR TITLE
Fixed repos.list() example in docs.

### DIFF
--- a/docs/workspace/repos.rst
+++ b/docs/workspace/repos.rst
@@ -129,7 +129,7 @@ Repos
             
             w = WorkspaceClient()
             
-            all = w.repos.list(workspace.ListReposRequest())
+            all = w.repos.list()
 
         Get repos.
         


### PR DESCRIPTION
## Changes
Simple docs change to fix an example that doesn't work: the `repos.list()` function doesn't take any positional arguments.

## Tests
No testing done as this is a docs change.

- [ ] `make test` run locally
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

