### PR TITLE
Added `w.clusters.commands(cluster_id).run('return [1,2,3]')` utility

### DIFF
--- a/databricks/sdk/dbutils.py
+++ b/databricks/sdk/dbutils.py
@@ -1,11 +1,10 @@
 import base64
 import json
 import logging
-import threading
 import typing
 from collections import namedtuple
 
-from .core import ApiClient, Config, DatabricksError
+from .core import ApiClient, Config
 from .mixins import compute as compute_ext
 from .mixins import files as dbfs_ext
 from .service import compute, workspace
@@ -166,15 +165,26 @@ class _SecretsUtil:
 class RemoteDbUtils:
 
     def __init__(self, config: 'Config' = None):
-        self._config = Config() if not config else config
-        self._client = ApiClient(self._config)
-        self._clusters = compute_ext.ClustersExt(self._client)
-        self._commands = compute.CommandExecutionAPI(self._client)
-        self._lock = threading.Lock()
-        self._ctx = None
+        config = Config() if not config else config
+        api_client = ApiClient(config)
+        clusters = compute_ext.ClustersExt(api_client)
+        command_execution = compute.CommandExecutionAPI(api_client)
 
-        self.fs = _FsUtil(dbfs_ext.DbfsExt(self._client), self.__getattr__)
-        self.secrets = _SecretsUtil(workspace.SecretsAPI(self._client))
+        def cluster_id_from_config() -> str:
+            # WorkspaceClient.dbutils is initialized in the constructor,
+            # hence we don't eagerly check for cluster ID. It is completely
+            # normal for WorkspaceClient instances not to use the command
+            # execution proxied calls through a cluster.
+            #
+            # inner function is used not to leak Config as a property and
+            # keep it confined to constructor scope.
+            if not config.cluster_id:
+                raise ValueError(config.wrap_debug_info('cluster_id is required in the configuration'))
+            return config.cluster_id
+
+        self._executor = compute_ext.CommandExecutor(clusters, command_execution, cluster_id_from_config)
+        self.fs = _FsUtil(dbfs_ext.DbfsExt(api_client), self.__getattr__)
+        self.secrets = _SecretsUtil(workspace.SecretsAPI(api_client))
         self._widgets = None
 
     # When we import widget_impl, the init file checks whether user has the
@@ -189,128 +199,33 @@ class RemoteDbUtils:
 
         return self._widgets
 
-    @property
-    def _cluster_id(self) -> str:
-        cluster_id = self._config.cluster_id
-        if not cluster_id:
-            message = 'cluster_id is required in the configuration'
-            raise ValueError(self._config.wrap_debug_info(message))
-        return cluster_id
-
-    def _running_command_context(self) -> compute.ContextStatusResponse:
-        if self._ctx:
-            return self._ctx
-        with self._lock:
-            if self._ctx:
-                return self._ctx
-            self._clusters.ensure_cluster_is_running(self._cluster_id)
-            self._ctx = self._commands.create(cluster_id=self._cluster_id,
-                                              language=compute.Language.PYTHON).result()
-        return self._ctx
-
     def __getattr__(self, util) -> '_ProxyUtil':
-        return _ProxyUtil(command_execution=self._commands,
-                          context_factory=self._running_command_context,
-                          cluster_id=self._cluster_id,
-                          name=util)
+        return _ProxyUtil(self._executor, util)
 
 
 class _ProxyUtil:
     """Enables temporary workaround to call remote in-REPL dbutils without having to re-implement them"""
 
-    def __init__(self, *, command_execution: compute.CommandExecutionAPI,
-                 context_factory: typing.Callable[[],
-                                                  compute.ContextStatusResponse], cluster_id: str, name: str):
-        self._commands = command_execution
-        self._cluster_id = cluster_id
-        self._context_factory = context_factory
+    def __init__(self, executor: compute_ext.CommandExecutor, name: str):
+        self._executor = executor
         self._name = name
 
     def __getattr__(self, method: str) -> '_ProxyCall':
