### PR TITLE
Feature: Check if a DataBricks path or dir exists

### DIFF
--- a/databricks/sdk/dbutils.py
+++ b/databricks/sdk/dbutils.py
@@ -42,6 +42,10 @@ class _FsUtil:
         """Copies a file or directory, possibly across FileSystems """
         self._dbfs.copy(from_, to, recursive=recurse)
         return True
+    
+    def exists(self, dir: str) -> bool:
+        """Check if a databricks path exists in DBFS"""
+        return self._dbfs.exists(dir)
 
     def head(self, file: str, maxBytes: int = 65536) -> str:
         """Returns up to the first 'maxBytes' bytes of the given file as a String encoded in UTF-8 """


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
Add a method to `_FsUtils` of `dbutils.py` to  check if a directory exists in DataBricks FileSystem (DBFS). There is a general difficulty faced by users in checking whether not a path/dir exists in DBFS which can be seen here in Questions  from [StackOverFlow](https://stackoverflow.com/questions/53064044/in-databricks-check-whether-a-path-exist-or-not/77430656#77430656) and [DataBricks Community](https://community.databricks.com/t5/data-engineering/how-to-check-file-exists-in-databricks/td-p/27945/page/2) (, which I have commented on). This addition uses existing class `dbfs_ext.DbfsExt` which is already an attribute of `_FsUtil`.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

