### PR TITLE
Additional retries on `DatabricksError: Workspace X exceeded the concurrent limit of Y requests` (SEV1)

### DIFF
--- a/databricks/sdk/core.py
+++ b/databricks/sdk/core.py
@@ -1097,7 +1097,7 @@ class ApiClient:
                 "com.databricks.backend.manager.util.UnknownWorkerEnvironmentException",
                 "does not have any associated worker environments", "There is no worker environment with id",
                 "Unknown worker environment", "ClusterNotReadyException", "Unexpected error",
-                "Please try again later or try a faster operation."
+                "Please try again later or try a faster operation.", "exceeded the concurrent limit of",
             ]
             for substring in transient_error_string_matches:
                 if substring not in message:


### PR DESCRIPTION
## Changes
Platform doesn't seem to send HTTP 429 correctly with this response, otherwise, the error would have been `TimeoutError`. This PR adds retries for error responses with this message.

Fixes https://github.com/databrickslabs/ucx/issues/401

## Tests

- [ ] `make test` run locally
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