-        return _ProxyCall(command_execution=self._commands,
-                          cluster_id=self._cluster_id,
-                          context_factory=self._context_factory,
-                          util=self._name,
-                          method=method)
-
-
-import html
-import re
+        return _ProxyCall(self._executor, self._name, method)
 
 
 class _ProxyCall:
 
-    def __init__(self, *, command_execution: compute.CommandExecutionAPI,
-                 context_factory: typing.Callable[[], compute.ContextStatusResponse], cluster_id: str,
-                 util: str, method: str):
-        self._commands = command_execution
-        self._cluster_id = cluster_id
-        self._context_factory = context_factory
+    def __init__(self, executor: compute_ext.CommandExecutor, util: str, method: str):
+        self._executor = executor
         self._util = util
         self._method = method
 
-    _out_re = re.compile(r'Out\[[\d\s]+]:\s')
-    _tag_re = re.compile(r'<[^>]*>')
-    _exception_re = re.compile(r'.*Exception:\s+(.*)')
-    _execution_error_re = re.compile(
-        r'ExecutionError: ([\s\S]*)\n(StatusCode=[0-9]*)\n(StatusDescription=.*)\n')
-    _error_message_re = re.compile(r'ErrorMessage=(.+)\n')
-    _ascii_escape_re = re.compile(r'(\x9B|\x1B\[)[0-?]*[ -/]*[@-~]')
-
-    def _is_failed(self, results: compute.Results) -> bool:
-        return results.result_type == compute.ResultType.ERROR
-
-    def _text(self, results: compute.Results) -> str:
-        if results.result_type != compute.ResultType.TEXT:
-            return ''
-        return self._out_re.sub("", str(results.data))
-
-    def _raise_if_failed(self, results: compute.Results):
-        if not self._is_failed(results):
-            return
-        raise DatabricksError(self._error_from_results(results))
-
-    def _error_from_results(self, results: compute.Results):
-        if not self._is_failed(results):
-            return
-        if results.cause:
-            _LOG.debug(f'{self._ascii_escape_re.sub("", results.cause)}')
-
-        summary = self._tag_re.sub("", results.summary)
-        summary = html.unescape(summary)
-
-        exception_matches = self._exception_re.findall(summary)
-        if len(exception_matches) == 1:
-            summary = exception_matches[0].replace("; nested exception is:", "")
-            summary = summary.rstrip(" ")
-            return summary
-
-        execution_error_matches = self._execution_error_re.findall(results.cause)
-        if len(execution_error_matches) == 1:
-            return "\n".join(execution_error_matches[0])
-
-        error_message_matches = self._error_message_re.findall(results.cause)
-        if len(error_message_matches) == 1:
-            return error_message_matches[0]
-
-        return summary
-
     def __call__(self, *args, **kwargs):
         raw = json.dumps((args, kwargs))
-        code = f'''
+        return self._executor.run(f'''
         import json
         (args, kwargs) = json.loads('{raw}')
         result = dbutils.{self._util}.{self._method}(*args, **kwargs)
-        dbutils.notebook.exit(json.dumps(result))
-        '''
-        ctx = self._context_factory()
-        result = self._commands.execute(cluster_id=self._cluster_id,
-                                        language=compute.Language.PYTHON,
-                                        context_id=ctx.id,
-                                        command=code).result()
-        if result.status == compute.CommandStatus.FINISHED:
-            self._raise_if_failed(result.results)
-            raw = result.results.data
-            return json.loads(raw)
-        else:
-            raise Exception(result.results.summary)
+        return result
+        ''')

--- a/databricks/sdk/mixins/compute.py
+++ b/databricks/sdk/mixins/compute.py
@@ -1,15 +1,26 @@
+import ast
 import datetime
+import html
+import json
 import logging
 import re
+import sys
+import threading
 import time
 from dataclasses import dataclass
-from typing import Optional
+from typing import Any, Optional, Callable
 
-from databricks.sdk.core import DatabricksError
+from databricks.sdk.core import Config, DatabricksError
 from databricks.sdk.errors import OperationFailed
 from databricks.sdk.service import compute
 
 _LOG = logging.getLogger('databricks.sdk')
