### PR TITLE
Regenerate Python SDK after bumping Deco tool

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 databricks/sdk/__init__.py linguist-generated=true
+databricks/sdk/errors/mapping.py linguist-generated=true
 databricks/sdk/service/billing.py linguist-generated=true
 databricks/sdk/service/catalog.py linguist-generated=true
 databricks/sdk/service/compute.py linguist-generated=true

--- a/databricks/sdk/service/billing.py
+++ b/databricks/sdk/service/billing.py
@@ -542,15 +542,15 @@ class BudgetsAPI:
         parsed = BudgetList.from_dict(json).budgets
         return parsed if parsed is not None else []
 
-    def update(self, budget: Budget, budget_id: str):
+    def update(self, budget_id: str, budget: Budget):
         """Modify budget.
         
         Modifies a budget in this account. Budget properties are completely overwritten.
         
-        :param budget: :class:`Budget`
-          Budget configuration to be created.
         :param budget_id: str
           Budget ID
+        :param budget: :class:`Budget`
+          Budget configuration to be created.
         
         
         """
@@ -705,7 +705,7 @@ class LogDeliveryAPI:
         parsed = WrappedLogDeliveryConfigurations.from_dict(json).log_delivery_configurations
         return parsed if parsed is not None else []
 
-    def patch_status(self, status: LogDeliveryConfigStatus, log_delivery_configuration_id: str):
+    def patch_status(self, log_delivery_configuration_id: str, status: LogDeliveryConfigStatus):
         """Enable or disable log delivery configuration.
         
         Enables or disables a log delivery configuration. Deletion of delivery configurations is not
@@ -713,13 +713,13 @@ class LogDeliveryAPI:
         re-enable a delivery configuration if this would violate the delivery configuration limits described
         under [Create log delivery](:method:LogDelivery/Create).
         
+        :param log_delivery_configuration_id: str
+          Databricks log delivery configuration ID
         :param status: :class:`LogDeliveryConfigStatus`
           Status of log delivery configuration. Set to `ENABLED` (enabled) or `DISABLED` (disabled). Defaults
           to `ENABLED`. You can [enable or disable the
           configuration](#operation/patch-log-delivery-config-status) later. Deletion of a configuration is
           not supported, so disable a log delivery configuration that is no longer needed.
-        :param log_delivery_configuration_id: str
-          Databricks log delivery configuration ID
         
         
         """

--- a/databricks/sdk/service/catalog.py
+++ b/databricks/sdk/service/catalog.py
@@ -3552,18 +3552,18 @@ class ArtifactAllowlistsAPI:
                            headers=headers)
         return ArtifactAllowlistInfo.from_dict(res)
 
-    def update(self, artifact_matchers: List[ArtifactMatcher],
-               artifact_type: ArtifactType) -> ArtifactAllowlistInfo:
+    def update(self, artifact_type: ArtifactType,
+               artifact_matchers: List[ArtifactMatcher]) -> ArtifactAllowlistInfo:
         """Set an artifact allowlist.
         
         Set the artifact allowlist of a certain artifact type. The whole artifact allowlist is replaced with
         the new allowlist. The caller must be a metastore admin or have the **MANAGE ALLOWLIST** privilege on
         the metastore.
         
-        :param artifact_matchers: List[:class:`ArtifactMatcher`]
-          A list of allowed artifact match patterns.
         :param artifact_type: :class:`ArtifactType`
           The artifact type of the allowlist.
+        :param artifact_matchers: List[:class:`ArtifactMatcher`]
+          A list of allowed artifact match patterns.
         
         :returns: :class:`ArtifactAllowlistInfo`
         """
@@ -3820,21 +3820,21 @@ class ConnectionsAPI:
         return parsed if parsed is not None else []
 
     def update(self,
+               name_arg: str,
                name: str,
                options: Dict[str, str],
-               name_arg: str,
                *,
                owner: Optional[str] = None) -> ConnectionInfo:
         """Update a connection.
         
         Updates the connection that matches the supplied name.
         
+        :param name_arg: str
+          Name of the connection.
         :param name: str
           Name of the connection.
         :param options: Dict[str,str]
           A map of key-value properties attached to the securable.
-        :param name_arg: str
-          Name of the connection.
         :param owner: str (optional)
           Username of current owner of the connection.
         
@@ -4348,19 +4348,19 @@ class MetastoresAPI:
     def __init__(self, api_client):
         self._api = api_client
 
-    def assign(self, metastore_id: str, default_catalog_name: str, workspace_id: int):
+    def assign(self, workspace_id: int, metastore_id: str, default_catalog_name: str):
         """Create an assignment.
         
         Creates a new metastore assignment. If an assignment for the same __workspace_id__ exists, it will be
         overwritten by the new __metastore_id__ and __default_catalog_name__. The caller must be an account
         admin.
         
