### PR TITLE
Fix serialization issues for generated resources

### DIFF
--- a/.codegen/service.py.tmpl
+++ b/.codegen/service.py.tmpl
@@ -219,7 +219,7 @@ class {{.Name}}API:{{if .Description}}
 {{- define "method-param-bind" -}}
       {{- if not .Entity }}None # ERROR: No Type
       {{- else if .Entity.ArrayValue }}[
-        {{- if .Entity.ArrayValue.IsObject -}}v.as_dict()
+        {{- if or .Entity.ArrayValue.IsObject .Entity.ArrayValue.IsExternal -}}v.as_dict()
         {{- else if .Entity.ArrayValue.Enum -}}v.value
         {{- else}}v{{end}} for v in {{.SnakeName}}]
       {{- else if .Entity.IsObject }}{{.SnakeName}}.as_dict()

--- a/databricks/sdk/service/jobs.py
+++ b/databricks/sdk/service/jobs.py
@@ -2975,7 +2975,8 @@ class JobsAPI:
         :returns: :class:`CreateResponse`
         """
         body = {}
-        if access_control_list is not None: body['access_control_list'] = [v for v in access_control_list]
+        if access_control_list is not None:
+            body['access_control_list'] = [v.as_dict() for v in access_control_list]
         if compute is not None: body['compute'] = [v.as_dict() for v in compute]
         if continuous is not None: body['continuous'] = continuous.as_dict()
         if email_notifications is not None: body['email_notifications'] = email_notifications.as_dict()
@@ -3685,7 +3686,8 @@ class JobsAPI:
           See :method:wait_get_run_job_terminated_or_skipped for more details.
         """
         body = {}
-        if access_control_list is not None: body['access_control_list'] = [v for v in access_control_list]
+        if access_control_list is not None:
+            body['access_control_list'] = [v.as_dict() for v in access_control_list]
         if email_notifications is not None: body['email_notifications'] = email_notifications.as_dict()
         if git_source is not None: body['git_source'] = git_source.as_dict()
         if health is not None: body['health'] = health.as_dict()

--- a/databricks/sdk/service/sharing.py
+++ b/databricks/sdk/service/sharing.py
@@ -1341,7 +1341,7 @@ class ProvidersAPI:
         headers = {'Accept': 'application/json', }
         json = self._api.do('GET', '/api/2.1/unity-catalog/providers', query=query, headers=headers)
         parsed = ListProvidersResponse.from_dict(json).providers
-        return parsed if parsed else []
+        return parsed if parsed is not None else []
 
     def list_shares(self, name: str) -> Iterator['ProviderShare']:
         """List shares by Provider.
@@ -1359,7 +1359,7 @@ class ProvidersAPI:
         headers = {'Accept': 'application/json', }
         json = self._api.do('GET', f'/api/2.1/unity-catalog/providers/{name}/shares', headers=headers)
         parsed = ListProviderSharesResponse.from_dict(json).shares
-        return parsed if parsed else []
+        return parsed if parsed is not None else []
 
     def update(self,
                name: str,
@@ -1560,7 +1560,7 @@ class RecipientsAPI:
         headers = {'Accept': 'application/json', }
         json = self._api.do('GET', '/api/2.1/unity-catalog/recipients', query=query, headers=headers)
         parsed = ListRecipientsResponse.from_dict(json).recipients
-        return parsed if parsed else []
+        return parsed if parsed is not None else []
 
     def rotate_token(self, existing_token_expire_in_seconds: int, name: str) -> RecipientInfo:
         """Rotate a token.
@@ -1717,7 +1717,7 @@ class SharesAPI:
         headers = {'Accept': 'application/json', }
         json = self._api.do('GET', '/api/2.1/unity-catalog/shares', headers=headers)
         parsed = ListSharesResponse.from_dict(json).shares
-        return parsed if parsed else []
+        return parsed if parsed is not None else []
 
     def share_permissions(self, name: str) -> catalog.PermissionsList:
         """Get permissions.
@@ -1793,6 +1793,6 @@ class SharesAPI:
         
         """
         body = {}
-        if changes is not None: body['changes'] = [v for v in changes]
+        if changes is not None: body['changes'] = [v.as_dict() for v in changes]
         headers = {'Accept': 'application/json', 'Content-Type': 'application/json', }
         self._api.do('PATCH', f'/api/2.1/unity-catalog/shares/{name}/permissions', body=body, headers=headers)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -295,19 +295,6 @@ def test_api_client_do_custom_headers(config, requests_mock):
     assert res == {"well": "done"}
 
 
-def test_api_client_do_custom_headers(config, requests_mock):
-    client = ApiClient(config)
-    requests_mock.get("/test",
-                      json={"well": "done"},
-                      request_headers={
-                          "test": "test",
-                          "User-Agent": config.user_agent
-                      })
-
-    res = client.do("GET", "/test", headers={"test": "test"})
-    assert res == {"well": "done"}
-
-
 def test_access_control_list(config, requests_mock):
     requests_mock.post("http://localhost/api/2.1/jobs/create",
                        request_headers={"User-Agent": config.user_agent})


### PR DESCRIPTION
## Changes
Fix serialization issues for generated resources by using the `to_dict` method when needed.

## Tests
- [X] `make test` run locally
- [X] `make fmt` applied
- [X] relevant integration tests applied

