### PR TITLE
[WIP] GitHub OIDC publishing

### DIFF
--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -7,6 +7,8 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     environment: release-test
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -1,0 +1,21 @@
+name: Release (TestPyPI)
+
+on:
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: release-test
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Build wheel
+        run: make dev install dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        name: Publish package distributions to TestPyPI
+        with:
+          repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,9 +8,6 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    environment: release
-    permissions:
-      id-token: write
     steps:
       - uses: actions/checkout@v3
 
@@ -28,4 +25,6 @@ jobs:
             dist/databricks-*.tar.gz
 
       - uses: pypa/gh-action-pypi-publish@release/v1
-        name: Publish package distributions to PyPI
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v3
 
@@ -25,6 +28,4 @@ jobs:
             dist/databricks-*.tar.gz
 
       - uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_TOKEN }}
+        name: Publish package distributions to PyPI


### PR DESCRIPTION
## Changes
By using OIDC publishing, we can remove unnecessary secrets from our repository, reducing risk of secrets being leaked as well as minimizing work needed to rotate them.

This PR also adds a test release action that releases this project to the test PyPI index at test.pypi.org.

Separately, I've configured the test PyPI index for this package to allow OIDC with the release-test environment. After confirming, I'll do the same with the prod PyPI index with the release environment.

## Tests
Can't test from this PR. Once merged, I'll run the test workflow and make a second PR with any bugfixes & the updated release workflow.