+        :param workspace_id: int
+          A workspace ID.
         :param metastore_id: str
           The unique ID of the metastore.
         :param default_catalog_name: str
           The name of the default catalog in the metastore.
-        :param workspace_id: int
-          A workspace ID.
         
         
         """

--- a/databricks/sdk/service/compute.py
+++ b/databricks/sdk/service/compute.py
@@ -5084,9 +5084,9 @@ class GlobalInitScriptsAPI:
         return parsed if parsed is not None else []
 
     def update(self,
+               script_id: str,
                name: str,
                script: str,
-               script_id: str,
                *,
                enabled: Optional[bool] = None,
                position: Optional[int] = None):
@@ -5095,12 +5095,12 @@ class GlobalInitScriptsAPI:
         Updates a global init script, specifying only the fields to change. All fields are optional.
         Unspecified fields retain their current value.
         
+        :param script_id: str
+          The ID of the global init script.
         :param name: str
           The name of the script
         :param script: str
           The Base64-encoded content of the script.
-        :param script_id: str
-          The ID of the global init script.
         :param enabled: bool (optional)
           Specifies whether the script is enabled. The script runs only if enabled.
         :param position: int (optional)

--- a/databricks/sdk/service/iam.py
+++ b/databricks/sdk/service/iam.py
@@ -2721,18 +2721,18 @@ class WorkspaceAssignmentAPI:
         parsed = PermissionAssignments.from_dict(json).permission_assignments
         return parsed if parsed is not None else []
 
-    def update(self, permissions: List[WorkspacePermission], workspace_id: int, principal_id: int):
+    def update(self, workspace_id: int, principal_id: int, permissions: List[WorkspacePermission]):
         """Create or update permissions assignment.
         
         Creates or updates the workspace permissions assignment in a given account and workspace for the
         specified principal.
         
-        :param permissions: List[:class:`WorkspacePermission`]
-          Array of permissions assignments to update on the workspace.
         :param workspace_id: int
           The workspace ID.
         :param principal_id: int
           The ID of the user, service principal, or group.
+        :param permissions: List[:class:`WorkspacePermission`]
+          Array of permissions assignments to update on the workspace.
         
         
         """

--- a/databricks/sdk/service/provisioning.py
+++ b/databricks/sdk/service/provisioning.py
@@ -1467,9 +1467,9 @@ class PrivateAccessAPI:
         return [PrivateAccessSettings.from_dict(v) for v in res]
 
     def replace(self,
+                private_access_settings_id: str,
                 private_access_settings_name: str,
                 region: str,
-                private_access_settings_id: str,
                 *,
                 allowed_vpc_endpoint_ids: Optional[List[str]] = None,
                 private_access_level: Optional[PrivateAccessLevel] = None,
@@ -1494,12 +1494,12 @@ class PrivateAccessAPI:
         [AWS PrivateLink]: https://aws.amazon.com/privatelink
         [Databricks article about PrivateLink]: https://docs.databricks.com/administration-guide/cloud-configurations/aws/privatelink.html
         
+        :param private_access_settings_id: str
+          Databricks Account API private access settings ID.
         :param private_access_settings_name: str
           The human-readable name of the private access settings object.
         :param region: str
           The cloud region for workspaces associated with this private access settings object.
-        :param private_access_settings_id: str
-          Databricks Account API private access settings ID.
         :param allowed_vpc_endpoint_ids: List[str] (optional)
           An array of Databricks VPC endpoint IDs. This is the Databricks ID that is returned when registering
           the VPC endpoint configuration in your Databricks account. This is not the ID of the VPC endpoint in

--- a/databricks/sdk/service/serving.py
+++ b/databricks/sdk/service/serving.py
@@ -1111,8 +1111,8 @@ class ServingEndpointsAPI:
         return ServingEndpointPermissions.from_dict(res)
 
     def update_config(self,
-                      served_models: List[ServedModelInput],
                       name: str,
+                      served_models: List[ServedModelInput],
                       *,
                       traffic_config: Optional[TrafficConfig] = None) -> Wait[ServingEndpointDetailed]:
         """Update a serving endpoint with a new config.
@@ -1121,11 +1121,11 @@ class ServingEndpointsAPI:
         served models, and the endpoint's traffic config. An endpoint that already has an update in progress
         can not be updated until the current update completes or fails.
         
+        :param name: str
+          The name of the serving endpoint to update. This field is required.
         :param served_models: List[:class:`ServedModelInput`]
           A list of served models for the endpoint to serve. A serving endpoint can have up to 10 served
           models.
-        :param name: str
-          The name of the serving endpoint to update. This field is required.
         :param traffic_config: :class:`TrafficConfig` (optional)
           The traffic config defining how invocations to the serving endpoint should be routed.
         
