### PR TITLE
Fix potential `SyntaxError` by invalid escape character

### DIFF
--- a/databricks/sdk/service/jobs.py
+++ b/databricks/sdk/service/jobs.py
@@ -2999,7 +2999,7 @@ class JobsAPI:
           4 concurrent active runs. Then setting the concurrency to 3 won’t kill any of the active runs.
           However, from then on, new runs are skipped unless there are fewer than 3 active runs.
           
-          This value cannot exceed 1000\. Setting this value to `0` causes all new runs to be skipped.
+          This value cannot exceed 1000. Setting this value to `0` causes all new runs to be skipped.
         :param name: str (optional)
           An optional name for the job. The maximum length is 4096 bytes in UTF-8 encoding.
         :param notification_settings: :class:`JobNotificationSettings` (optional)

--- a/docs/workspace/jobs.rst
+++ b/docs/workspace/jobs.rst
@@ -189,7 +189,7 @@ Jobs
           4 concurrent active runs. Then setting the concurrency to 3 won’t kill any of the active runs.
           However, from then on, new runs are skipped unless there are fewer than 3 active runs.
           
-          This value cannot exceed 1000\. Setting this value to `0` causes all new runs to be skipped.
+          This value cannot exceed 1000. Setting this value to `0` causes all new runs to be skipped.
         :param name: str (optional)
           An optional name for the job. The maximum length is 4096 bytes in UTF-8 encoding.
         :param notification_settings: :class:`JobNotificationSettings` (optional)


### PR DESCRIPTION
## Changes

Replace `\.` with `.` in docstring. This can prevent issues while importing such as:

```
.venv/lib/python3.8/site-packages/databricks/sdk/__init__.py:36: in <module>
    from databricks.sdk.service.jobs import JobsAPI
E     File "/__w/713/s/.venv/lib/python3.8/site-packages/databricks/sdk/service/jobs.py", line 2957
E       """Create a new job.
E       ^
E   SyntaxError: invalid escape sequence \.
```

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] `make fmt` applied
- [ ] relevant integration tests applied

