### PR TITLE
Add more detailed error message on default credentials not found error

### DIFF
--- a/databricks/sdk/core.py
+++ b/databricks/sdk/core.py
@@ -527,7 +527,10 @@ class DefaultCredentials:
                 return header_factory
             except Exception as e:
                 raise ValueError(f'{auth_type}: {e}') from e
-        raise ValueError('cannot configure default credentials')
+        auth_flow_url = "https://docs.databricks.com/en/dev-tools/auth.html#databricks-client-unified-authentication"
+        raise ValueError(
+            f'cannot configure default credentials, please check {auth_flow_url} to configure credentials for your preferred authentication method.'
+        )
 
 
 class ConfigAttribute:

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -4,19 +4,24 @@ from databricks.sdk.core import Config
 
 from .conftest import __tests__, raises
 
+default_auth_base_error_message = \
+    "default auth: cannot configure default credentials, " \
+    "please check https://docs.databricks.com/en/dev-tools/auth.html#databricks-client-unified-authentication " \
+    "to configure credentials for your preferred authentication method"
 
-@raises("default auth: cannot configure default credentials")
+
+@raises(default_auth_base_error_message)
 def test_config_no_params():
     Config()
 
 
-@raises("default auth: cannot configure default credentials. Config: host=https://x. Env: DATABRICKS_HOST")
+@raises(f"{default_auth_base_error_message}. Config: host=https://x. Env: DATABRICKS_HOST")
 def test_config_host_env(monkeypatch):
     monkeypatch.setenv('DATABRICKS_HOST', 'x')
     Config()
 
 
-@raises("default auth: cannot configure default credentials. Config: token=***. Env: DATABRICKS_TOKEN")
+@raises(f"{default_auth_base_error_message}. Config: token=***. Env: DATABRICKS_TOKEN")
 def test_config_token_env(monkeypatch):
     monkeypatch.setenv('DATABRICKS_TOKEN', 'x')
     Config()
@@ -40,7 +45,7 @@ def test_config_host_param_token_env(monkeypatch):
 
 
 @raises(
-    "default auth: cannot configure default credentials. Config: username=x, password=***. Env: DATABRICKS_USERNAME, DATABRICKS_PASSWORD"
+    f"{default_auth_base_error_message}. Config: username=x, password=***. Env: DATABRICKS_USERNAME, DATABRICKS_PASSWORD"
 )
 def test_config_user_password_env(monkeypatch):
     monkeypatch.setenv('DATABRICKS_PASSWORD', 'x')
@@ -107,20 +112,19 @@ def test_config_conflicting_envs_auth_type(monkeypatch):
     assert cfg.host == 'https://x'
 
 
-@raises(
-    "default auth: cannot configure default credentials. Config: config_file=x. Env: DATABRICKS_CONFIG_FILE")
+@raises(f"{default_auth_base_error_message}. Config: config_file=x. Env: DATABRICKS_CONFIG_FILE")
 def test_config_config_file(monkeypatch):
     monkeypatch.setenv('DATABRICKS_CONFIG_FILE', 'x')
     Config()
 
 
-@raises("default auth: cannot configure default credentials. Config: host=https://x")
+@raises(f"{default_auth_base_error_message}. Config: host=https://x")
 def test_config_config_file_skip_default_profile_if_host_specified(monkeypatch):
     monkeypatch.setenv('HOME', __tests__ + '/testdata')
     cfg = Config(host='x')
 
 
-@raises("default auth: cannot configure default credentials")
+@raises(default_auth_base_error_message)
 def test_config_config_file_with_empty_default_profile_select_default(monkeypatch):
     monkeypatch.setenv('HOME', __tests__ + '/testdata/empty_default')
     Config()
@@ -153,8 +157,7 @@ def test_config_pat_from_databricks_cfg_dot_profile(monkeypatch):
 
 
 @raises(
-    "default auth: cannot configure default credentials. Config: token=***, profile=nohost. Env: DATABRICKS_CONFIG_PROFILE"
-)
+    f"{default_auth_base_error_message}. Config: token=***, profile=nohost. Env: DATABRICKS_CONFIG_PROFILE")
 def test_config_pat_from_databricks_cfg_nohost_profile(monkeypatch):
     monkeypatch.setenv('DATABRICKS_CONFIG_PROFILE', 'nohost')
     monkeypatch.setenv('HOME', __tests__ + '/testdata')
@@ -162,7 +165,7 @@ def test_config_pat_from_databricks_cfg_nohost_profile(monkeypatch):
 
 
 @raises(
-    "default auth: cannot configure default credentials. Config: token=***, profile=nohost. Env: DATABRICKS_TOKEN, DATABRICKS_CONFIG_PROFILE"
+    f"{default_auth_base_error_message}. Config: token=***, profile=nohost. Env: DATABRICKS_TOKEN, DATABRICKS_CONFIG_PROFILE"
 )
 def test_config_config_profile_and_token(monkeypatch):
     monkeypatch.setenv('DATABRICKS_CONFIG_PROFILE', 'nohost')
@@ -209,7 +212,7 @@ def test_config_azure_cli_host_fail(monkeypatch):
     cfg = Config(azure_workspace_resource_id='/sub/rg/ws')
 
 
-@raises("default auth: cannot configure default credentials. Config: azure_workspace_resource_id=/sub/rg/ws")
+@raises(f"{default_auth_base_error_message}. Config: azure_workspace_resource_id=/sub/rg/ws")
 def test_config_azure_cli_host_az_not_installed(monkeypatch):
     monkeypatch.setenv('HOME', __tests__ + '/testdata/azure')
     monkeypatch.setenv('PATH', __tests__ + '/whatever')


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
- Added more detailed error message for default credentials not found error - found the original error message was a bit difficult to follow / understand

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->
Not quite sure if I need to do anything special if CI checks passed.
Manually tried using default auth locally without `.databrickscfg` file, verified that the prompt is printed out

- [ ] `make test` run locally
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