@@ -1147,8 +1147,8 @@ class ServingEndpointsAPI:
 
     def update_config_and_wait(
         self,
-        served_models: List[ServedModelInput],
         name: str,
+        served_models: List[ServedModelInput],
         *,
         traffic_config: Optional[TrafficConfig] = None,
         timeout=timedelta(minutes=20)) -> ServingEndpointDetailed:

--- a/databricks/sdk/service/settings.py
+++ b/databricks/sdk/service/settings.py
@@ -840,11 +840,11 @@ class AccountIpAccessListsAPI:
         return parsed if parsed is not None else []
 
     def replace(self,
+                ip_access_list_id: str,
                 label: str,
                 list_type: ListType,
                 ip_addresses: List[str],
                 enabled: bool,
-                ip_access_list_id: str,
                 *,
                 list_id: Optional[str] = None):
         """Replace access list.
@@ -859,6 +859,8 @@ class AccountIpAccessListsAPI:
         returned with `error_code` value `INVALID_STATE`. It can take a few minutes for the changes to take
         effect.
         
+        :param ip_access_list_id: str
+          The ID for the corresponding IP access list.
         :param label: str
           Label for the IP access list. This **cannot** be empty.
         :param list_type: :class:`ListType`
@@ -870,8 +872,6 @@ class AccountIpAccessListsAPI:
           Array of IP addresses or CIDR values to be added to the IP access list.
         :param enabled: bool
           Specifies whether this IP access list is enabled.
-        :param ip_access_list_id: str
-          The ID for the corresponding IP access list.
         :param list_id: str (optional)
           Universally unique identifier (UUID) of the IP access list.
         
@@ -890,11 +890,11 @@ class AccountIpAccessListsAPI:
                      headers=headers)
 
     def update(self,
+               ip_access_list_id: str,
                label: str,
                list_type: ListType,
                ip_addresses: List[str],
                enabled: bool,
-               ip_access_list_id: str,
                *,
                list_id: Optional[str] = None):
         """Update access list.
@@ -913,6 +913,8 @@ class AccountIpAccessListsAPI:
         
         It can take a few minutes for the changes to take effect.
         
+        :param ip_access_list_id: str
+          The ID for the corresponding IP access list.
         :param label: str
           Label for the IP access list. This **cannot** be empty.
         :param list_type: :class:`ListType`
@@ -924,8 +926,6 @@ class AccountIpAccessListsAPI:
           Array of IP addresses or CIDR values to be added to the IP access list.
         :param enabled: bool
           Specifies whether this IP access list is enabled.
-        :param ip_access_list_id: str
-          The ID for the corresponding IP access list.
         :param list_id: str (optional)
           Universally unique identifier (UUID) of the IP access list.
         
@@ -1257,11 +1257,11 @@ class IpAccessListsAPI:
         return parsed if parsed is not None else []
 
     def replace(self,
+                ip_access_list_id: str,
                 label: str,
                 list_type: ListType,
                 ip_addresses: List[str],
                 enabled: bool,
-                ip_access_list_id: str,
                 *,
                 list_id: Optional[str] = None):
         """Replace access list.
@@ -1277,6 +1277,8 @@ class IpAccessListsAPI:
         effect. Note that your resulting IP access list has no effect until you enable the feature. See
         :method:workspaceconf/setStatus.
         
+        :param ip_access_list_id: str
+          The ID for the corresponding IP access list to modify.
         :param label: str
           Label for the IP access list. This **cannot** be empty.
         :param list_type: :class:`ListType`
@@ -1288,8 +1290,6 @@ class IpAccessListsAPI:
           Array of IP addresses or CIDR values to be added to the IP access list.
         :param enabled: bool
           Specifies whether this IP access list is enabled.
-        :param ip_access_list_id: str
-          The ID for the corresponding IP access list to modify.
         :param list_id: str (optional)
           Universally unique identifier (UUID) of the IP access list.
         
@@ -1305,11 +1305,11 @@ class IpAccessListsAPI:
         self._api.do('PUT', f'/api/2.0/ip-access-lists/{ip_access_list_id}', body=body, headers=headers)
 
     def update(self,
+               ip_access_list_id: str,
                label: str,
                list_type: ListType,
                ip_addresses: List[str],
                enabled: bool,
-               ip_access_list_id: str,
                *,
                list_id: Optional[str] = None):
         """Update access list.
@@ -1329,6 +1329,8 @@ class IpAccessListsAPI:
         It can take a few minutes for the changes to take effect. Note that your resulting IP access list has
         no effect until you enable the feature. See :method:workspaceconf/setStatus.
         
