### PR TITLE
Added Python 3.12 to project classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,4 +35,5 @@ setup(name="databricks-sdk",
           "Programming Language :: Python :: 3.9",
           "Programming Language :: Python :: 3.10",
           "Programming Language :: Python :: 3.11",
+          "Programming Language :: Python :: 3.12",
           "Operating System :: OS Independent"])


### PR DESCRIPTION
As long as we test for 3.12 compatibility, we can safely tell we're py3.12-compatible

