### PR TITLE
Add ErrorInfo to API errors

### DIFF
--- a/databricks/sdk/core.py
+++ b/databricks/sdk/core.py
@@ -925,7 +925,7 @@ class DatabricksError(IOError):
                  status: str = None,
                  scimType: str = None,
                  error: str = None,
-                 details: List[dict[str, any]] = [],
+                 details: List[Dict[str, any]] = [],
                  **kwargs):
         if error:
             # API 1.2 has different response format, let's adapt

--- a/databricks/sdk/core.py
+++ b/databricks/sdk/core.py
@@ -925,7 +925,7 @@ class DatabricksError(IOError):
                  status: str = None,
                  scimType: str = None,
                  error: str = None,
-                 details: List[dict] = [],
+                 details: List[dict[str, any]] = [],
                  **kwargs):
         if error:
             # API 1.2 has different response format, let's adapt

--- a/databricks/sdk/core.py
+++ b/databricks/sdk/core.py
@@ -925,7 +925,7 @@ class DatabricksError(IOError):
                  status: str = None,
                  scimType: str = None,
                  error: str = None,
-                 details: List[ErrorDetail] = [],
+                 details: List[dict] = [],
                  **kwargs):
         if error:
             # API 1.2 has different response format, let's adapt

--- a/databricks/sdk/core.py
+++ b/databricks/sdk/core.py
@@ -892,10 +892,6 @@ class Config:
         return cpy
 
 
-# Known ErrorDetail types
-errorInfoType = "type.googleapis.com/google.rpc.ErrorInfo"
-
-
 class ErrorDetail:
 
     def __init__(self,
@@ -919,13 +915,16 @@ class ErrorDetail:
 class DatabricksError(IOError):
     """ Generic error from Databricks REST API """
 
+    # Known ErrorDetail types
+    _error_info_type = "type.googleapis.com/google.rpc.ErrorInfo"
+
     def __init__(self,
                  message: str = None,
                  *,
                  error_code: str = None,
                  detail: str = None,
                  status: str = None,
-                 scimType: str = None,
+                 scim_type: str = None,
                  error: str = None,
                  details: List[ErrorDetail] = [],
                  **kwargs):
@@ -940,7 +939,7 @@ class DatabricksError(IOError):
             else:
                 message = detail
             # add more context from SCIM responses
-            message = f"{scimType} {message}".strip(" ")
+            message = f"{scim_type} {message}".strip(" ")
             error_code = f"SCIM_{status}"
         super().__init__(message if message else error)
         self.error_code = error_code
@@ -948,12 +947,12 @@ class DatabricksError(IOError):
         self.kwargs = kwargs
 
     def get_error_info(self) -> List[ErrorDetail]:
-        return self._get_details_by_type(errorInfoType)
+        return self._get_details_by_type(DatabricksError._error_info_type)
 
-    def _get_details_by_type(self, errorType) -> List[ErrorDetail]:
+    def _get_details_by_type(self, error_type) -> List[ErrorDetail]:
         if self.details == None:
             return []
-        return [detail for detail in self.details if detail.type == errorType]
+        return [detail for detail in self.details if detail.type == error_type]
 
 
 class ApiClient:

--- a/databricks/sdk/core.py
+++ b/databricks/sdk/core.py
@@ -914,7 +914,6 @@ class ErrorDetail:
 
 class DatabricksError(IOError):
     """ Generic error from Databricks REST API """
-
     # Known ErrorDetail types
     _error_info_type = "type.googleapis.com/google.rpc.ErrorInfo"
 
@@ -924,7 +923,7 @@ class DatabricksError(IOError):
                  error_code: str = None,
                  detail: str = None,
                  status: str = None,
-                 scim_type: str = None,
+                 scimType: str = None,
                  error: str = None,
                  details: List[ErrorDetail] = [],
                  **kwargs):
@@ -939,7 +938,7 @@ class DatabricksError(IOError):
             else:
                 message = detail
             # add more context from SCIM responses
-            message = f"{scim_type} {message}".strip(" ")
+            message = f"{scimType} {message}".strip(" ")
             error_code = f"SCIM_{status}"
         super().__init__(message if message else error)
         self.error_code = error_code

--- a/databricks/sdk/core.py
+++ b/databricks/sdk/core.py
@@ -947,10 +947,10 @@ class DatabricksError(IOError):
         self.details = [ErrorDetail.from_dict(detail) for detail in details]
         self.kwargs = kwargs
 
-    def GetErrorInfo(self) -> List[ErrorDetail]:
-        return self.getDetailsByType(errorInfoType)
+    def get_error_info(self) -> List[ErrorDetail]:
+        return self._get_details_by_type(errorInfoType)
 
-    def getDetailsByType(self, errorType) -> List[ErrorDetail]:
+    def _get_details_by_type(self, errorType) -> List[ErrorDetail]:
         if self.details == None:
             return []
         return [detail for detail in self.details if detail.type == errorType]

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -314,7 +314,7 @@ def test_error(config, requests_mock):
     with pytest.raises(DatabricksError) as raised:
         client.do("GET", "/test", headers={"test": "test"})
 
