### PR TITLE
Add contents: write permission to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: release
     permissions:
+      contents: write
       id-token: write
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
The release workflow is failing without this permission, because it needs to upload files to the associated GitHub release.