+_out_re = re.compile(r"Out\[[\d\s]+]:\s")
+_tag_re = re.compile(r"<[^>]*>")
+_exception_re = re.compile(r".*Exception:\s+(.*)")
+_execution_error_re = re.compile(r"ExecutionError: ([\s\S]*)\n(StatusCode=[0-9]*)\n(StatusDescription=.*)\n")
+_error_message_re = re.compile(r"ErrorMessage=(.+)\n")
+_ascii_escape_re = re.compile(r"(\x9B|\x1B\[)[0-?]*[ -/]*[@-~]")
 
 
 @dataclass
@@ -132,7 +143,7 @@ class ClustersExt(compute.ClustersAPI):
             return False
         val = compute.CloudProviderNodeStatus
         for st in nt.node_info.status:
-            if st in (val.NotAvailableInRegion, val.NotEnabledOnSubscription):
+            if st in (val.NOT_AVAILABLE_IN_REGION, val.NOT_ENABLED_ON_SUBSCRIPTION):
                 return True
         return False
 
@@ -240,3 +251,216 @@ class ClustersExt(compute.ClustersAPI):
             except OperationFailed as e:
                 _LOG.debug('Operation failed, retrying', exc_info=e)
         raise TimeoutError(f'timed out after {timeout}')
+
+    def commands(self, *,
+                 cluster_id: Optional[str] = None,
+                 language: compute.Language = compute.Language.PYTHON) -> 'CommandExecutor':
+        """Create command executor for a cluster.
+
+        Use `run` method on the result object to issue commands through a cluster and
+        get their results. Upon the first command run the executor would ensure
+        the cluster is running.
+
+        :param cluster_id: str (optional)
+            Databricks Cluster ID to run execute commands on. If no value is provided,
+            `DATABRICKS_CLUSTER_ID` environment variable or `cluster_id` configuration
+            attribute is used to find the cluster. In case no cluster is found, raises
+            the `ValueError`.
+
+        :param language: :class:`databricks.sdk.service.compute.Language`
+            Supported programming language for command execution. Supported values are:
+            - Language.PYTHON
+            - Language.SCALA
+            - Language.SQL
+
+            By default, SDK creates command executors with Language.PYTHON.
+
+        :return: :class:`CommandExecutor`
+        """
+        if not cluster_id:
+            cluster_id = self._api._cfg.cluster_id
+        if not cluster_id:
+            message = 'cluster_id is required either in configuration or ' \
+                      'in DATABRICKS_CLUSTER_ID environment variable'
+            raise ValueError(message)
+        command_execution_api = compute.CommandExecutionAPI(self._api)
+        return CommandExecutor(self, command_execution_api, lambda: cluster_id, language=language)
+
+
+class _ReturnToPrintJson(ast.NodeTransformer):
+
+    def __init__(self) -> None:
+        self._has_json_import = False
+        self._has_print = False
+        self.has_return = False
+
+    @staticmethod
+    def transform(code: str) -> (str, bool):
+        # perform AST transformations for very repetitive tasks, like JSON serialization
+        code_tree = ast.parse(code)
+        transform = _ReturnToPrintJson()
+        new_tree = transform.apply(code_tree)
+        code = ast.unparse(new_tree)
+        return code, transform.has_return
+
+    def apply(self, node: ast.AST) -> ast.AST:
+        node = self.visit(node)
+        if self.has_return and self._has_print:
+            msg = 'cannot have print() call, return .. is converted to print(json.dumps(..))'
+            raise ValueError(msg)
+        if self.has_return and not self._has_json_import:
+            new_import = ast.parse("import json").body[0]
+            node.body.insert(0, new_import)
+        return node
+
+    def visit_Import(self, node: ast.Import) -> ast.Import: # noqa: N802
+        for name in node.names:
+            if "json" != ast.unparse(name):
+                continue
+            self._has_json_import = True
+            break
+        return node
+
+    def visit_Call(self, node: ast.Call): # noqa: N802
+        if ast.unparse(node.func) == 'print':
+            self._has_print = True
+        return node
+
+    def visit_Return(self, node): # noqa: N802
+        value = node.value
+        if not value:
+            # Remove the original return statement
+            return None
+        return_expr = ast.unparse(value)
+        replaced_code = f"print(json.dumps({return_expr}))"
+        print_call = ast.parse(replaced_code).body[0]
+        self.has_return = True
+        return print_call
+
+
+class CommandExecutor:
+
+    def __init__(self,
+                 clusters: ClustersExt,
+                 command_execution: compute.CommandExecutionAPI,
+                 cluster_id_provider: Callable[[], str],
+                 *, language: compute.Language = compute.Language.PYTHON):
+        self._cluster_id_provider = cluster_id_provider
+        self._language = language
+        self._clusters = clusters
+        self._commands = command_execution
+        self._lock = threading.Lock()
+        self._ctx = None
+
+    def run(self, code: str) -> Any:
+        code = self._trim_leading_whitespace(code)
+
+        parse_results_data_as_json = False
+        if self._language == compute.Language.PYTHON:
+            code, parse_results_data_as_json = _ReturnToPrintJson.transform(code)
+
+        ctx = self._running_command_context()
+        cluster_id = self._cluster_id_provider()
+        command_status_response = self._commands.execute(cluster_id=cluster_id,
+                                                         language=self._language,
+                                                         context_id=ctx.id,
+                                                         command=code).result()
+
+        results = command_status_response.results
+        if command_status_response.status == compute.CommandStatus.FINISHED:
+            self._raise_if_failed(results)
+            if results.result_type == compute.ResultType.TEXT and parse_results_data_as_json:
+                try:
+                    # parse json from converted return statement
+                    return json.loads(results.data)
+                except json.JSONDecodeError as e:
+                    _LOG.warning('cannot parse converted return statement. Just returning text', exc_info=e)
+                    return results.data
+            return results.data
+        else:
+            # there might be an opportunity to convert builtin exceptions
+            raise DatabricksError(results.summary)
+
+    def install_notebook_library(self, library: str):
+        return self.run(f"""
+            get_ipython().run_line_magic('pip', 'install {library}')
+            dbutils.library.restartPython()
+            """)
+
+    def _running_command_context(self) -> compute.ContextStatusResponse:
+        if self._ctx:
+            return self._ctx
+        with self._lock:
+            if self._ctx:
+                return self._ctx
+            cluster_id = self._cluster_id_provider()
+            self._clusters.ensure_cluster_is_running(cluster_id)
+            self._ctx = self._commands.create(cluster_id=cluster_id, language=self._language).result()
+        return self._ctx
+
+    @staticmethod
+    def _is_failed(results: compute.Results) -> bool:
+        return results.result_type == compute.ResultType.ERROR
+
+    @staticmethod
+    def _text(results: compute.Results) -> str:
+        if results.result_type != compute.ResultType.TEXT:
+            return ""
+        return _out_re.sub("", str(results.data))
+
+    def _raise_if_failed(self, results: compute.Results):
+        if not self._is_failed(results):
+            return
+        raise DatabricksError(self._error_from_results(results))
+
+    def _error_from_results(self, results: compute.Results) -> str:
+        if not self._is_failed(results):
+            return ''
+        if results.cause:
+            sys.stderr.write(_ascii_escape_re.sub("", results.cause))
+
+        summary = _tag_re.sub("", results.summary)
+        summary = html.unescape(summary)
+
+        exception_matches = _exception_re.findall(summary)
+        if len(exception_matches) == 1:
+            summary = exception_matches[0].replace("; nested exception is:", "")
+            summary = summary.rstrip(" ")
+            return summary
+
+        execution_error_matches = _execution_error_re.findall(results.cause)
+        if len(execution_error_matches) == 1:
+            return "\n".join(execution_error_matches[0])
+
+        error_message_matches = _error_message_re.findall(results.cause)
+        if len(error_message_matches) == 1:
+            return error_message_matches[0]
+
+        return summary
+
+    @staticmethod
+    def _trim_leading_whitespace(command_str: str) -> str:
+        """Removes leading whitespace, so that Python code blocks that
+        are embedded into Python code still could be interpreted properly."""
+        lines = command_str.replace("\t", "    ").split("\n")
+        leading_whitespace = float("inf")
+        if lines[0] == "":
+            lines = lines[1:]
+        for line in lines:
+            pos = 0
+            for char in line:
+                if char in (" ", "\t"):
+                    pos += 1
+                else:
+                    break
+            if pos < leading_whitespace:
+                leading_whitespace = pos
+        new_command = ""
+        for line in lines:
+            if line == "" or line.strip(" \t") == "":
+                continue
+            if len(line) < leading_whitespace:
+                new_command += line + "\n"
+            else:
+                new_command += line[leading_whitespace:] + "\n"
+        return new_command