+        :param ip_access_list_id: str
+          The ID for the corresponding IP access list to modify.
         :param label: str
           Label for the IP access list. This **cannot** be empty.
         :param list_type: :class:`ListType`
@@ -1340,8 +1342,6 @@ class IpAccessListsAPI:
           Array of IP addresses or CIDR values to be added to the IP access list.
         :param enabled: bool
           Specifies whether this IP access list is enabled.
-        :param ip_access_list_id: str
-          The ID for the corresponding IP access list to modify.
         :param list_id: str (optional)
           Universally unique identifier (UUID) of the IP access list.
         

--- a/databricks/sdk/service/sharing.py
+++ b/databricks/sdk/service/sharing.py
@@ -1566,18 +1566,18 @@ class RecipientsAPI:
         parsed = ListRecipientsResponse.from_dict(json).recipients
         return parsed if parsed is not None else []
 
-    def rotate_token(self, existing_token_expire_in_seconds: int, name: str) -> RecipientInfo:
+    def rotate_token(self, name: str, existing_token_expire_in_seconds: int) -> RecipientInfo:
         """Rotate a token.
         
         Refreshes the specified recipient's delta sharing authentication token with the provided token info.
         The caller must be the owner of the recipient.
         
+        :param name: str
+          The name of the recipient.
         :param existing_token_expire_in_seconds: int
           The expiration time of the bearer token in ISO 8601 format. This will set the expiration_time of
           existing token only to a smaller timestamp, it cannot extend the expiration_time. Use 0 to expire
           the existing token immediately, negative number will return an error.
-        :param name: str
-          The name of the recipient.
         
         :returns: :class:`RecipientInfo`
         """

--- a/databricks/sdk/service/sql.py
+++ b/databricks/sdk/service/sql.py
@@ -242,6 +242,7 @@ class ChannelInfo:
 
 
 class ChannelName(Enum):
+    """Name of the channel"""
 
     CHANNEL_NAME_CURRENT = 'CHANNEL_NAME_CURRENT'
     CHANNEL_NAME_CUSTOM = 'CHANNEL_NAME_CUSTOM'
@@ -2579,23 +2580,23 @@ class AlertsAPI:
         return [Alert.from_dict(v) for v in res]
 
     def update(self,
+               alert_id: str,
                name: str,
                options: AlertOptions,
                query_id: str,
-               alert_id: str,
                *,
                rearm: Optional[int] = None):
         """Update an alert.
         
         Updates an alert.
         
+        :param alert_id: str
         :param name: str
           Name of the alert.
         :param options: :class:`AlertOptions`
           Alert configuration options.
         :param query_id: str
           Query ID.
-        :param alert_id: str
         :param rearm: int (optional)
           Number of seconds after being triggered before the alert rearms itself and can be triggered again.
           If `null`, alert will never be triggered again.
@@ -2662,21 +2663,21 @@ class DashboardWidgetsAPI:
         self._api.do('DELETE', f'/api/2.0/preview/sql/widgets/{id}', headers=headers)
 
     def update(self,
+               id: str,
                dashboard_id: str,
                options: WidgetOptions,
                width: int,
-               id: str,
                *,
                text: Optional[str] = None,
                visualization_id: Optional[str] = None) -> Widget:
         """Update existing widget.
         
+        :param id: str
         :param dashboard_id: str
           Dashboard ID returned by :method:dashboards/create.
         :param options: :class:`WidgetOptions`
         :param width: int
           Width of a widget
-        :param id: str
         :param text: str (optional)
           If this is a textbox widget, the application displays this text. This field is ignored if the widget
           contains a visualization in the `visualization` field.

--- a/docs/account/budgets.rst
+++ b/docs/account/budgets.rst
@@ -108,7 +108,7 @@ Budgets
         :returns: Iterator over :class:`BudgetWithStatus`
         
 
-    .. py:method:: update(budget, budget_id)
+    .. py:method:: update(budget_id, budget)
 
         Usage:
 
@@ -147,10 +147,10 @@ Budgets
         
         Modifies a budget in this account. Budget properties are completely overwritten.
         
-        :param budget: :class:`Budget`
-          Budget configuration to be created.
         :param budget_id: str
           Budget ID
+        :param budget: :class:`Budget`
+          Budget configuration to be created.
         
         
         

--- a/docs/account/ip_access_lists.rst
+++ b/docs/account/ip_access_lists.rst
@@ -133,7 +133,7 @@ Account IP Access Lists
         :returns: Iterator over :class:`IpAccessListInfo`
         
 
-    .. py:method:: replace(label, list_type, ip_addresses, enabled, ip_access_list_id [, list_id])
+    .. py:method:: replace(ip_access_list_id, label, list_type, ip_addresses, enabled [, list_id])
 
         Usage:
 
