### PR TITLE
Use `[]` instead of `None` as default list value for deserialising responses

### DIFF
--- a/databricks/sdk/service/_internal.py
+++ b/databricks/sdk/service/_internal.py
@@ -10,7 +10,7 @@ def _from_dict(d: Dict[str, any], field: str, cls: Type) -> any:
 
 def _repeated(d: Dict[str, any], field: str, cls: Type) -> any:
     if field not in d or not d[field]:
-        return None
+        return []
     from_dict = getattr(cls, 'from_dict')
     return [from_dict(v) for v in d[field]]
 


### PR DESCRIPTION
## Changes

This PR makes the experience consistent with Go SDK for the read path. Currently, we use `None` as the default value for list fields. This may result in unexpected runtime bugs like

```
_backup = w.groups.get(...)
_backup_members = sorted([m.value for m in _backup.members])
...

E           TypeError: 'NoneType' object is not iterable
```

Technically, we can ask users to be very defensive in programming and do `sorted(m.value for m in _backup.members) if _backup.members else []`, but most of the intended users do not know/want to know about these details.

What other pros and cons does keeping `None` as a default value?


## Tests

- [x] `make test` run locally
- [x] `make fmt` applied
- [ ] relevant integration tests applied

