### PR TITLE
Add support for tokenless authentication for GitHub Actions configured with OpenID Connect with Azure User Managed Identity (or Service Principal)

### DIFF
--- a/databricks/sdk/core.py
+++ b/databricks/sdk/core.py
@@ -15,16 +15,17 @@ import urllib.parse
 from datetime import datetime, timedelta
 from json import JSONDecodeError
 from types import TracebackType
-from typing import (Any, BinaryIO, Callable, Dict, Iterable, Iterator, List, Optional, Type, Union)
+from typing import (Any, BinaryIO, Callable, Dict, Iterable, Iterator, List,
+                    Optional, Type, Union)
 
 import requests
 import requests.auth
 from requests.adapters import HTTPAdapter
 
-from .azure import (ARM_DATABRICKS_RESOURCE_ID, ENVIRONMENTS, AzureEnvironment, add_sp_management_token,
-                    add_workspace_id_header)
-from .oauth import (ClientCredentials, OAuthClient, OidcEndpoints, Refreshable, Token, TokenCache,
-                    TokenSource)
+from .azure import (ARM_DATABRICKS_RESOURCE_ID, ENVIRONMENTS, AzureEnvironment,
+                    add_sp_management_token, add_workspace_id_header)
+from .oauth import (ClientCredentials, OAuthClient, OidcEndpoints, Refreshable,
+                    Token, TokenCache, TokenSource)
 from .retries import retried
 from .version import __version__
 
@@ -99,7 +100,8 @@ def runtime_native_auth(cfg: 'Config') -> Optional[HeaderFactory]:
     # This import MUST be after the "DATABRICKS_RUNTIME_VERSION" check
     # above, so that we are not throwing import errors when not in
     # runtime and no config variables are set.