@@ -171,6 +171,8 @@ Account IP Access Lists
         returned with `error_code` value `INVALID_STATE`. It can take a few minutes for the changes to take
         effect.
         
+        :param ip_access_list_id: str
+          The ID for the corresponding IP access list.
         :param label: str
           Label for the IP access list. This **cannot** be empty.
         :param list_type: :class:`ListType`
@@ -182,15 +184,13 @@ Account IP Access Lists
           Array of IP addresses or CIDR values to be added to the IP access list.
         :param enabled: bool
           Specifies whether this IP access list is enabled.
-        :param ip_access_list_id: str
-          The ID for the corresponding IP access list.
         :param list_id: str (optional)
           Universally unique identifier (UUID) of the IP access list.
         
         
         
 
-    .. py:method:: update(label, list_type, ip_addresses, enabled, ip_access_list_id [, list_id])
+    .. py:method:: update(ip_access_list_id, label, list_type, ip_addresses, enabled [, list_id])
 
         Update access list.
         
@@ -208,6 +208,8 @@ Account IP Access Lists
         
         It can take a few minutes for the changes to take effect.
         
+        :param ip_access_list_id: str
+          The ID for the corresponding IP access list.
         :param label: str
           Label for the IP access list. This **cannot** be empty.
         :param list_type: :class:`ListType`
@@ -219,8 +221,6 @@ Account IP Access Lists
           Array of IP addresses or CIDR values to be added to the IP access list.
         :param enabled: bool
           Specifies whether this IP access list is enabled.
-        :param ip_access_list_id: str
-          The ID for the corresponding IP access list.
         :param list_id: str (optional)
           Universally unique identifier (UUID) of the IP access list.
         

--- a/docs/account/log_delivery.rst
+++ b/docs/account/log_delivery.rst
@@ -186,7 +186,7 @@ Log delivery configurations
         :returns: Iterator over :class:`LogDeliveryConfiguration`
         
 
-    .. py:method:: patch_status(status, log_delivery_configuration_id)
+    .. py:method:: patch_status(log_delivery_configuration_id, status)
 
         Enable or disable log delivery configuration.
         
@@ -195,13 +195,13 @@ Log delivery configurations
         re-enable a delivery configuration if this would violate the delivery configuration limits described
         under [Create log delivery](:method:LogDelivery/Create).
         
