### PR TITLE
Adjust token expiry window to 40 seconds because of Azure

### DIFF
--- a/databricks/sdk/oauth.py
+++ b/databricks/sdk/oauth.py
@@ -57,7 +57,9 @@ class Token:
     def expired(self):
         if not self.expiry:
             return False
-        potentially_expired = self.expiry - timedelta(seconds=10)
+        # Azure Databricks rejects tokens that expire in 30 seconds or less,
+        # so we refresh the token 40 seconds before it expires.
+        potentially_expired = self.expiry - timedelta(seconds=40)
         now = datetime.now(tz=potentially_expired.tzinfo)
         is_expired = potentially_expired < now
         return is_expired


### PR DESCRIPTION
## Changes

Align with https://github.com/databricks/databricks-sdk-go/pull/617 and https://github.com/databricks/databricks-sdk-js/pull/63

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] `make fmt` applied
- [ ] relevant integration tests applied

