### PR TITLE
Fixed redeclared `test_streaming_response_read_partial` test

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -62,7 +62,7 @@ def test_streaming_response_read_partial(config):
     assert response.read(8) == b"some ini"
 
 
-def test_streaming_response_read_partial(config):
+def test_streaming_response_read_full(config):
     content = b"some initial binary data: \x00\x01"
     response = StreamingResponse(DummyResponse([content, content]))
     assert response.read() == content + content


### PR DESCRIPTION
Name the test how it should have been named. Python compiler didn't catch this because of the weak typing.
