### PR TITLE
Retry on all 429 and 503, even when missing Retry-After header

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -387,14 +387,19 @@ def http_fixture_server(handler: typing.Callable[[BaseHTTPRequestHandler], None]
         srv.shutdown()
 
 
-def test_http_429_without_retry_after():
+@pytest.mark.parametrize('status_code,include_retry_after', (
+    (429, False),
+    (429, True),
+    (503, False),
+    (503, True)))
+def test_http_retry_after(status_code, include_retry_after):
     requests = []
 
     def inner(h: BaseHTTPRequestHandler):
         if len(requests) == 0:
-            h.send_response(429)
-            # No Retry-After, but should still wait for 1 second
-            # h.send_header('Retry-After', '1')
+            h.send_response(status_code)
+            if include_retry_after:
+                h.send_header('Retry-After', '1')
             h.send_header('Content-Type', 'application/json')
             h.end_headers()
         else:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -387,11 +387,8 @@ def http_fixture_server(handler: typing.Callable[[BaseHTTPRequestHandler], None]
         srv.shutdown()
 
 
-@pytest.mark.parametrize('status_code,include_retry_after', (
-    (429, False),
-    (429, True),
-    (503, False),
-    (503, True)))
+@pytest.mark.parametrize('status_code,include_retry_after',
+                         ((429, False), (429, True), (503, False), (503, True)))
 def test_http_retry_after(status_code, include_retry_after):
     requests = []
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -387,13 +387,14 @@ def http_fixture_server(handler: typing.Callable[[BaseHTTPRequestHandler], None]
         srv.shutdown()
 
 
-def test_http_retry_after_handling():
+def test_http_429_without_retry_after():
     requests = []
 
     def inner(h: BaseHTTPRequestHandler):
         if len(requests) == 0:
             h.send_response(429)
-            h.send_header('Retry-After', '1')
+            # No Retry-After, but should still wait for 1 second
+            # h.send_header('Retry-After', '1')
             h.send_header('Content-Type', 'application/json')
             h.end_headers()
         else:


### PR DESCRIPTION
## Changes
Change HTTP client to always retry on 429 and 503, regardless of whether Retry-After header is present. If absent, default to 1 second, as we do today.

Subsumes #391 and #396 while we're still discussing error architecture in the SDK.

## Tests
Unit test to ensure that 429 and 503 work with and without Retry-After header.

