### PR TITLE
Add retries on `RPC token bucket limit has been exceeded`

### DIFF
--- a/databricks/sdk/core.py
+++ b/databricks/sdk/core.py
@@ -1097,7 +1097,7 @@ class ApiClient:
                 "com.databricks.backend.manager.util.UnknownWorkerEnvironmentException",
                 "does not have any associated worker environments", "There is no worker environment with id",
                 "Unknown worker environment", "ClusterNotReadyException", "Unexpected error",
-                "Please try again later or try a faster operation."
+                "Please try again later or try a faster operation.", "RPC token bucket limit has been exceeded",
             ]
             for substring in transient_error_string_matches:
                 if substring not in message:

--- a/databricks/sdk/core.py
+++ b/databricks/sdk/core.py
@@ -1097,7 +1097,8 @@ class ApiClient:
                 "com.databricks.backend.manager.util.UnknownWorkerEnvironmentException",
                 "does not have any associated worker environments", "There is no worker environment with id",
                 "Unknown worker environment", "ClusterNotReadyException", "Unexpected error",
-                "Please try again later or try a faster operation.", "RPC token bucket limit has been exceeded",
+                "Please try again later or try a faster operation.",
+                "RPC token bucket limit has been exceeded",
             ]
             for substring in transient_error_string_matches:
                 if substring not in message:


### PR DESCRIPTION
## Changes

Another case when the platform is not sending a proper HTTP 429 response. This time for the SCIM user list:
<img width="925" alt="image" src="https://github.com/databricks/databricks-sdk-py/assets/259697/c6159844-949b-4746-8750-7e7125056493">


## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

