### PR TITLE
[JOBS-11439] Add taskValues support in remoteDbUtils

### DIFF
--- a/databricks/sdk/dbutils.py
+++ b/databricks/sdk/dbutils.py
@@ -174,7 +174,9 @@ class _JobsUtil:
             Returns `debugValue` if present, throws an error otherwise as this implementation is always run outside of a job run
             """
             if debugValue is None:
-                raise ValueError('No debug value set for task value, when outside of job run')
+                raise TypeError(
+                    'Must pass debugValue when calling get outside of a job context. debugValue cannot be None.'
+                )
             return debugValue
 
         def set(self, key: str, value: any) -> None:

--- a/databricks/sdk/dbutils.py
+++ b/databricks/sdk/dbutils.py
@@ -171,8 +171,10 @@ class _JobsUtil:
 
         def get(self, taskKey: str, key: str, default: any = None, debugValue: any = None) -> None:
             """
-            Returns the latest task value that belongs to the current job run
+            Returns `debugValue` if present, throws an error otherwise as this implementation is always run outside of a job run
             """
+            if debugValue is None:
+                raise ValueError('No debug value set for task value, when outside of job run')
             return debugValue
 
         def set(self, key: str, value: any) -> None:

--- a/databricks/sdk/dbutils.py
+++ b/databricks/sdk/dbutils.py
@@ -163,6 +163,35 @@ class _SecretsUtil:
         return [SecretScope(v.name) for v in self._api.list_scopes()]
 
 
+class _JobsUtil:
+    """Remote equivalent of jobs util"""
+
+    class _TaskValuesUtil:
+        """Remote equivalent of task values util"""
+        values = {}
+
+        def get(self, taskKey: str, key: str, default: any = None, debugValue: any = None) -> None:
+            """
+            Returns the latest task value that belongs to the current job run
+            """
+            return debugValue
+
+        def set(self, key: str, value: any) -> None:
+            """
+            Sets a task value on the current task run
+            """
+            self.values[key] = value
+
+        def checkTaskValue(self, key: str, value: any) -> bool:
+            """
+            Check that the task value with given key is equal to the given value
+            """
+            return self.values.get(key) == value
+
+    def __init__(self) -> None:
+        self.taskValues = self._TaskValuesUtil()
+
+
 class RemoteDbUtils:
 
     def __init__(self, config: 'Config' = None):
@@ -175,6 +204,7 @@ class RemoteDbUtils:
 
         self.fs = _FsUtil(dbfs_ext.DbfsExt(self._client), self.__getattr__)
         self.secrets = _SecretsUtil(workspace.SecretsAPI(self._client))
+        self.jobs = _JobsUtil()
         self._widgets = None
 
     # When we import widget_impl, the init file checks whether user has the

--- a/databricks/sdk/dbutils.py
+++ b/databricks/sdk/dbutils.py
@@ -168,7 +168,6 @@ class _JobsUtil:
 
     class _TaskValuesUtil:
         """Remote equivalent of task values util"""
-        values = {}
 
         def get(self, taskKey: str, key: str, default: any = None, debugValue: any = None) -> None:
             """
@@ -180,13 +179,6 @@ class _JobsUtil:
             """
             Sets a task value on the current task run
             """
-            self.values[key] = value
-
-        def checkTaskValue(self, key: str, value: any) -> bool:
-            """
-            Check that the task value with given key is equal to the given value
-            """
-            return self.values.get(key) == value
 
     def __init__(self) -> None:
         self.taskValues = self._TaskValuesUtil()

--- a/tests/test_dbutils.py
+++ b/tests/test_dbutils.py
@@ -204,3 +204,21 @@ def test_secrets_get_and_redacting_logs(dbutils, mocker):
     inner.assert_called_with('GET', '/api/2.0/secrets/get', query={'key': 'bar', 'scope': 'foo'})
 
     assert value == 'hello'
+
+
+def test_jobs_task_values_check_task_value(dbutils):
+    assert (dbutils.jobs.taskValues.checkTaskValue('key', 'value') == False)
+
+
+def test_jobs_task_values_set(dbutils):
+    dbutils.jobs.taskValues.set('key', 'value')
+
+    assert dbutils.jobs.taskValues.checkTaskValue('key', 'value')
+
+
+def test_jobs_task_values_get(dbutils):
+    assert dbutils.jobs.taskValues.get('taskKey', 'key', debugValue='debug') == 'debug'
+
+    dbutils.jobs.taskValues.set('key', 'value')
+
+    assert dbutils.jobs.taskValues.get('taskKey', 'key', debugValue='debug') == 'debug'

--- a/tests/test_dbutils.py
+++ b/tests/test_dbutils.py
@@ -215,6 +215,7 @@ def test_jobs_task_values_get(dbutils):
 
     dbutils.jobs.taskValues.set('key', 'value')
 
+    # Expect `get` to always return the `debugValue`` when calling outside of a job context and not what was previously set using `set`
     assert dbutils.jobs.taskValues.get('taskKey', 'key', debugValue='debug') == 'debug'
 
 
@@ -222,5 +223,6 @@ def test_jobs_task_values_get_throws(dbutils):
     try:
         dbutils.jobs.taskValues.get('taskKey', 'key')
         assert False
-    except ValueError as e:
-        assert str(e) == 'No debug value set for task value, when outside of job run'
+    except TypeError as e:
+        assert str(
+            e) == 'Must pass debugValue when calling get outside of a job context. debugValue cannot be None.'

--- a/tests/test_dbutils.py
+++ b/tests/test_dbutils.py
@@ -206,14 +206,8 @@ def test_secrets_get_and_redacting_logs(dbutils, mocker):
     assert value == 'hello'
 
 
-def test_jobs_task_values_check_task_value(dbutils):
-    assert (dbutils.jobs.taskValues.checkTaskValue('key', 'value') == False)
-
-
 def test_jobs_task_values_set(dbutils):
     dbutils.jobs.taskValues.set('key', 'value')
-
-    assert dbutils.jobs.taskValues.checkTaskValue('key', 'value')
 
 
 def test_jobs_task_values_get(dbutils):

--- a/tests/test_dbutils.py
+++ b/tests/test_dbutils.py
@@ -216,3 +216,11 @@ def test_jobs_task_values_get(dbutils):
     dbutils.jobs.taskValues.set('key', 'value')
 
     assert dbutils.jobs.taskValues.get('taskKey', 'key', debugValue='debug') == 'debug'
+
+
+def test_jobs_task_values_get_throws(dbutils):
+    try:
+        dbutils.jobs.taskValues.get('taskKey', 'key')
+        assert False
+    except ValueError as e:
+        assert str(e) == 'No debug value set for task value, when outside of job run'


### PR DESCRIPTION
## Changes
Support `dbutils.jobs.taskValues` methods in `RemoteDbUtils` and add additional `checkTaskValue` to allow local testing

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->
Added three test cases in `test_dbutils.py`. Integration tests are not needed since changes only for remote mode
- [x] `make test` run locally
- [x] `make fmt` applied
- [x] relevant integration tests applied

