### PR TITLE
Move Release Pipeline to OIDC

### DIFF
--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -21,3 +21,5 @@ jobs:
         name: Publish package distributions to TestPyPI
         with:
           repository-url: https://test.pypi.org/legacy/
+          # See https://github.com/pypa/gh-action-pypi-publish#tolerating-release-package-file-duplicates
+          skip-existing: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v3
 
@@ -25,6 +28,4 @@ jobs:
             dist/databricks-*.tar.gz
 
       - uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_TOKEN }}
+        name: Publish package distributions to PyPI


### PR DESCRIPTION
## Changes
In https://github.com/databricks/databricks-sdk-py/pull/386, I added a workflow for testing OIDC auth to TestPyPI. This failed due to an existing package: https://github.com/databricks/databricks-sdk-py/actions/runs/6418567925/job/17426619417.

This PR fixes that issue by adding `skip-existing: true` and at the same time changes the production publishing pipeline to use OIDC as well.

## Tests
- [x] Updated test pipeline succeeds: https://github.com/databricks/databricks-sdk-py/actions/runs/6418660406/job/17426893715

