### PR TITLE
Fix eager default argument evaluation in `DatabricksError`

### DIFF
--- a/databricks/sdk/core.py
+++ b/databricks/sdk/core.py
@@ -925,7 +925,7 @@ class DatabricksError(IOError):
                  status: str = None,
                  scimType: str = None,
                  error: str = None,
-                 details: List[Dict[str, any]] = [],
+                 details: List[Dict[str, any]] = None,
                  **kwargs):
         if error:
             # API 1.2 has different response format, let's adapt
@@ -942,7 +942,7 @@ class DatabricksError(IOError):
             error_code = f"SCIM_{status}"
         super().__init__(message if message else error)
         self.error_code = error_code
-        self.details = [ErrorDetail.from_dict(detail) for detail in details]
+        self.details = [ErrorDetail.from_dict(detail) for detail in details] if details else []
         self.kwargs = kwargs
 
     def get_error_info(self) -> List[ErrorDetail]:


### PR DESCRIPTION
Python’s default arguments are evaluated once when the function is defined, not each time the function is called. This means that if you use a mutable default argument and mutate it, you will have mutated that object for all future calls to the function as well.