-    from databricks.sdk.runtime import (init_runtime_legacy_auth, init_runtime_native_auth,
+    from databricks.sdk.runtime import (init_runtime_legacy_auth,
+                                        init_runtime_native_auth,
                                         init_runtime_repl_auth)
     for init in [init_runtime_native_auth, init_runtime_repl_auth, init_runtime_legacy_auth]:
         if init is None:

--- a/databricks/sdk/core.py
+++ b/databricks/sdk/core.py
@@ -237,13 +237,15 @@ def github_oidc_azure(cfg: 'Config') -> Optional[HeaderFactory]:
         return None
 
     # get the ID Token with aud=api://AzureADTokenExchange sub=repo:org/repo:environment:name
-    client_assertion = response.json()['value']
+    response_json = response.json()
+    if 'value' not in response_json:
+        return None
 
     logger.info("Configured AAD token for GitHub Actions OIDC (%s)", cfg.azure_client_id)
     params = {
         'client_assertion_type': 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer',
         'resource': cfg.effective_azure_login_app_id,
-        'client_assertion': client_assertion,
+        'client_assertion': response_json['value'],
     }
     aad_endpoint = cfg.arm_environment.active_directory_endpoint
     if not cfg.azure_tenant_id:

--- a/databricks/sdk/core.py
+++ b/databricks/sdk/core.py
@@ -30,7 +30,6 @@ from .retries import retried
 from .version import __version__
 
 __all__ = ['Config', 'DatabricksError']
-_ARM_CLIENT_ID_FOR_UNIT_TESTS = 'unit-test'
 
 logger = logging.getLogger('databricks.sdk')
 
@@ -643,8 +642,6 @@ class Config:
 
     @property
     def is_azure(self) -> bool:
-        if self.azure_client_id == _ARM_CLIENT_ID_FOR_UNIT_TESTS:
-            return True
         has_resource_id = self.azure_workspace_resource_id is not None
         has_host = self.host is not None
         is_public_cloud = has_host and ".azuredatabricks.net" in self.host

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -14,8 +14,7 @@ import requests
 
 from databricks.sdk import WorkspaceClient
 from databricks.sdk.azure import ENVIRONMENTS, AzureEnvironment
-from databricks.sdk.core import (_ARM_CLIENT_ID_FOR_UNIT_TESTS, ApiClient,
-                                 Config, CredentialsProvider,
+from databricks.sdk.core import (ApiClient, Config, CredentialsProvider,
                                  DatabricksCliTokenSource, DatabricksError,
                                  HeaderFactory, StreamingResponse,
                                  databricks_cli)
@@ -538,7 +537,10 @@ def test_github_oidc_flow_works_with_azure(monkeypatch):
                                               service_management_endpoint=host + '/',
                                               resource_manager_endpoint=host + '/',
                                               active_directory_endpoint=host + '/')
-        cfg = Config(host=host, azure_client_id=_ARM_CLIENT_ID_FOR_UNIT_TESTS, azure_environment=host)
+        cfg = Config(host=host,
+                     azure_workspace_resource_id=...,
+                     azure_client_id='test',
+                     azure_environment=host)
         headers = cfg.authenticate()
 
         assert {'Authorization': 'Taker this-is-it'} == headers

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -13,7 +13,9 @@ import pytest
 import requests
 
 from databricks.sdk import WorkspaceClient
-from databricks.sdk.core import (ApiClient, Config, CredentialsProvider,
+from databricks.sdk.azure import ENVIRONMENTS, AzureEnvironment
+from databricks.sdk.core import (_ARM_CLIENT_ID_FOR_UNIT_TESTS, ApiClient,
+                                 Config, CredentialsProvider,
                                  DatabricksCliTokenSource, DatabricksError,
                                  HeaderFactory, StreamingResponse,
                                  databricks_cli)
@@ -507,3 +509,36 @@ def test_http_retried_on_connection_error():
         assert 'foo' in res
 
     assert len(requests) == 2
+
+
+def test_github_oidc_flow_works_with_azure(monkeypatch):
+
+    def inner(h: BaseHTTPRequestHandler):
+        if 'audience=api://AzureADTokenExchange' in h.path:
+            auth = h.headers['Authorization']
+            assert 'Bearer gh-actions-token' == auth
+            h.send_response(200)
+            h.end_headers()
+            h.wfile.write(b'{"value": "this_is_jwt_token"}')
+            return
+        if '/oidc/oauth2/v2.0/authorize' == h.path:
+            h.send_response(301)
+            h.send_header('Location', f'http://{h.headers["Host"]}/mocked-tenant-id/irrelevant/part')
+            h.end_headers()
+            return
+        if '/mocked-tenant-id/oauth2/token' == h.path:
+            h.send_response(200)
+            h.end_headers()
+            h.wfile.write(b'{"expires_in": 100, "access_token": "this-is-it", "token_type": "Taker"}')
+
+    with http_fixture_server(inner) as host:
+        monkeypatch.setenv('ACTIONS_ID_TOKEN_REQUEST_URL', f'{host}/oidc')
+        monkeypatch.setenv('ACTIONS_ID_TOKEN_REQUEST_TOKEN', 'gh-actions-token')
+        ENVIRONMENTS[host] = AzureEnvironment(name=host,
+                                              service_management_endpoint=host + '/',
+                                              resource_manager_endpoint=host + '/',
+                                              active_directory_endpoint=host + '/')
+        cfg = Config(host=host, azure_client_id=_ARM_CLIENT_ID_FOR_UNIT_TESTS, azure_environment=host)
+        headers = cfg.authenticate()
+
+        assert {'Authorization': 'Taker this-is-it'} == headers


### PR DESCRIPTION
## Changes
See https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-cloud-providers and https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-azure

Technically, it should also work with Azure DevOps Workload Identity Federation, once we figure out the environment variables: https://techcommunity.microsoft.com/t5/azure-devops-blog/introduction-to-azure-devops-workload-identity-federation-oidc/ba-p/3908687

## Tests

setup:
```
resource "github_actions_environment_secret" "scope" {
  for_each    = github_repository_environment.default
  repository  = each.value.repository
  environment = each.value.environment
  secret_name = "ARM_CLIENT_ID"
  # this value is not a secret as well
  plaintext_value = data.azurerm_user_assigned_identity.scopes[local.project_scopes[each.key]].client_id
}

...

resource "azurerm_federated_identity_credential" "oidc" {
  for_each            = github_repository_environment.default
  name                = "${local.org}-${each.value.repository}-${each.value.environment}-oidc"
  resource_group_name = local.resource_group_name
  audience            = ["api://AzureADTokenExchange"]
  issuer              = "https://token.actions.githubusercontent.com"
  parent_id           = data.azurerm_user_assigned_identity.scopes[local.project_scopes[each.key]].id
  subject             = "repo:${local.org}/${each.value.repository}:environment:${each.value.environment}"
}

...

resource "azurerm_user_assigned_identity" "scopes" {
  for_each = local.scopes
  name     = "labs-${each.key}-identity"

  resource_group_name = azurerm_resource_group.this.name
  location            = azurerm_resource_group.this.location
  // ...
}

...

resource "databricks_service_principal" "scopes" {
  provider = databricks.account
  for_each = local.scopes

  application_id = azurerm_user_assigned_identity.scopes[each.key].client_id
  display_name   = azurerm_user_assigned_identity.scopes[each.key].name
  external_id    = azurerm_user_assigned_identity.scopes[each.key].principal_id
}
```

result

<img width="603" alt="_Experiment__Call_integration_tests_via_OIDC_·_databrickslabs_ucx_5a94b24" src="https://github.com/databricks/databricks-sdk-py/assets/259697/33b08224-ceed-4c15-bfcd-32e0b58f8483">

- [ ] `make test` run locally
- [x] `make fmt` applied
- [ ] relevant integration tests applied

