### PR TITLE
Make ucws tests skipped when DATABRICKS_ACCOUNT_ID is present

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -71,6 +71,7 @@ def w(env_or_skip) -> WorkspaceClient:
 def ucws(env_or_skip) -> WorkspaceClient:
     _load_debug_env_if_runs_from_ide('ucws')
     env_or_skip("CLOUD_ENV")
+    skip_for_env("DATABRICKS_ACCOUNT_ID")
     if 'TEST_METASTORE_ID' not in os.environ:
         pytest.skip("not in Unity Catalog Workspace test env")
     return WorkspaceClient()
@@ -85,6 +86,17 @@ def env_or_skip():
         return os.environ[var]
 
     return inner
+
+@pytest.fixture(scope='session')
+def skip_for_env():
+
+    def inner(var) -> str:
+        if var in os.environ and os.environ[var] != "":
+            pytest.skip(f'Environment variable {var} is set')
+        return os.environ[var]
+
+    return inner
+
 
 
 def _load_debug_env_if_runs_from_ide(key) -> bool:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -68,10 +68,11 @@ def w(env_or_skip) -> WorkspaceClient:
 
 
 @pytest.fixture(scope='session')
-def ucws(env_or_skip, skip_for_env) -> WorkspaceClient:
+def ucws(env_or_skip) -> WorkspaceClient:
     _load_debug_env_if_runs_from_ide('ucws')
     env_or_skip("CLOUD_ENV")
-    skip_for_env("DATABRICKS_ACCOUNT_ID")
+    if 'DATABRICKS_ACCOUNT_ID' in os.environ:
+        pytest.skip("Skipping workspace test on account level")
     if 'TEST_METASTORE_ID' not in os.environ:
         pytest.skip("not in Unity Catalog Workspace test env")
     return WorkspaceClient()
@@ -83,17 +84,6 @@ def env_or_skip():
     def inner(var) -> str:
         if var not in os.environ:
             pytest.skip(f'Environment variable {var} is missing')
-        return os.environ[var]
-
-    return inner
-
-
-@pytest.fixture(scope='session')
-def skip_for_env():
-
-    def inner(var) -> str:
-        if var in os.environ and os.environ[var] != "":
-            pytest.skip(f'Environment variable {var} is set')
         return os.environ[var]
 
     return inner

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -68,7 +68,7 @@ def w(env_or_skip) -> WorkspaceClient:
 
 
 @pytest.fixture(scope='session')
-def ucws(env_or_skip) -> WorkspaceClient:
+def ucws(env_or_skip, skip_for_env) -> WorkspaceClient:
     _load_debug_env_if_runs_from_ide('ucws')
     env_or_skip("CLOUD_ENV")
     skip_for_env("DATABRICKS_ACCOUNT_ID")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -87,6 +87,7 @@ def env_or_skip():
 
     return inner
 
+
 @pytest.fixture(scope='session')
 def skip_for_env():
 
@@ -96,7 +97,6 @@ def skip_for_env():
         return os.environ[var]
 
     return inner
-
 
 
 def _load_debug_env_if_runs_from_ide(key) -> bool:


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
- Added `skip_for_env` function and make all tests with `ucws` skip when `DATABRICKS_ACCOUNT_ID` is present

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->
Verified that the ucws tests got skipped when running `make dev integration`
- [ ] `make test` run locally
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