--- a/tests/integration/test_clusters.py
+++ b/tests/integration/test_clusters.py
@@ -45,3 +45,9 @@ def test_error_unmarshall(w, random):
     err = exc_info.value
     assert 'Cluster __non_existing__ does not exist' in str(err)
     assert 'INVALID_PARAMETER_VALUE' == err.error_code
+
+def test_commands(w, env_or_skip):
+    cluster_id = env_or_skip("TEST_DEFAULT_CLUSTER_ID")
+    ce = w.clusters.commands(cluster_id=cluster_id)
+    rows = ce.run('return spark.sql("SHOW DATABASES").collect()')
+    assert len(rows) > 0

--- a/tests/test_compute_mixins.py
+++ b/tests/test_compute_mixins.py
@@ -1,6 +1,9 @@
 import pytest
 
-from databricks.sdk.mixins.compute import SemVer
+from databricks.sdk.core import ApiClient, Config
+from databricks.sdk.mixins.compute import (ClustersExt, CommandExecutor,
+                                           SemVer, _ReturnToPrintJson)
+from databricks.sdk.service.compute import CommandExecutionAPI
 
 
 @pytest.mark.parametrize("given,expected", [('v0.0.4', SemVer(0, 0, 4)), ('v1.2.3', SemVer(1, 2, 3)),
@@ -29,3 +32,27 @@ def test_sorting_semver():
         SemVer(1, 0, 0),
         SemVer(12, 0, 0),
     ]
+
+
+def test_parse_results_data_as_json():
+    out, has_return = _ReturnToPrintJson.transform("\n".join(["return [{'success': True}]"]))
+    assert out.splitlines() == ['import json', "print(json.dumps([{'success': True}]))"]
+    assert has_return
+
+
+def test_parse_results_data_as_json_with_json_import_existing():
+    out, has_return = _ReturnToPrintJson.transform("\n".join(["import json", "return [{'success': True}]"]))
+    assert out.splitlines() == ['import json', "print(json.dumps([{'success': True}]))"]
+    assert has_return
+
+
+def test_parse_results_data_as_json_with_json_without_return():
+    out, has_return = _ReturnToPrintJson.transform("\n".join(["print(1)"]))
+    assert out.splitlines() == ['print(1)']
+    assert not has_return
+
+
+def test_parse_results_data_as_json_with_json_print_and_return():
+    with pytest.raises(ValueError):
+        _ReturnToPrintJson.transform("\n".join(["print(1)", "return 1"]))
+


### PR DESCRIPTION
## Changes
This PR refactors the wrapper around Command Execution API, which was used by `dbutils.fs.mounts()` and other cluster-proxied `dbutils` into a dedicated mixin.

Usage:

```python
cluster_id = env_or_skip("TEST_DEFAULT_CLUSTER_ID")
ce = w.clusters.commands(cluster_id=cluster_id)
rows = ce.run('return spark.sql("SHOW DATABASES").collect()')
assert len(rows) > 0
```

<img width="765" alt="image" src="https://github.com/databricks/databricks-sdk-py/assets/259697/cdabd212-2a66-4cc6-8b4d-cf3cf315c1f1">

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] `make fmt` applied
- [x] relevant integration tests applied

