### PR TITLE
Fix select spark version in staging

### DIFF
--- a/databricks/sdk/mixins/compute.py
+++ b/databricks/sdk/mixins/compute.py
@@ -27,6 +27,11 @@ class SemVer:
                           r"(?:-(?P<pre_release>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)"
                           r"(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?"
                           r"(?:\+(?P<build>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$")
+    _pattern_no_patch = re.compile(r"^"
+                          r"(?P<major>0|[1-9]\d*)\.(?P<minor>x|0|[1-9]\d*)"
+                          r"(?:-(?P<pre_release>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)"
+                          r"(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?"
+                          r"(?:\+(?P<build>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$")
 
     @classmethod
     def parse(cls, v: str) -> 'SemVer':
@@ -34,16 +39,22 @@ class SemVer:
             raise ValueError(f'Not a valid SemVer: {v}')
         if v[0] != 'v':
             v = f'v{v}'
+        # Try regular SemVer, then fall back to the version without patch.
         m = cls._pattern.match(v[1:])
+        if not m:
+            m = cls._pattern_no_patch.match(v[1:])
         if not m:
             raise ValueError(f'Not a valid SemVer: {v}')
         # patch and/or minor versions may be wildcards.
         # for now, we're converting wildcards to zeroes.
         minor = m.group('minor')
-        patch = m.group('patch')
+        try:
+            patch = m.group('patch')
+        except IndexError:
+            patch = None
         return SemVer(major=int(m.group('major')),
                       minor=0 if minor == 'x' else int(minor),
-                      patch=0 if patch == 'x' else int(patch),
+                      patch=0 if patch == 'x' or patch is None else int(patch),
                       pre_release=m.group('pre_release'),
                       build=m.group('build'))
 
@@ -58,7 +69,9 @@ class SemVer:
             return self.patch < other.patch
         if self.pre_release != other.pre_release:
             return self.pre_release < other.pre_release
-        return self.build < other.build
+        if self.build != other.build:
+            return self.build < other.build
+        return False
 
 
 class ClustersExt(compute.ClustersAPI):

--- a/tests/test_compute_mixins.py
+++ b/tests/test_compute_mixins.py
@@ -6,7 +6,9 @@ from databricks.sdk.mixins.compute import SemVer
 @pytest.mark.parametrize("given,expected", [('v0.0.4', SemVer(0, 0, 4)), ('v1.2.3', SemVer(1, 2, 3)),
                                             ('v12.1.x', SemVer(12, 1, 0)), ('v10.20.30', SemVer(10, 20, 30)),
                                             ('v1.1.2+meta', SemVer(1, 1, 2, build='meta')),
-                                            ('v1.0.0-alpha', SemVer(1, 0, 0, pre_release='alpha'))])
+                                            ('v1.0.0-alpha', SemVer(1, 0, 0, pre_release='alpha')),
+                                            ('8.x-snapshot-scala2.12', SemVer(8, 0, 0, pre_release='snapshot-scala2.12')),
+                                            ])
 def test_parse_semver(given, expected):
     assert SemVer.parse(given) == expected
 


### PR DESCRIPTION
## Changes
In staging, there are some spark versions that do not have a patch version. We fall back to a different pattern with no patch component for these. Additionally, we check if the builds are equal to one another (which allows us to avoid comparing one < the other in the case where they are both None).

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