-    errorInfos = raised.value.GetErrorInfo()
+    errorInfos = raised.value.get_error_info()
     assert len(errorInfos) == 1
     errorInfo = errorInfos[0]
     assert errorInfo.reason == "errorReason"

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -314,9 +314,10 @@ def test_error(config, requests_mock):
     with pytest.raises(DatabricksError) as raised:
         client.do("GET", "/test", headers={"test": "test"})
 
-    error = raised.value
-    detail = error.GetErrorInfo()[0]
-    assert detail.reason == "errorReason"
-    assert detail.domain == "errorDomain"
-    assert detail.metadata["etag"] == "errorEtag"
-    assert detail.type == errorInfoType
+    errorInfos = raised.value.GetErrorInfo()
+    assert len(errorInfos) == 1
+    errorInfo = errorInfos[0]
+    assert errorInfo.reason == "errorReason"
+    assert errorInfo.domain == "errorDomain"
+    assert errorInfo.metadata["etag"] == "errorEtag"
+    assert errorInfo.type == errorInfoType

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -323,11 +323,7 @@ def test_error(config, requests_mock):
     assert error_info.type == DatabricksError._error_info_type
 
 
-def test_error_with_scimType(config):
-    args = {
-        "detail": "detail",
-        "scimType": "scim type"
-    }
+def test_error_with_scimType():
+    args = {"detail": "detail", "scimType": "scim type"}
     error = DatabricksError(**args)
     assert str(error) == f"scim type detail"
-

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -11,7 +11,7 @@ import requests
 from databricks.sdk.core import (ApiClient, Config, CredentialsProvider,
                                  DatabricksCliTokenSource, DatabricksError,
                                  HeaderFactory, StreamingResponse,
-                                 databricks_cli, errorInfoType)
+                                 databricks_cli)
 from databricks.sdk.version import __version__
 
 from .conftest import noop_credentials
@@ -293,7 +293,7 @@ def test_error(config, requests_mock):
         "message":
         "errorMessage",
         "details": [{
-            "type": errorInfoType,
+            "type": DatabricksError._error_info_type,
             "reason": "errorReason",
             "domain": "errorDomain",
             "metadata": {
@@ -314,10 +314,10 @@ def test_error(config, requests_mock):
     with pytest.raises(DatabricksError) as raised:
         client.do("GET", "/test", headers={"test": "test"})
 
-    errorInfos = raised.value.get_error_info()
-    assert len(errorInfos) == 1
-    errorInfo = errorInfos[0]
-    assert errorInfo.reason == "errorReason"
-    assert errorInfo.domain == "errorDomain"
-    assert errorInfo.metadata["etag"] == "errorEtag"
-    assert errorInfo.type == errorInfoType
+    error_infos = raised.value.get_error_info()
+    assert len(error_infos) == 1
+    error_info = error_infos[0]
+    assert error_info.reason == "errorReason"
+    assert error_info.domain == "errorDomain"
+    assert error_info.metadata["etag"] == "errorEtag"
+    assert error_info.type == DatabricksError._error_info_type

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -294,17 +294,17 @@ def test_error(config, requests_mock):
         "errorMessage",
         "details": [{
             "type": DatabricksError._error_info_type,
-            "reason": "errorReason",
-            "domain": "errorDomain",
+            "reason": "error reason",
+            "domain": "error domain",
             "metadata": {
-                "etag": "errorEtag"
+                "etag": "error etag"
             },
         }, {
-            "type": "wrongType",
-            "reason": "wrongReason",
-            "domain": "wrongDomain",
+            "type": "wrong type",
+            "reason": "wrong reason",
+            "domain": "wrong domain",
             "metadata": {
-                "etag": "wrongEtag"
+                "etag": "wrong etag"
             }
         }],
     }
@@ -317,7 +317,17 @@ def test_error(config, requests_mock):
     error_infos = raised.value.get_error_info()
     assert len(error_infos) == 1
     error_info = error_infos[0]
-    assert error_info.reason == "errorReason"
-    assert error_info.domain == "errorDomain"
-    assert error_info.metadata["etag"] == "errorEtag"
+    assert error_info.reason == "error reason"
+    assert error_info.domain == "error domain"
+    assert error_info.metadata["etag"] == "error etag"
     assert error_info.type == DatabricksError._error_info_type
+
+
+def test_error_with_scimType(config):
+    args = {
+        "detail": "detail",
+        "scimType": "scim type"
+    }
+    error = DatabricksError(**args)
+    assert str(error) == f"scim type detail"
+


### PR DESCRIPTION
## Changes

Databricks API can return error details in case of errors. In some cases, users need to access such details to be able to solve the issue. This is the case for the errors of type ErrorInfo used by the Settings Platform.
This PR adds the necessary fields to the APIError to Unmarshal the ErrorDetails and to expose the details of type ErrorInfo to the users.

## Tests

- [x] `make test` run locally
- [x] `make fmt` applied
- [x] relevant integration tests applied