+        :param log_delivery_configuration_id: str
+          Databricks log delivery configuration ID
         :param status: :class:`LogDeliveryConfigStatus`
           Status of log delivery configuration. Set to `ENABLED` (enabled) or `DISABLED` (disabled). Defaults
           to `ENABLED`. You can [enable or disable the
           configuration](#operation/patch-log-delivery-config-status) later. Deletion of a configuration is
           not supported, so disable a log delivery configuration that is no longer needed.
-        :param log_delivery_configuration_id: str
-          Databricks log delivery configuration ID
         
         
         

--- a/docs/account/private_access.rst
+++ b/docs/account/private_access.rst
@@ -143,7 +143,7 @@ Private Access Settings
         :returns: Iterator over :class:`PrivateAccessSettings`
         
 
-    .. py:method:: replace(private_access_settings_name, region, private_access_settings_id [, allowed_vpc_endpoint_ids, private_access_level, public_access_enabled])
+    .. py:method:: replace(private_access_settings_id, private_access_settings_name, region [, allowed_vpc_endpoint_ids, private_access_level, public_access_enabled])
 
         Usage:
 
@@ -186,12 +186,12 @@ Private Access Settings
         [AWS PrivateLink]: https://aws.amazon.com/privatelink
         [Databricks article about PrivateLink]: https://docs.databricks.com/administration-guide/cloud-configurations/aws/privatelink.html
         
+        :param private_access_settings_id: str
+          Databricks Account API private access settings ID.
         :param private_access_settings_name: str
           The human-readable name of the private access settings object.
         :param region: str
           The cloud region for workspaces associated with this private access settings object.
-        :param private_access_settings_id: str
-          Databricks Account API private access settings ID.
         :param allowed_vpc_endpoint_ids: List[str] (optional)
           An array of Databricks VPC endpoint IDs. This is the Databricks ID that is returned when registering
           the VPC endpoint configuration in your Databricks account. This is not the ID of the VPC endpoint in

--- a/docs/account/workspace_assignment.rst
+++ b/docs/account/workspace_assignment.rst
@@ -58,7 +58,7 @@ Workspace Assignment
         :returns: Iterator over :class:`PermissionAssignment`
         
 
-    .. py:method:: update(permissions, workspace_id, principal_id)
+    .. py:method:: update(workspace_id, principal_id, permissions)
 
         Usage:
 
@@ -76,7 +76,7 @@ Workspace Assignment
             
             spn_id = spn.id
             
-            workspace_id = os.environ["TEST_WORKSPACE_ID"]
+            workspace_id = os.environ["DUMMY_WORKSPACE_ID"]
             
             a.workspace_assignment.update(workspace_id=workspace_id,
                                           principal_id=spn_id,
@@ -87,12 +87,12 @@ Workspace Assignment
         Creates or updates the workspace permissions assignment in a given account and workspace for the
         specified principal.
         
-        :param permissions: List[:class:`WorkspacePermission`]
-          Array of permissions assignments to update on the workspace.
         :param workspace_id: int
           The workspace ID.
         :param principal_id: int
           The ID of the user, service principal, or group.
+        :param permissions: List[:class:`WorkspacePermission`]
+          Array of permissions assignments to update on the workspace.
         
         
         

--- a/docs/workspace/alerts.rst
+++ b/docs/workspace/alerts.rst
@@ -125,7 +125,7 @@ Alerts
         :returns: Iterator over :class:`Alert`
         
 
-    .. py:method:: update(name, options, query_id, alert_id [, rearm])
+    .. py:method:: update(alert_id, name, options, query_id [, rearm])
 
         Usage:
 
@@ -162,13 +162,13 @@ Alerts
         
         Updates an alert.
         
+        :param alert_id: str
         :param name: str
           Name of the alert.
         :param options: :class:`AlertOptions`
           Alert configuration options.
         :param query_id: str
           Query ID.
-        :param alert_id: str
         :param rearm: int (optional)
           Number of seconds after being triggered before the alert rearms itself and can be triggered again.
           If `null`, alert will never be triggered again.

--- a/docs/workspace/artifact_allowlists.rst
+++ b/docs/workspace/artifact_allowlists.rst
@@ -18,7 +18,7 @@ Artifact Allowlists
         :returns: :class:`ArtifactAllowlistInfo`
         
 
-    .. py:method:: update(artifact_matchers, artifact_type)
+    .. py:method:: update(artifact_type, artifact_matchers)
 
         Set an artifact allowlist.
         
@@ -26,10 +26,10 @@ Artifact Allowlists
         the new allowlist. The caller must be a metastore admin or have the **MANAGE ALLOWLIST** privilege on
         the metastore.
         
-        :param artifact_matchers: List[:class:`ArtifactMatcher`]
-          A list of allowed artifact match patterns.
         :param artifact_type: :class:`ArtifactType`
           The artifact type of the allowlist.
+        :param artifact_matchers: List[:class:`ArtifactMatcher`]
+          A list of allowed artifact match patterns.
         
         :returns: :class:`ArtifactAllowlistInfo`
         

--- a/docs/workspace/connections.rst
+++ b/docs/workspace/connections.rst
@@ -144,7 +144,7 @@ Connections
         :returns: Iterator over :class:`ConnectionInfo`
         
 
-    .. py:method:: update(name, options, name_arg [, owner])
+    .. py:method:: update(name_arg, name, options [, owner])
 
         Usage:
 
@@ -187,12 +187,12 @@ Connections
         
         Updates the connection that matches the supplied name.
         
+        :param name_arg: str
+          Name of the connection.
         :param name: str
           Name of the connection.
         :param options: Dict[str,str]
           A map of key-value properties attached to the securable.
-        :param name_arg: str
-          Name of the connection.
         :param owner: str (optional)
           Username of current owner of the connection.
         

--- a/docs/workspace/dashboard_widgets.rst
+++ b/docs/workspace/dashboard_widgets.rst
@@ -32,16 +32,16 @@ Dashboard Widgets
         
         
 
-    .. py:method:: update(dashboard_id, options, width, id [, text, visualization_id])
+    .. py:method:: update(id, dashboard_id, options, width [, text, visualization_id])
 
         Update existing widget.
         
+        :param id: str
         :param dashboard_id: str
           Dashboard ID returned by :method:dashboards/create.
         :param options: :class:`WidgetOptions`
         :param width: int
           Width of a widget
-        :param id: str
         :param text: str (optional)
           If this is a textbox widget, the application displays this text. This field is ignored if the widget
           contains a visualization in the `visualization` field.

--- a/docs/workspace/global_init_scripts.rst
+++ b/docs/workspace/global_init_scripts.rst
@@ -121,7 +121,7 @@ Global Init Scripts
         :returns: Iterator over :class:`GlobalInitScriptDetails`
         
 
-    .. py:method:: update(name, script, script_id [, enabled, position])
+    .. py:method:: update(script_id, name, script [, enabled, position])
 
         Usage:
 
@@ -151,12 +151,12 @@ Global Init Scripts
         Updates a global init script, specifying only the fields to change. All fields are optional.
         Unspecified fields retain their current value.
         
+        :param script_id: str
+          The ID of the global init script.
         :param name: str
           The name of the script
         :param script: str
           The Base64-encoded content of the script.
-        :param script_id: str
-          The ID of the global init script.
         :param enabled: bool (optional)
           Specifies whether the script is enabled. The script runs only if enabled.
         :param position: int (optional)

--- a/docs/workspace/ip_access_lists.rst
+++ b/docs/workspace/ip_access_lists.rst
@@ -133,7 +133,7 @@ IP Access Lists
         :returns: Iterator over :class:`IpAccessListInfo`
         
 
-    .. py:method:: replace(label, list_type, ip_addresses, enabled, ip_access_list_id [, list_id])
+    .. py:method:: replace(ip_access_list_id, label, list_type, ip_addresses, enabled [, list_id])
 
         Usage:
 
@@ -172,6 +172,8 @@ IP Access Lists
         effect. Note that your resulting IP access list has no effect until you enable the feature. See
         :method:workspaceconf/setStatus.
         
+        :param ip_access_list_id: str
+          The ID for the corresponding IP access list to modify.
         :param label: str
           Label for the IP access list. This **cannot** be empty.
         :param list_type: :class:`ListType`
@@ -183,15 +185,13 @@ IP Access Lists
           Array of IP addresses or CIDR values to be added to the IP access list.
         :param enabled: bool
           Specifies whether this IP access list is enabled.
-        :param ip_access_list_id: str
-          The ID for the corresponding IP access list to modify.
         :param list_id: str (optional)
           Universally unique identifier (UUID) of the IP access list.
         
         
         
 
-    .. py:method:: update(label, list_type, ip_addresses, enabled, ip_access_list_id [, list_id])
+    .. py:method:: update(ip_access_list_id, label, list_type, ip_addresses, enabled [, list_id])
 
         Update access list.
         
@@ -210,6 +210,8 @@ IP Access Lists
         It can take a few minutes for the changes to take effect. Note that your resulting IP access list has
         no effect until you enable the feature. See :method:workspaceconf/setStatus.
         
+        :param ip_access_list_id: str
+          The ID for the corresponding IP access list to modify.
         :param label: str
           Label for the IP access list. This **cannot** be empty.
         :param list_type: :class:`ListType`
@@ -221,8 +223,6 @@ IP Access Lists
           Array of IP addresses or CIDR values to be added to the IP access list.
         :param enabled: bool
           Specifies whether this IP access list is enabled.
-        :param ip_access_list_id: str
-          The ID for the corresponding IP access list to modify.
         :param list_id: str (optional)
           Universally unique identifier (UUID) of the IP access list.
         

--- a/docs/workspace/metastores.rst
+++ b/docs/workspace/metastores.rst
@@ -14,7 +14,7 @@ Metastores
     Catalog was released. If your workspace includes a legacy Hive metastore, the data in that metastore is
     available in a catalog named hive_metastore.
 
-    .. py:method:: assign(metastore_id, default_catalog_name, workspace_id)
+    .. py:method:: assign(workspace_id, metastore_id, default_catalog_name)
 
         Usage:
 
@@ -27,7 +27,7 @@ Metastores
             
             w = WorkspaceClient()
             
-            workspace_id = os.environ["TEST_WORKSPACE_ID"]
+            workspace_id = os.environ["DUMMY_WORKSPACE_ID"]
             
             created = w.metastores.create(name=f'sdk-{time.time_ns()}',
                                           storage_root="s3://%s/%s" %
@@ -44,12 +44,12 @@ Metastores
         overwritten by the new __metastore_id__ and __default_catalog_name__. The caller must be an account
         admin.
         
+        :param workspace_id: int
+          A workspace ID.
         :param metastore_id: str
           The unique ID of the metastore.
         :param default_catalog_name: str
           The name of the default catalog in the metastore.
-        :param workspace_id: int
-          A workspace ID.
         
         
         
@@ -242,7 +242,7 @@ Metastores
             
             w = WorkspaceClient()
             
-            workspace_id = os.environ["TEST_WORKSPACE_ID"]
+            workspace_id = os.environ["DUMMY_WORKSPACE_ID"]
             
             created = w.metastores.create(name=f'sdk-{time.time_ns()}',
                                           storage_root="s3://%s/%s" %

--- a/docs/workspace/recipients.rst
+++ b/docs/workspace/recipients.rst
@@ -131,7 +131,7 @@ Recipients
         :returns: Iterator over :class:`RecipientInfo`
         
 
-    .. py:method:: rotate_token(existing_token_expire_in_seconds, name)
+    .. py:method:: rotate_token(name, existing_token_expire_in_seconds)
 
         Usage:
 
@@ -155,12 +155,12 @@ Recipients
         Refreshes the specified recipient's delta sharing authentication token with the provided token info.
         The caller must be the owner of the recipient.
         
+        :param name: str
+          The name of the recipient.
         :param existing_token_expire_in_seconds: int
           The expiration time of the bearer token in ISO 8601 format. This will set the expiration_time of
           existing token only to a smaller timestamp, it cannot extend the expiration_time. Use 0 to expire
           the existing token immediately, negative number will return an error.
-        :param name: str
-          The name of the recipient.
         
         :returns: :class:`RecipientInfo`
         

--- a/docs/workspace/serving_endpoints.rst
+++ b/docs/workspace/serving_endpoints.rst
@@ -173,7 +173,7 @@ Serving endpoints
         :returns: :class:`ServingEndpointPermissions`
         
 
-    .. py:method:: update_config(served_models, name [, traffic_config])
+    .. py:method:: update_config(name, served_models [, traffic_config])
 
         Update a serving endpoint with a new config.
         
@@ -181,11 +181,11 @@ Serving endpoints
         served models, and the endpoint's traffic config. An endpoint that already has an update in progress
         can not be updated until the current update completes or fails.
         
+        :param name: str
+          The name of the serving endpoint to update. This field is required.
         :param served_models: List[:class:`ServedModelInput`]
           A list of served models for the endpoint to serve. A serving endpoint can have up to 10 served
           models.
-        :param name: str
-          The name of the serving endpoint to update. This field is required.
         :param traffic_config: :class:`TrafficConfig` (optional)
           The traffic config defining how invocations to the serving endpoint should be routed.
         

--- a/examples/metastores/assign_metastores.py
+++ b/examples/metastores/assign_metastores.py
@@ -5,7 +5,7 @@ from databricks.sdk import WorkspaceClient
 
 w = WorkspaceClient()
 
-workspace_id = os.environ["TEST_WORKSPACE_ID"]
+workspace_id = os.environ["DUMMY_WORKSPACE_ID"]
 
 created = w.metastores.create(name=f'sdk-{time.time_ns()}',
                               storage_root="s3://%s/%s" %

--- a/examples/metastores/unassign_metastores.py
+++ b/examples/metastores/unassign_metastores.py
@@ -5,7 +5,7 @@ from databricks.sdk import WorkspaceClient
 
 w = WorkspaceClient()
 
-workspace_id = os.environ["TEST_WORKSPACE_ID"]
+workspace_id = os.environ["DUMMY_WORKSPACE_ID"]
 
 created = w.metastores.create(name=f'sdk-{time.time_ns()}',
                               storage_root="s3://%s/%s" %

--- a/examples/workspace_assignment/list_workspace_assignment_on_aws.py
+++ b/examples/workspace_assignment/list_workspace_assignment_on_aws.py
@@ -4,6 +4,6 @@ from databricks.sdk import AccountClient
 
 a = AccountClient()
 
-workspace_id = os.environ["TEST_WORKSPACE_ID"]
+workspace_id = os.environ["DUMMY_WORKSPACE_ID"]
 
 all = a.workspace_assignment.list(workspace_id=workspace_id)

--- a/examples/workspace_assignment/update_workspace_assignment_on_aws.py
+++ b/examples/workspace_assignment/update_workspace_assignment_on_aws.py
@@ -10,7 +10,7 @@ spn = a.service_principals.create(display_name=f'sdk-{time.time_ns()}')
 
 spn_id = spn.id
 
-workspace_id = os.environ["TEST_WORKSPACE_ID"]
+workspace_id = os.environ["DUMMY_WORKSPACE_ID"]
 
 a.workspace_assignment.update(workspace_id=workspace_id,
                               principal_id=spn_id,


### PR DESCRIPTION
## Changes
Several changes were made to our codegen tool:
1. Path parameters will always precede body parameters in methods. This ensures that path parameters always come first, i.e. the ID of the object. This is a pretty bad breaking change for customers, but fortunately only a handful of APIs, primarily update APIs, are affected, namely:
  * AlertsAPI.update
  * DashboardWidgetsAPI.update
  * RecipientsAPI.rotate_token
  * AccountIPAccessListsAPI.update and AccountsIPAccessListsAPI.replace
  * IPAccessListsAPI.update and IPAccessListsAPI.replace
  * ServingEndpointsAPI.update_config and ServingEndpointsAPI.update_config_and_wait
  * PrivateAccessAPI.replace
  * WorkspaceAssignmentsAPI.update
  * GlobalInitScriptsAPI.update
  * MetastoresAPI.assign
  * ConnectionsAPI.update
  * ArtifactAllowlistsAPI.update
  * BudgetsAPI.update
  * LogDeliveryAPI.patch_status
2. New integration tests were added, so there are new autogenerated examples in the SDK.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

