### PR TITLE
Fix deserialization of repeated enums

### DIFF
--- a/.codegen/service.py.tmpl
+++ b/.codegen/service.py.tmpl
@@ -8,7 +8,7 @@ import time
 import random
 import logging
 from ..errors import OperationTimeout, OperationFailed
-from ._internal import _enum, _from_dict, _repeated, Wait
+from ._internal import _enum, _from_dict, _repeated_dict, _repeated_enum, Wait
 
 _LOG = logging.getLogger('databricks.sdk')
 
@@ -45,8 +45,9 @@ class {{.PascalName}}{{if eq "List" .PascalName}}Request{{end}}:{{if .Descriptio
 {{- define "from_dict_type" -}}
 	{{- if not .Entity }}None
 	{{- else if .Entity.ArrayValue }}
-		{{- if .Entity.ArrayValue.IsObject }}_repeated(d, '{{.Name}}', {{template "type-nq" .Entity.ArrayValue}})
-		{{- else if .Entity.ArrayValue.IsExternal }}_repeated(d, '{{.Name}}', {{template "type-nq" .Entity.ArrayValue}})
+		{{- if .Entity.ArrayValue.IsObject }}_repeated_dict(d, '{{.Name}}', {{template "type-nq" .Entity.ArrayValue}})
+		{{- else if .Entity.ArrayValue.IsExternal }}_repeated_dict(d, '{{.Name}}', {{.Entity.Package.Name}}.{{template "type-nq" .Entity.ArrayValue}})
+		{{- else if .Entity.ArrayValue.Enum }}_repeated_enum(d, '{{.Name}}', {{template "type-nq" .Entity.ArrayValue}})
 		{{- else}}d.get('{{.Name}}', None){{- end -}}
 	{{- else if .Entity.IsObject }}_from_dict(d, '{{.Name}}', {{.Entity.PascalName}})
 	{{- else if .Entity.IsExternal }}_from_dict(d, '{{.Name}}', {{.Entity.Package.Name}}.{{.Entity.PascalName}})

--- a/databricks/sdk/service/_internal.py
+++ b/databricks/sdk/service/_internal.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Callable, Dict, Generic, Type, TypeVar, Optional
+from typing import Callable, Dict, Generic, Optional, Type, TypeVar
 
 
 def _from_dict(d: Dict[str, any], field: str, cls: Type) -> any:

--- a/databricks/sdk/service/_internal.py
+++ b/databricks/sdk/service/_internal.py
@@ -8,7 +8,7 @@ def _from_dict(d: Dict[str, any], field: str, cls: Type) -> any:
     return getattr(cls, 'from_dict')(d[field])
 
 
-def _repeated(d: Dict[str, any], field: str, cls: Type) -> any:
+def _repeated_dict(d: Dict[str, any], field: str, cls: Type) -> any:
     if field not in d or not d[field]:
         return None
     from_dict = getattr(cls, 'from_dict')
@@ -19,6 +19,12 @@ def _enum(d: Dict[str, any], field: str, cls: Type) -> any:
     if field not in d or not d[field]:
         return None
     return next((v for v in getattr(cls, '__members__').values() if v.value == d[field]), None)
+
+
+def _repeated_enum(d: Dict[str, any], field: str, cls: Type) -> any:
+    if field not in d or not d[field]:
+        return None
+    return [next((v for v in getattr(cls, '__members__').values() if v.value == e), None) for e in d[field]]
 
 
 ReturnType = TypeVar('ReturnType')

--- a/databricks/sdk/service/_internal.py
+++ b/databricks/sdk/service/_internal.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Callable, Dict, Generic, Type, TypeVar
+from typing import Callable, Dict, Generic, Type, TypeVar, Optional
 
 
 def _from_dict(d: Dict[str, any], field: str, cls: Type) -> any:
@@ -15,16 +15,27 @@ def _repeated_dict(d: Dict[str, any], field: str, cls: Type) -> any:
     return [from_dict(v) for v in d[field]]
 
 
+def _get_enum_value(cls: Type, value: str) -> Optional[Type]:
+    return next((v for v in getattr(cls, '__members__').values() if v.value == value), None)
+
+
 def _enum(d: Dict[str, any], field: str, cls: Type) -> any:
+    """Unknown enum values are returned as None."""
     if field not in d or not d[field]:
         return None
-    return next((v for v in getattr(cls, '__members__').values() if v.value == d[field]), None)
+    return _get_enum_value(cls, d[field])
 
 
 def _repeated_enum(d: Dict[str, any], field: str, cls: Type) -> any:
+    """For now, unknown enum values are not included in the response."""
     if field not in d or not d[field]:
         return None
-    return [next((v for v in getattr(cls, '__members__').values() if v.value == e), None) for e in d[field]]
+    res = []
+    for e in d[field]:
+        val = _get_enum_value(cls, e)
+        if val:
+            res.append(val)
+    return res
 
 
 ReturnType = TypeVar('ReturnType')

--- a/databricks/sdk/service/billing.py
+++ b/databricks/sdk/service/billing.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import BinaryIO, Dict, Iterator, List, Optional
 
-from ._internal import _enum, _from_dict, _repeated
+from ._internal import _enum, _from_dict, _repeated_dict
 
 _LOG = logging.getLogger('databricks.sdk')
 
@@ -37,7 +37,7 @@ class Budget:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'Budget':
-        return cls(alerts=_repeated(d, 'alerts', BudgetAlert),
+        return cls(alerts=_repeated_dict(d, 'alerts', BudgetAlert),
                    end_date=d.get('end_date', None),
                    filter=d.get('filter', None),
                    name=d.get('name', None),
@@ -76,7 +76,7 @@ class BudgetList:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'BudgetList':
-        return cls(budgets=_repeated(d, 'budgets', BudgetWithStatus))
+        return cls(budgets=_repeated_dict(d, 'budgets', BudgetWithStatus))
 
 
 @dataclass
@@ -112,7 +112,7 @@ class BudgetWithStatus:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'BudgetWithStatus':
-        return cls(alerts=_repeated(d, 'alerts', BudgetAlert),
+        return cls(alerts=_repeated_dict(d, 'alerts', BudgetAlert),
                    budget_id=d.get('budget_id', None),
                    creation_time=d.get('creation_time', None),
                    end_date=d.get('end_date', None),
@@ -120,7 +120,7 @@ class BudgetWithStatus:
                    name=d.get('name', None),
                    period=d.get('period', None),
                    start_date=d.get('start_date', None),
-                   status_daily=_repeated(d, 'status_daily', BudgetWithStatusStatusDailyItem),
+                   status_daily=_repeated_dict(d, 'status_daily', BudgetWithStatusStatusDailyItem),
                    target_amount=d.get('target_amount', None),
                    update_time=d.get('update_time', None))
 
@@ -416,8 +416,8 @@ class WrappedLogDeliveryConfigurations:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'WrappedLogDeliveryConfigurations':
-        return cls(
-            log_delivery_configurations=_repeated(d, 'log_delivery_configurations', LogDeliveryConfiguration))
+        return cls(log_delivery_configurations=_repeated_dict(d, 'log_delivery_configurations',
+                                                              LogDeliveryConfiguration))
 
 
 class BillableUsageAPI:

--- a/databricks/sdk/service/catalog.py
+++ b/databricks/sdk/service/catalog.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Dict, Iterator, List, Optional
 
-from ._internal import _enum, _from_dict, _repeated
+from ._internal import _enum, _from_dict, _repeated_dict, _repeated_enum
 
 _LOG = logging.getLogger('databricks.sdk')
 
@@ -180,7 +180,7 @@ class ArtifactAllowlistInfo:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'ArtifactAllowlistInfo':
-        return cls(artifact_matchers=_repeated(d, 'artifact_matchers', ArtifactMatcher),
+        return cls(artifact_matchers=_repeated_dict(d, 'artifact_matchers', ArtifactMatcher),
                    created_at=d.get('created_at', None),
                    created_by=d.get('created_by', None),
                    metastore_id=d.get('metastore_id', None))
@@ -1065,7 +1065,7 @@ class DependencyList:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'DependencyList':
-        return cls(dependencies=_repeated(d, 'dependencies', Dependency))
+        return cls(dependencies=_repeated_dict(d, 'dependencies', Dependency))
 
 
 class DisableSchemaName(Enum):
@@ -1088,7 +1088,8 @@ class EffectivePermissionsList:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'EffectivePermissionsList':
-        return cls(privilege_assignments=_repeated(d, 'privilege_assignments', EffectivePrivilegeAssignment))
+        return cls(
+            privilege_assignments=_repeated_dict(d, 'privilege_assignments', EffectivePrivilegeAssignment))
 
 
 @dataclass
@@ -1154,7 +1155,7 @@ class EffectivePrivilegeAssignment:
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'EffectivePrivilegeAssignment':
         return cls(principal=d.get('principal', None),
-                   privileges=_repeated(d, 'privileges', EffectivePrivilege))
+                   privileges=_repeated_dict(d, 'privileges', EffectivePrivilege))
 
 
 class EnablePredictiveOptimization(Enum):
@@ -1467,7 +1468,7 @@ class FunctionParameterInfos:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'FunctionParameterInfos':
-        return cls(parameters=_repeated(d, 'parameters', FunctionParameterInfo))
+        return cls(parameters=_repeated_dict(d, 'parameters', FunctionParameterInfo))
 
 
 class FunctionParameterMode(Enum):
@@ -1598,7 +1599,7 @@ class ListCatalogsResponse:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'ListCatalogsResponse':
-        return cls(catalogs=_repeated(d, 'catalogs', CatalogInfo))
+        return cls(catalogs=_repeated_dict(d, 'catalogs', CatalogInfo))
 
 
 @dataclass
@@ -1612,7 +1613,7 @@ class ListConnectionsResponse:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'ListConnectionsResponse':
-        return cls(connections=_repeated(d, 'connections', ConnectionInfo))
+        return cls(connections=_repeated_dict(d, 'connections', ConnectionInfo))
 
 
 @dataclass
@@ -1627,7 +1628,7 @@ class ListExternalLocationsResponse:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'ListExternalLocationsResponse':
-        return cls(external_locations=_repeated(d, 'external_locations', ExternalLocationInfo))
+        return cls(external_locations=_repeated_dict(d, 'external_locations', ExternalLocationInfo))
 
 
 @dataclass
@@ -1641,7 +1642,7 @@ class ListFunctionsResponse:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'ListFunctionsResponse':
-        return cls(functions=_repeated(d, 'functions', FunctionInfo))
+        return cls(functions=_repeated_dict(d, 'functions', FunctionInfo))
 
 
 @dataclass
@@ -1655,7 +1656,7 @@ class ListMetastoresResponse:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'ListMetastoresResponse':
-        return cls(metastores=_repeated(d, 'metastores', MetastoreInfo))
+        return cls(metastores=_repeated_dict(d, 'metastores', MetastoreInfo))
 
 
 @dataclass
@@ -1671,7 +1672,7 @@ class ListModelVersionsResponse:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'ListModelVersionsResponse':
-        return cls(model_versions=_repeated(d, 'model_versions', ModelVersionInfo),
+        return cls(model_versions=_repeated_dict(d, 'model_versions', ModelVersionInfo),
                    next_page_token=d.get('next_page_token', None))
 
 
@@ -1689,7 +1690,7 @@ class ListRegisteredModelsResponse:
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'ListRegisteredModelsResponse':
         return cls(next_page_token=d.get('next_page_token', None),
-                   registered_models=_repeated(d, 'registered_models', RegisteredModelInfo))
+                   registered_models=_repeated_dict(d, 'registered_models', RegisteredModelInfo))
 
 
 @dataclass
@@ -1703,7 +1704,7 @@ class ListSchemasResponse:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'ListSchemasResponse':
-        return cls(schemas=_repeated(d, 'schemas', SchemaInfo))
+        return cls(schemas=_repeated_dict(d, 'schemas', SchemaInfo))
 
 
 @dataclass
@@ -1718,7 +1719,7 @@ class ListStorageCredentialsResponse:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'ListStorageCredentialsResponse':
-        return cls(storage_credentials=_repeated(d, 'storage_credentials', StorageCredentialInfo))
+        return cls(storage_credentials=_repeated_dict(d, 'storage_credentials', StorageCredentialInfo))
 
 
 @dataclass
@@ -1732,7 +1733,7 @@ class ListSystemSchemasResponse:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'ListSystemSchemasResponse':
-        return cls(schemas=_repeated(d, 'schemas', SystemSchemaInfo))
+        return cls(schemas=_repeated_dict(d, 'schemas', SystemSchemaInfo))
 
 
 @dataclass
@@ -1749,7 +1750,7 @@ class ListTableSummariesResponse:
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'ListTableSummariesResponse':
         return cls(next_page_token=d.get('next_page_token', None),
-                   tables=_repeated(d, 'tables', TableSummary))
+                   tables=_repeated_dict(d, 'tables', TableSummary))
 
 
 @dataclass
@@ -1765,7 +1766,8 @@ class ListTablesResponse:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'ListTablesResponse':
-        return cls(next_page_token=d.get('next_page_token', None), tables=_repeated(d, 'tables', TableInfo))
+        return cls(next_page_token=d.get('next_page_token', None),
+                   tables=_repeated_dict(d, 'tables', TableInfo))
 
 
 @dataclass
@@ -1779,7 +1781,7 @@ class ListVolumesResponseContent:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'ListVolumesResponseContent':
-        return cls(volumes=_repeated(d, 'volumes', VolumeInfo))
+        return cls(volumes=_repeated_dict(d, 'volumes', VolumeInfo))
 
 
 class MatchType(Enum):
@@ -1990,7 +1992,9 @@ class PermissionsChange:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'PermissionsChange':
-        return cls(add=d.get('add', None), principal=d.get('principal', None), remove=d.get('remove', None))
+        return cls(add=_repeated_enum(d, 'add', Privilege),
+                   principal=d.get('principal', None),
+                   remove=_repeated_enum(d, 'remove', Privilege))
 
 
 @dataclass
@@ -2005,7 +2009,7 @@ class PermissionsList:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'PermissionsList':
-        return cls(privilege_assignments=_repeated(d, 'privilege_assignments', PrivilegeAssignment))
+        return cls(privilege_assignments=_repeated_dict(d, 'privilege_assignments', PrivilegeAssignment))
 
 
 @dataclass
@@ -2082,7 +2086,7 @@ class PrivilegeAssignment:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'PrivilegeAssignment':
-        return cls(principal=d.get('principal', None), privileges=d.get('privileges', None))
+        return cls(principal=d.get('principal', None), privileges=_repeated_enum(d, 'privileges', Privilege))
 
 
 PropertiesKvPairs = Dict[str, str]
@@ -2166,7 +2170,7 @@ class RegisteredModelInfo:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'RegisteredModelInfo':
-        return cls(aliases=_repeated(d, 'aliases', RegisteredModelAlias),
+        return cls(aliases=_repeated_dict(d, 'aliases', RegisteredModelAlias),
                    catalog_name=d.get('catalog_name', None),
                    comment=d.get('comment', None),
                    created_at=d.get('created_at', None),
@@ -2282,7 +2286,7 @@ class SetArtifactAllowlist:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'SetArtifactAllowlist':
-        return cls(artifact_matchers=_repeated(d, 'artifact_matchers', ArtifactMatcher),
+        return cls(artifact_matchers=_repeated_dict(d, 'artifact_matchers', ArtifactMatcher),
                    artifact_type=_enum(d, 'artifact_type', ArtifactType))
 
 
@@ -2453,7 +2457,7 @@ class TableConstraintList:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'TableConstraintList':
-        return cls(table_constraints=_repeated(d, 'table_constraints', TableConstraint))
+        return cls(table_constraints=_repeated_dict(d, 'table_constraints', TableConstraint))
 
 
 @dataclass
@@ -2550,7 +2554,7 @@ class TableInfo:
     def from_dict(cls, d: Dict[str, any]) -> 'TableInfo':
         return cls(access_point=d.get('access_point', None),
                    catalog_name=d.get('catalog_name', None),
-                   columns=_repeated(d, 'columns', ColumnInfo),
+                   columns=_repeated_dict(d, 'columns', ColumnInfo),
                    comment=d.get('comment', None),
                    created_at=d.get('created_at', None),
                    created_by=d.get('created_by', None),
@@ -2833,7 +2837,7 @@ class UpdatePermissions:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'UpdatePermissions':
-        return cls(changes=_repeated(d, 'changes', PermissionsChange),
+        return cls(changes=_repeated_dict(d, 'changes', PermissionsChange),
                    full_name=d.get('full_name', None),
                    securable_type=_enum(d, 'securable_type', SecurableType))
 
@@ -3026,8 +3030,8 @@ class UpdateWorkspaceBindingsParameters:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'UpdateWorkspaceBindingsParameters':
-        return cls(add=_repeated(d, 'add', WorkspaceBinding),
-                   remove=_repeated(d, 'remove', WorkspaceBinding),
+        return cls(add=_repeated_dict(d, 'add', WorkspaceBinding),
+                   remove=_repeated_dict(d, 'remove', WorkspaceBinding),
                    securable_name=d.get('securable_name', None),
                    securable_type=d.get('securable_type', None))
 
@@ -3083,7 +3087,7 @@ class ValidateStorageCredentialResponse:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'ValidateStorageCredentialResponse':
-        return cls(is_dir=d.get('isDir', None), results=_repeated(d, 'results', ValidationResult))
+        return cls(is_dir=d.get('isDir', None), results=_repeated_dict(d, 'results', ValidationResult))
 
 
 @dataclass
@@ -3224,7 +3228,7 @@ class WorkspaceBindingsResponse:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'WorkspaceBindingsResponse':
-        return cls(bindings=_repeated(d, 'bindings', WorkspaceBinding))
+        return cls(bindings=_repeated_dict(d, 'bindings', WorkspaceBinding))
 
 
 class AccountMetastoreAssignmentsAPI:

--- a/databricks/sdk/service/compute.py
+++ b/databricks/sdk/service/compute.py
@@ -9,7 +9,7 @@ from enum import Enum
 from typing import Any, Callable, Dict, Iterator, List, Optional
 
 from ..errors import OperationFailed
-from ._internal import Wait, _enum, _from_dict, _repeated
+from ._internal import Wait, _enum, _from_dict, _repeated_dict, _repeated_enum
 
 _LOG = logging.getLogger('databricks.sdk')
 
@@ -204,7 +204,7 @@ class CloudProviderNodeInfo:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'CloudProviderNodeInfo':
-        return cls(status=d.get('status', None))
+        return cls(status=_repeated_enum(d, 'status', CloudProviderNodeStatus))
 
 
 class CloudProviderNodeStatus(Enum):
@@ -257,7 +257,7 @@ class ClusterAccessControlResponse:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'ClusterAccessControlResponse':
-        return cls(all_permissions=_repeated(d, 'all_permissions', ClusterPermission),
+        return cls(all_permissions=_repeated_dict(d, 'all_permissions', ClusterPermission),
                    display_name=d.get('display_name', None),
                    group_name=d.get('group_name', None),
                    service_principal_name=d.get('service_principal_name', None),
@@ -340,7 +340,7 @@ class ClusterAttributes:
                    enable_elastic_disk=d.get('enable_elastic_disk', None),
                    enable_local_disk_encryption=d.get('enable_local_disk_encryption', None),
                    gcp_attributes=_from_dict(d, 'gcp_attributes', GcpAttributes),
-                   init_scripts=_repeated(d, 'init_scripts', InitScriptInfo),
+                   init_scripts=_repeated_dict(d, 'init_scripts', InitScriptInfo),
                    instance_pool_id=d.get('instance_pool_id', None),
                    node_type_id=d.get('node_type_id', None),
                    policy_id=d.get('policy_id', None),
@@ -476,9 +476,9 @@ class ClusterDetails:
                    driver_node_type_id=d.get('driver_node_type_id', None),
                    enable_elastic_disk=d.get('enable_elastic_disk', None),
                    enable_local_disk_encryption=d.get('enable_local_disk_encryption', None),
-                   executors=_repeated(d, 'executors', SparkNode),
+                   executors=_repeated_dict(d, 'executors', SparkNode),
                    gcp_attributes=_from_dict(d, 'gcp_attributes', GcpAttributes),
-                   init_scripts=_repeated(d, 'init_scripts', InitScriptInfo),
+                   init_scripts=_repeated_dict(d, 'init_scripts', InitScriptInfo),
                    instance_pool_id=d.get('instance_pool_id', None),
                    jdbc_port=d.get('jdbc_port', None),
                    last_restarted_time=d.get('last_restarted_time', None),
@@ -543,7 +543,7 @@ class ClusterLibraryStatuses:
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'ClusterLibraryStatuses':
         return cls(cluster_id=d.get('cluster_id', None),
-                   library_statuses=_repeated(d, 'library_statuses', LibraryFullStatus))
+                   library_statuses=_repeated_dict(d, 'library_statuses', LibraryFullStatus))
 
 
 @dataclass
@@ -606,7 +606,7 @@ class ClusterPermissions:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'ClusterPermissions':
-        return cls(access_control_list=_repeated(d, 'access_control_list', ClusterAccessControlResponse),
+        return cls(access_control_list=_repeated_dict(d, 'access_control_list', ClusterAccessControlResponse),
                    object_id=d.get('object_id', None),
                    object_type=d.get('object_type', None))
 
@@ -642,7 +642,7 @@ class ClusterPermissionsRequest:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'ClusterPermissionsRequest':
-        return cls(access_control_list=_repeated(d, 'access_control_list', ClusterAccessControlRequest),
+        return cls(access_control_list=_repeated_dict(d, 'access_control_list', ClusterAccessControlRequest),
                    cluster_id=d.get('cluster_id', None))
 
 
@@ -690,7 +690,7 @@ class ClusterPolicyAccessControlResponse:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'ClusterPolicyAccessControlResponse':
-        return cls(all_permissions=_repeated(d, 'all_permissions', ClusterPolicyPermission),
+        return cls(all_permissions=_repeated_dict(d, 'all_permissions', ClusterPolicyPermission),
                    display_name=d.get('display_name', None),
                    group_name=d.get('group_name', None),
                    service_principal_name=d.get('service_principal_name', None),
@@ -739,8 +739,8 @@ class ClusterPolicyPermissions:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'ClusterPolicyPermissions':
-        return cls(access_control_list=_repeated(d, 'access_control_list',
-                                                 ClusterPolicyAccessControlResponse),
+        return cls(access_control_list=_repeated_dict(d, 'access_control_list',
+                                                      ClusterPolicyAccessControlResponse),
                    object_id=d.get('object_id', None),
                    object_type=d.get('object_type', None))
 
@@ -776,7 +776,8 @@ class ClusterPolicyPermissionsRequest:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'ClusterPolicyPermissionsRequest':
-        return cls(access_control_list=_repeated(d, 'access_control_list', ClusterPolicyAccessControlRequest),
+        return cls(access_control_list=_repeated_dict(d, 'access_control_list',
+                                                      ClusterPolicyAccessControlRequest),
                    cluster_policy_id=d.get('cluster_policy_id', None))
 
 
@@ -894,7 +895,7 @@ class ClusterSpec:
                    enable_elastic_disk=d.get('enable_elastic_disk', None),
                    enable_local_disk_encryption=d.get('enable_local_disk_encryption', None),
                    gcp_attributes=_from_dict(d, 'gcp_attributes', GcpAttributes),
-                   init_scripts=_repeated(d, 'init_scripts', InitScriptInfo),
+                   init_scripts=_repeated_dict(d, 'init_scripts', InitScriptInfo),
                    instance_pool_id=d.get('instance_pool_id', None),
                    node_type_id=d.get('node_type_id', None),
                    num_workers=d.get('num_workers', None),
@@ -1089,7 +1090,7 @@ class CreateCluster:
                    enable_elastic_disk=d.get('enable_elastic_disk', None),
                    enable_local_disk_encryption=d.get('enable_local_disk_encryption', None),
                    gcp_attributes=_from_dict(d, 'gcp_attributes', GcpAttributes),
-                   init_scripts=_repeated(d, 'init_scripts', InitScriptInfo),
+                   init_scripts=_repeated_dict(d, 'init_scripts', InitScriptInfo),
                    instance_pool_id=d.get('instance_pool_id', None),
                    node_type_id=d.get('node_type_id', None),
                    num_workers=d.get('num_workers', None),
@@ -1182,7 +1183,7 @@ class CreateInstancePool:
                    max_capacity=d.get('max_capacity', None),
                    min_idle_instances=d.get('min_idle_instances', None),
                    node_type_id=d.get('node_type_id', None),
-                   preloaded_docker_images=_repeated(d, 'preloaded_docker_images', DockerImage),
+                   preloaded_docker_images=_repeated_dict(d, 'preloaded_docker_images', DockerImage),
                    preloaded_spark_versions=d.get('preloaded_spark_versions', None))
 
 
@@ -1226,7 +1227,7 @@ class CreatePolicy:
     def from_dict(cls, d: Dict[str, any]) -> 'CreatePolicy':
         return cls(definition=d.get('definition', None),
                    description=d.get('description', None),
-                   libraries=_repeated(d, 'libraries', Library),
+                   libraries=_repeated_dict(d, 'libraries', Library),
                    max_clusters_per_user=d.get('max_clusters_per_user', None),
                    name=d.get('name', None),
                    policy_family_definition_overrides=d.get('policy_family_definition_overrides', None),
@@ -1583,7 +1584,7 @@ class EditCluster:
                    enable_elastic_disk=d.get('enable_elastic_disk', None),
                    enable_local_disk_encryption=d.get('enable_local_disk_encryption', None),
                    gcp_attributes=_from_dict(d, 'gcp_attributes', GcpAttributes),
-                   init_scripts=_repeated(d, 'init_scripts', InitScriptInfo),
+                   init_scripts=_repeated_dict(d, 'init_scripts', InitScriptInfo),
                    instance_pool_id=d.get('instance_pool_id', None),
                    node_type_id=d.get('node_type_id', None),
                    num_workers=d.get('num_workers', None),
@@ -1658,7 +1659,7 @@ class EditPolicy:
     def from_dict(cls, d: Dict[str, any]) -> 'EditPolicy':
         return cls(definition=d.get('definition', None),
                    description=d.get('description', None),
-                   libraries=_repeated(d, 'libraries', Library),
+                   libraries=_repeated_dict(d, 'libraries', Library),
                    max_clusters_per_user=d.get('max_clusters_per_user', None),
                    name=d.get('name', None),
                    policy_family_definition_overrides=d.get('policy_family_definition_overrides', None),
@@ -1821,7 +1822,7 @@ class GetClusterPermissionLevelsResponse:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'GetClusterPermissionLevelsResponse':
-        return cls(permission_levels=_repeated(d, 'permission_levels', ClusterPermissionsDescription))
+        return cls(permission_levels=_repeated_dict(d, 'permission_levels', ClusterPermissionsDescription))
 
 
 @dataclass
@@ -1835,7 +1836,8 @@ class GetClusterPolicyPermissionLevelsResponse:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'GetClusterPolicyPermissionLevelsResponse':
-        return cls(permission_levels=_repeated(d, 'permission_levels', ClusterPolicyPermissionsDescription))
+        return cls(
+            permission_levels=_repeated_dict(d, 'permission_levels', ClusterPolicyPermissionsDescription))
 
 
 @dataclass
@@ -1863,7 +1865,7 @@ class GetEvents:
     def from_dict(cls, d: Dict[str, any]) -> 'GetEvents':
         return cls(cluster_id=d.get('cluster_id', None),
                    end_time=d.get('end_time', None),
-                   event_types=d.get('event_types', None),
+                   event_types=_repeated_enum(d, 'event_types', EventType),
                    limit=d.get('limit', None),
                    offset=d.get('offset', None),
                    order=_enum(d, 'order', GetEventsOrder),
@@ -1892,7 +1894,7 @@ class GetEventsResponse:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'GetEventsResponse':
-        return cls(events=_repeated(d, 'events', ClusterEvent),
+        return cls(events=_repeated_dict(d, 'events', ClusterEvent),
                    next_page=_from_dict(d, 'next_page', GetEvents),
                    total_count=d.get('total_count', None))
 
@@ -1958,7 +1960,7 @@ class GetInstancePool:
                    max_capacity=d.get('max_capacity', None),
                    min_idle_instances=d.get('min_idle_instances', None),
                    node_type_id=d.get('node_type_id', None),
-                   preloaded_docker_images=_repeated(d, 'preloaded_docker_images', DockerImage),
+                   preloaded_docker_images=_repeated_dict(d, 'preloaded_docker_images', DockerImage),
                    preloaded_spark_versions=d.get('preloaded_spark_versions', None),
                    state=_enum(d, 'state', InstancePoolState),
                    stats=_from_dict(d, 'stats', InstancePoolStats),
@@ -1976,7 +1978,8 @@ class GetInstancePoolPermissionLevelsResponse:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'GetInstancePoolPermissionLevelsResponse':
-        return cls(permission_levels=_repeated(d, 'permission_levels', InstancePoolPermissionsDescription))
+        return cls(
+            permission_levels=_repeated_dict(d, 'permission_levels', InstancePoolPermissionsDescription))
 
 
 @dataclass
@@ -1990,7 +1993,7 @@ class GetSparkVersionsResponse:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'GetSparkVersionsResponse':
-        return cls(versions=_repeated(d, 'versions', SparkVersion))
+        return cls(versions=_repeated_dict(d, 'versions', SparkVersion))
 
 
 @dataclass
@@ -2130,8 +2133,8 @@ class InitScriptEventDetails:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'InitScriptEventDetails':
-        return cls(cluster=_repeated(d, 'cluster', InitScriptInfoAndExecutionDetails),
-                   global_=_repeated(d, 'global', InitScriptInfoAndExecutionDetails),
+        return cls(cluster=_repeated_dict(d, 'cluster', InitScriptInfoAndExecutionDetails),
+                   global_=_repeated_dict(d, 'global', InitScriptInfoAndExecutionDetails),
                    reported_for_node=d.get('reported_for_node', None))
 
 
@@ -2223,7 +2226,7 @@ class InstallLibraries:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'InstallLibraries':
-        return cls(cluster_id=d.get('cluster_id', None), libraries=_repeated(d, 'libraries', Library))
+        return cls(cluster_id=d.get('cluster_id', None), libraries=_repeated_dict(d, 'libraries', Library))
 
 
 @dataclass
@@ -2270,7 +2273,7 @@ class InstancePoolAccessControlResponse:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'InstancePoolAccessControlResponse':
-        return cls(all_permissions=_repeated(d, 'all_permissions', InstancePoolPermission),
+        return cls(all_permissions=_repeated_dict(d, 'all_permissions', InstancePoolPermission),
                    display_name=d.get('display_name', None),
                    group_name=d.get('group_name', None),
                    service_principal_name=d.get('service_principal_name', None),
@@ -2338,7 +2341,7 @@ class InstancePoolAndStats:
                    max_capacity=d.get('max_capacity', None),
                    min_idle_instances=d.get('min_idle_instances', None),
                    node_type_id=d.get('node_type_id', None),
-                   preloaded_docker_images=_repeated(d, 'preloaded_docker_images', DockerImage),
+                   preloaded_docker_images=_repeated_dict(d, 'preloaded_docker_images', DockerImage),
                    preloaded_spark_versions=d.get('preloaded_spark_versions', None),
                    state=_enum(d, 'state', InstancePoolState),
                    stats=_from_dict(d, 'stats', InstancePoolStats),
@@ -2464,7 +2467,8 @@ class InstancePoolPermissions:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'InstancePoolPermissions':
-        return cls(access_control_list=_repeated(d, 'access_control_list', InstancePoolAccessControlResponse),
+        return cls(access_control_list=_repeated_dict(d, 'access_control_list',
+                                                      InstancePoolAccessControlResponse),
                    object_id=d.get('object_id', None),
                    object_type=d.get('object_type', None))
 
@@ -2500,7 +2504,8 @@ class InstancePoolPermissionsRequest:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'InstancePoolPermissionsRequest':
-        return cls(access_control_list=_repeated(d, 'access_control_list', InstancePoolAccessControlRequest),
+        return cls(access_control_list=_repeated_dict(d, 'access_control_list',
+                                                      InstancePoolAccessControlRequest),
                    instance_pool_id=d.get('instance_pool_id', None))
 
 
@@ -2547,7 +2552,7 @@ class InstancePoolStatus:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'InstancePoolStatus':
-        return cls(pending_instance_errors=_repeated(d, 'pending_instance_errors', PendingInstanceError))
+        return cls(pending_instance_errors=_repeated_dict(d, 'pending_instance_errors', PendingInstanceError))
 
 
 @dataclass
@@ -2654,7 +2659,7 @@ class ListAllClusterLibraryStatusesResponse:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'ListAllClusterLibraryStatusesResponse':
-        return cls(statuses=_repeated(d, 'statuses', ClusterLibraryStatuses))
+        return cls(statuses=_repeated_dict(d, 'statuses', ClusterLibraryStatuses))
 
 
 @dataclass
@@ -2684,7 +2689,7 @@ class ListClustersResponse:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'ListClustersResponse':
-        return cls(clusters=_repeated(d, 'clusters', ClusterDetails))
+        return cls(clusters=_repeated_dict(d, 'clusters', ClusterDetails))
 
 
 @dataclass
@@ -2698,7 +2703,7 @@ class ListGlobalInitScriptsResponse:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'ListGlobalInitScriptsResponse':
-        return cls(scripts=_repeated(d, 'scripts', GlobalInitScriptDetails))
+        return cls(scripts=_repeated_dict(d, 'scripts', GlobalInitScriptDetails))
 
 
 @dataclass
@@ -2712,7 +2717,7 @@ class ListInstancePools:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'ListInstancePools':
-        return cls(instance_pools=_repeated(d, 'instance_pools', InstancePoolAndStats))
+        return cls(instance_pools=_repeated_dict(d, 'instance_pools', InstancePoolAndStats))
 
 
 @dataclass
@@ -2726,7 +2731,7 @@ class ListInstanceProfilesResponse:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'ListInstanceProfilesResponse':
-        return cls(instance_profiles=_repeated(d, 'instance_profiles', InstanceProfile))
+        return cls(instance_profiles=_repeated_dict(d, 'instance_profiles', InstanceProfile))
 
 
 @dataclass
@@ -2740,7 +2745,7 @@ class ListNodeTypesResponse:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'ListNodeTypesResponse':
-        return cls(node_types=_repeated(d, 'node_types', NodeType))
+        return cls(node_types=_repeated_dict(d, 'node_types', NodeType))
 
 
 @dataclass
@@ -2754,7 +2759,7 @@ class ListPoliciesResponse:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'ListPoliciesResponse':
-        return cls(policies=_repeated(d, 'policies', Policy))
+        return cls(policies=_repeated_dict(d, 'policies', Policy))
 
 
 @dataclass
@@ -2771,7 +2776,7 @@ class ListPolicyFamiliesResponse:
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'ListPolicyFamiliesResponse':
         return cls(next_page_token=d.get('next_page_token', None),
-                   policy_families=_repeated(d, 'policy_families', PolicyFamily))
+                   policy_families=_repeated_dict(d, 'policy_families', PolicyFamily))
 
 
 class ListSortColumn(Enum):
@@ -3039,7 +3044,7 @@ class Policy:
                    definition=d.get('definition', None),
                    description=d.get('description', None),
                    is_default=d.get('is_default', None),
-                   libraries=_repeated(d, 'libraries', Library),
+                   libraries=_repeated_dict(d, 'libraries', Library),
                    max_clusters_per_user=d.get('max_clusters_per_user', None),
                    name=d.get('name', None),
                    policy_family_definition_overrides=d.get('policy_family_definition_overrides', None),
@@ -3458,7 +3463,7 @@ class UninstallLibraries:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'UninstallLibraries':
-        return cls(cluster_id=d.get('cluster_id', None), libraries=_repeated(d, 'libraries', Library))
+        return cls(cluster_id=d.get('cluster_id', None), libraries=_repeated_dict(d, 'libraries', Library))
 
 
 @dataclass

--- a/databricks/sdk/service/files.py
+++ b/databricks/sdk/service/files.py
@@ -4,7 +4,7 @@ import logging
 from dataclasses import dataclass
 from typing import BinaryIO, Dict, Iterator, List, Optional
 
-from ._internal import _repeated
+from ._internal import _repeated_dict
 
 _LOG = logging.getLogger('databricks.sdk')
 
@@ -126,7 +126,7 @@ class ListStatusResponse:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'ListStatusResponse':
-        return cls(files=_repeated(d, 'files', FileInfo))
+        return cls(files=_repeated_dict(d, 'files', FileInfo))
 
 
 @dataclass

--- a/databricks/sdk/service/iam.py
+++ b/databricks/sdk/service/iam.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Dict, Iterator, List, Optional
 
-from ._internal import _enum, _from_dict, _repeated
+from ._internal import _enum, _from_dict, _repeated_dict, _repeated_enum
 
 _LOG = logging.getLogger('databricks.sdk')
 
@@ -56,7 +56,7 @@ class AccessControlResponse:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'AccessControlResponse':
-        return cls(all_permissions=_repeated(d, 'all_permissions', Permission),
+        return cls(all_permissions=_repeated_dict(d, 'all_permissions', Permission),
                    display_name=d.get('display_name', None),
                    group_name=d.get('group_name', None),
                    service_principal_name=d.get('service_principal_name', None),
@@ -97,7 +97,7 @@ class GetAssignableRolesForResourceResponse:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'GetAssignableRolesForResourceResponse':
-        return cls(roles=_repeated(d, 'roles', Role))
+        return cls(roles=_repeated_dict(d, 'roles', Role))
 
 
 @dataclass
@@ -111,7 +111,7 @@ class GetPasswordPermissionLevelsResponse:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'GetPasswordPermissionLevelsResponse':
-        return cls(permission_levels=_repeated(d, 'permission_levels', PasswordPermissionsDescription))
+        return cls(permission_levels=_repeated_dict(d, 'permission_levels', PasswordPermissionsDescription))
 
 
 @dataclass
@@ -125,7 +125,7 @@ class GetPermissionLevelsResponse:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'GetPermissionLevelsResponse':
-        return cls(permission_levels=_repeated(d, 'permission_levels', PermissionsDescription))
+        return cls(permission_levels=_repeated_dict(d, 'permission_levels', PermissionsDescription))
 
 
 class GetSortOrder(Enum):
@@ -178,14 +178,14 @@ class Group:
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'Group':
         return cls(display_name=d.get('displayName', None),
-                   entitlements=_repeated(d, 'entitlements', ComplexValue),
+                   entitlements=_repeated_dict(d, 'entitlements', ComplexValue),
                    external_id=d.get('externalId', None),
-                   groups=_repeated(d, 'groups', ComplexValue),
+                   groups=_repeated_dict(d, 'groups', ComplexValue),
                    id=d.get('id', None),
-                   members=_repeated(d, 'members', ComplexValue),
+                   members=_repeated_dict(d, 'members', ComplexValue),
                    meta=_from_dict(d, 'meta', ResourceMeta),
-                   roles=_repeated(d, 'roles', ComplexValue),
-                   schemas=d.get('schemas', None))
+                   roles=_repeated_dict(d, 'roles', ComplexValue),
+                   schemas=_repeated_enum(d, 'schemas', GroupSchema))
 
 
 class GroupSchema(Enum):
@@ -213,8 +213,8 @@ class ListGroupsResponse:
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'ListGroupsResponse':
         return cls(items_per_page=d.get('itemsPerPage', None),
-                   resources=_repeated(d, 'Resources', Group),
-                   schemas=d.get('schemas', None),
+                   resources=_repeated_dict(d, 'Resources', Group),
+                   schemas=_repeated_enum(d, 'schemas', ListResponseSchema),
                    start_index=d.get('startIndex', None),
                    total_results=d.get('totalResults', None))
 
@@ -244,8 +244,8 @@ class ListServicePrincipalResponse:
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'ListServicePrincipalResponse':
         return cls(items_per_page=d.get('itemsPerPage', None),
-                   resources=_repeated(d, 'Resources', ServicePrincipal),
-                   schemas=d.get('schemas', None),
+                   resources=_repeated_dict(d, 'Resources', ServicePrincipal),
+                   schemas=_repeated_enum(d, 'schemas', ListResponseSchema),
                    start_index=d.get('startIndex', None),
                    total_results=d.get('totalResults', None))
 
@@ -276,8 +276,8 @@ class ListUsersResponse:
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'ListUsersResponse':
         return cls(items_per_page=d.get('itemsPerPage', None),
-                   resources=_repeated(d, 'Resources', User),
-                   schemas=d.get('schemas', None),
+                   resources=_repeated_dict(d, 'Resources', User),
+                   schemas=_repeated_enum(d, 'schemas', ListResponseSchema),
                    start_index=d.get('startIndex', None),
                    total_results=d.get('totalResults', None))
 
@@ -314,7 +314,7 @@ class ObjectPermissions:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'ObjectPermissions':
-        return cls(access_control_list=_repeated(d, 'access_control_list', AccessControlResponse),
+        return cls(access_control_list=_repeated_dict(d, 'access_control_list', AccessControlResponse),
                    object_id=d.get('object_id', None),
                    object_type=d.get('object_type', None))
 
@@ -335,8 +335,8 @@ class PartialUpdate:
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'PartialUpdate':
         return cls(id=d.get('id', None),
-                   operations=_repeated(d, 'Operations', Patch),
-                   schemas=d.get('schemas', None))
+                   operations=_repeated_dict(d, 'Operations', Patch),
+                   schemas=_repeated_enum(d, 'schemas', PatchSchema))
 
 
 @dataclass
@@ -383,7 +383,7 @@ class PasswordAccessControlResponse:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'PasswordAccessControlResponse':
-        return cls(all_permissions=_repeated(d, 'all_permissions', PasswordPermission),
+        return cls(all_permissions=_repeated_dict(d, 'all_permissions', PasswordPermission),
                    display_name=d.get('display_name', None),
                    group_name=d.get('group_name', None),
                    service_principal_name=d.get('service_principal_name', None),
@@ -432,7 +432,8 @@ class PasswordPermissions:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'PasswordPermissions':
-        return cls(access_control_list=_repeated(d, 'access_control_list', PasswordAccessControlResponse),
+        return cls(access_control_list=_repeated_dict(d, 'access_control_list',
+                                                      PasswordAccessControlResponse),
                    object_id=d.get('object_id', None),
                    object_type=d.get('object_type', None))
 
@@ -466,7 +467,7 @@ class PasswordPermissionsRequest:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'PasswordPermissionsRequest':
-        return cls(access_control_list=_repeated(d, 'access_control_list', PasswordAccessControlRequest))
+        return cls(access_control_list=_repeated_dict(d, 'access_control_list', PasswordAccessControlRequest))
 
 
 @dataclass
@@ -536,7 +537,7 @@ class PermissionAssignment:
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'PermissionAssignment':
         return cls(error=d.get('error', None),
-                   permissions=d.get('permissions', None),
+                   permissions=_repeated_enum(d, 'permissions', WorkspacePermission),
                    principal=_from_dict(d, 'principal', PrincipalOutput))
 
 
@@ -552,7 +553,7 @@ class PermissionAssignments:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'PermissionAssignments':
-        return cls(permission_assignments=_repeated(d, 'permission_assignments', PermissionAssignment))
+        return cls(permission_assignments=_repeated_dict(d, 'permission_assignments', PermissionAssignment))
 
 
 class PermissionLevel(Enum):
@@ -625,7 +626,7 @@ class PermissionsRequest:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'PermissionsRequest':
-        return cls(access_control_list=_repeated(d, 'access_control_list', AccessControlRequest),
+        return cls(access_control_list=_repeated_dict(d, 'access_control_list', AccessControlRequest),
                    request_object_id=d.get('request_object_id', None),
                    request_object_type=d.get('request_object_type', None))
 
@@ -701,7 +702,7 @@ class RuleSetResponse:
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'RuleSetResponse':
         return cls(etag=d.get('etag', None),
-                   grant_rules=_repeated(d, 'grant_rules', GrantRule),
+                   grant_rules=_repeated_dict(d, 'grant_rules', GrantRule),
                    name=d.get('name', None))
 
 
@@ -721,7 +722,7 @@ class RuleSetUpdateRequest:
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'RuleSetUpdateRequest':
         return cls(etag=d.get('etag', None),
-                   grant_rules=_repeated(d, 'grant_rules', GrantRule),
+                   grant_rules=_repeated_dict(d, 'grant_rules', GrantRule),
                    name=d.get('name', None))
 
 
@@ -755,12 +756,12 @@ class ServicePrincipal:
         return cls(active=d.get('active', None),
                    application_id=d.get('applicationId', None),
                    display_name=d.get('displayName', None),
-                   entitlements=_repeated(d, 'entitlements', ComplexValue),
+                   entitlements=_repeated_dict(d, 'entitlements', ComplexValue),
                    external_id=d.get('externalId', None),
-                   groups=_repeated(d, 'groups', ComplexValue),
+                   groups=_repeated_dict(d, 'groups', ComplexValue),
                    id=d.get('id', None),
-                   roles=_repeated(d, 'roles', ComplexValue),
-                   schemas=d.get('schemas', None))
+                   roles=_repeated_dict(d, 'roles', ComplexValue),
+                   schemas=_repeated_enum(d, 'schemas', ServicePrincipalSchema))
 
 
 class ServicePrincipalSchema(Enum):
@@ -799,7 +800,7 @@ class UpdateWorkspaceAssignments:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'UpdateWorkspaceAssignments':
-        return cls(permissions=d.get('permissions', None),
+        return cls(permissions=_repeated_enum(d, 'permissions', WorkspacePermission),
                    principal_id=d.get('principal_id', None),
                    workspace_id=d.get('workspace_id', None))
 
@@ -837,14 +838,14 @@ class User:
     def from_dict(cls, d: Dict[str, any]) -> 'User':
         return cls(active=d.get('active', None),
                    display_name=d.get('displayName', None),
-                   emails=_repeated(d, 'emails', ComplexValue),
-                   entitlements=_repeated(d, 'entitlements', ComplexValue),
+                   emails=_repeated_dict(d, 'emails', ComplexValue),
+                   entitlements=_repeated_dict(d, 'entitlements', ComplexValue),
                    external_id=d.get('externalId', None),
-                   groups=_repeated(d, 'groups', ComplexValue),
+                   groups=_repeated_dict(d, 'groups', ComplexValue),
                    id=d.get('id', None),
                    name=_from_dict(d, 'name', Name),
-                   roles=_repeated(d, 'roles', ComplexValue),
-                   schemas=d.get('schemas', None),
+                   roles=_repeated_dict(d, 'roles', ComplexValue),
+                   schemas=_repeated_enum(d, 'schemas', UserSchema),
                    user_name=d.get('userName', None))
 
 
@@ -871,7 +872,7 @@ class WorkspacePermissions:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'WorkspacePermissions':
-        return cls(permissions=_repeated(d, 'permissions', PermissionOutput))
+        return cls(permissions=_repeated_dict(d, 'permissions', PermissionOutput))
 
 
 class AccountAccessControlAPI:

--- a/databricks/sdk/service/jobs.py
+++ b/databricks/sdk/service/jobs.py
@@ -9,7 +9,7 @@ from enum import Enum
 from typing import Any, Callable, Dict, Iterator, List, Optional
 
 from ..errors import OperationFailed
-from ._internal import Wait, _enum, _from_dict, _repeated
+from ._internal import Wait, _enum, _from_dict, _repeated_dict
 
 _LOG = logging.getLogger('databricks.sdk')
 
@@ -114,9 +114,9 @@ class BaseRun:
                    end_time=d.get('end_time', None),
                    execution_duration=d.get('execution_duration', None),
                    git_source=_from_dict(d, 'git_source', GitSource),
-                   job_clusters=_repeated(d, 'job_clusters', JobCluster),
+                   job_clusters=_repeated_dict(d, 'job_clusters', JobCluster),
                    job_id=d.get('job_id', None),
-                   job_parameters=_repeated(d, 'job_parameters', JobParameter),
+                   job_parameters=_repeated_dict(d, 'job_parameters', JobParameter),
                    number_in_job=d.get('number_in_job', None),
                    original_attempt_run_id=d.get('original_attempt_run_id', None),
                    overriding_parameters=_from_dict(d, 'overriding_parameters', RunParameters),
@@ -129,7 +129,7 @@ class BaseRun:
                    setup_duration=d.get('setup_duration', None),
                    start_time=d.get('start_time', None),
                    state=_from_dict(d, 'state', RunState),
-                   tasks=_repeated(d, 'tasks', RunTask),
+                   tasks=_repeated_dict(d, 'tasks', RunTask),
                    trigger=_enum(d, 'trigger', TriggerType),
                    trigger_info=_from_dict(d, 'trigger_info', TriggerInfo))
 
@@ -196,7 +196,7 @@ class ClusterSpec:
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'ClusterSpec':
         return cls(existing_cluster_id=d.get('existing_cluster_id', None),
-                   libraries=_repeated(d, 'libraries', compute.Library),
+                   libraries=_repeated_dict(d, 'libraries', jobs.compute.Library),
                    new_cluster=_from_dict(d, 'new_cluster', compute.ClusterSpec))
 
 
@@ -305,8 +305,9 @@ class CreateJob:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'CreateJob':
-        return cls(access_control_list=_repeated(d, 'access_control_list', iam.AccessControlRequest),
-                   compute=_repeated(d, 'compute', JobCompute),
+        return cls(access_control_list=_repeated_dict(d, 'access_control_list',
+                                                      jobs.iam.AccessControlRequest),
+                   compute=_repeated_dict(d, 'compute', JobCompute),
                    continuous=_from_dict(d, 'continuous', Continuous),
                    deployment=_from_dict(d, 'deployment', JobDeployment),
                    edit_mode=_enum(d, 'edit_mode', CreateJobEditMode),
@@ -314,16 +315,16 @@ class CreateJob:
                    format=_enum(d, 'format', Format),
                    git_source=_from_dict(d, 'git_source', GitSource),
                    health=_from_dict(d, 'health', JobsHealthRules),
-                   job_clusters=_repeated(d, 'job_clusters', JobCluster),
+                   job_clusters=_repeated_dict(d, 'job_clusters', JobCluster),
                    max_concurrent_runs=d.get('max_concurrent_runs', None),
                    name=d.get('name', None),
                    notification_settings=_from_dict(d, 'notification_settings', JobNotificationSettings),
-                   parameters=_repeated(d, 'parameters', JobParameterDefinition),
+                   parameters=_repeated_dict(d, 'parameters', JobParameterDefinition),
                    queue=_from_dict(d, 'queue', QueueSettings),
                    run_as=_from_dict(d, 'run_as', JobRunAs),
                    schedule=_from_dict(d, 'schedule', CronSchedule),
                    tags=d.get('tags', None),
-                   tasks=_repeated(d, 'tasks', Task),
+                   tasks=_repeated_dict(d, 'tasks', Task),
                    timeout_seconds=d.get('timeout_seconds', None),
                    trigger=_from_dict(d, 'trigger', TriggerSettings),
                    webhook_notifications=_from_dict(d, 'webhook_notifications', WebhookNotifications))
@@ -459,7 +460,7 @@ class ExportRunOutput:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'ExportRunOutput':
-        return cls(views=_repeated(d, 'views', ViewItem))
+        return cls(views=_repeated_dict(d, 'views', ViewItem))
 
 
 @dataclass
@@ -501,7 +502,7 @@ class GetJobPermissionLevelsResponse:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'GetJobPermissionLevelsResponse':
-        return cls(permission_levels=_repeated(d, 'permission_levels', JobPermissionsDescription))
+        return cls(permission_levels=_repeated_dict(d, 'permission_levels', JobPermissionsDescription))
 
 
 class GitProvider(Enum):
@@ -647,7 +648,7 @@ class JobAccessControlResponse:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'JobAccessControlResponse':
-        return cls(all_permissions=_repeated(d, 'all_permissions', JobPermission),
+        return cls(all_permissions=_repeated_dict(d, 'all_permissions', JobPermission),
                    display_name=d.get('display_name', None),
                    group_name=d.get('group_name', None),
                    service_principal_name=d.get('service_principal_name', None),
@@ -841,7 +842,7 @@ class JobPermissions:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'JobPermissions':
-        return cls(access_control_list=_repeated(d, 'access_control_list', JobAccessControlResponse),
+        return cls(access_control_list=_repeated_dict(d, 'access_control_list', JobAccessControlResponse),
                    object_id=d.get('object_id', None),
                    object_type=d.get('object_type', None))
 
@@ -877,7 +878,7 @@ class JobPermissionsRequest:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'JobPermissionsRequest':
-        return cls(access_control_list=_repeated(d, 'access_control_list', JobAccessControlRequest),
+        return cls(access_control_list=_repeated_dict(d, 'access_control_list', JobAccessControlRequest),
                    job_id=d.get('job_id', None))
 
 
@@ -957,7 +958,7 @@ class JobSettings:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'JobSettings':
-        return cls(compute=_repeated(d, 'compute', JobCompute),
+        return cls(compute=_repeated_dict(d, 'compute', JobCompute),
                    continuous=_from_dict(d, 'continuous', Continuous),
                    deployment=_from_dict(d, 'deployment', JobDeployment),
                    edit_mode=_enum(d, 'edit_mode', JobSettingsEditMode),
@@ -965,16 +966,16 @@ class JobSettings:
                    format=_enum(d, 'format', Format),
                    git_source=_from_dict(d, 'git_source', GitSource),
                    health=_from_dict(d, 'health', JobsHealthRules),
-                   job_clusters=_repeated(d, 'job_clusters', JobCluster),
+                   job_clusters=_repeated_dict(d, 'job_clusters', JobCluster),
                    max_concurrent_runs=d.get('max_concurrent_runs', None),
                    name=d.get('name', None),
                    notification_settings=_from_dict(d, 'notification_settings', JobNotificationSettings),
-                   parameters=_repeated(d, 'parameters', JobParameterDefinition),
+                   parameters=_repeated_dict(d, 'parameters', JobParameterDefinition),
                    queue=_from_dict(d, 'queue', QueueSettings),
                    run_as=_from_dict(d, 'run_as', JobRunAs),
                    schedule=_from_dict(d, 'schedule', CronSchedule),
                    tags=d.get('tags', None),
-                   tasks=_repeated(d, 'tasks', Task),
+                   tasks=_repeated_dict(d, 'tasks', Task),
                    timeout_seconds=d.get('timeout_seconds', None),
                    trigger=_from_dict(d, 'trigger', TriggerSettings),
                    webhook_notifications=_from_dict(d, 'webhook_notifications', WebhookNotifications))
@@ -1072,7 +1073,7 @@ class JobsHealthRules:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'JobsHealthRules':
-        return cls(rules=_repeated(d, 'rules', JobsHealthRule))
+        return cls(rules=_repeated_dict(d, 'rules', JobsHealthRule))
 
 
 @dataclass
@@ -1093,7 +1094,7 @@ class ListJobsResponse:
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'ListJobsResponse':
         return cls(has_more=d.get('has_more', None),
-                   jobs=_repeated(d, 'jobs', BaseJob),
+                   jobs=_repeated_dict(d, 'jobs', BaseJob),
                    next_page_token=d.get('next_page_token', None),
                    prev_page_token=d.get('prev_page_token', None))
 
@@ -1118,7 +1119,7 @@ class ListRunsResponse:
         return cls(has_more=d.get('has_more', None),
                    next_page_token=d.get('next_page_token', None),
                    prev_page_token=d.get('prev_page_token', None),
-                   runs=_repeated(d, 'runs', BaseRun))
+                   runs=_repeated_dict(d, 'runs', BaseRun))
 
 
 class ListRunsRunType(Enum):
@@ -1585,13 +1586,13 @@ class Run:
                    end_time=d.get('end_time', None),
                    execution_duration=d.get('execution_duration', None),
                    git_source=_from_dict(d, 'git_source', GitSource),
-                   job_clusters=_repeated(d, 'job_clusters', JobCluster),
+                   job_clusters=_repeated_dict(d, 'job_clusters', JobCluster),
                    job_id=d.get('job_id', None),
-                   job_parameters=_repeated(d, 'job_parameters', JobParameter),
+                   job_parameters=_repeated_dict(d, 'job_parameters', JobParameter),
                    number_in_job=d.get('number_in_job', None),
                    original_attempt_run_id=d.get('original_attempt_run_id', None),
                    overriding_parameters=_from_dict(d, 'overriding_parameters', RunParameters),
-                   repair_history=_repeated(d, 'repair_history', RepairHistoryItem),
+                   repair_history=_repeated_dict(d, 'repair_history', RepairHistoryItem),
                    run_duration=d.get('run_duration', None),
                    run_id=d.get('run_id', None),
                    run_name=d.get('run_name', None),
@@ -1601,7 +1602,7 @@ class Run:
                    setup_duration=d.get('setup_duration', None),
                    start_time=d.get('start_time', None),
                    state=_from_dict(d, 'state', RunState),
-                   tasks=_repeated(d, 'tasks', RunTask),
+                   tasks=_repeated_dict(d, 'tasks', RunTask),
                    trigger=_enum(d, 'trigger', TriggerType),
                    trigger_info=_from_dict(d, 'trigger_info', TriggerInfo))
 
@@ -1973,13 +1974,13 @@ class RunTask:
                    cluster_instance=_from_dict(d, 'cluster_instance', ClusterInstance),
                    condition_task=_from_dict(d, 'condition_task', RunConditionTask),
                    dbt_task=_from_dict(d, 'dbt_task', DbtTask),
-                   depends_on=_repeated(d, 'depends_on', TaskDependency),
+                   depends_on=_repeated_dict(d, 'depends_on', TaskDependency),
                    description=d.get('description', None),
                    end_time=d.get('end_time', None),
                    execution_duration=d.get('execution_duration', None),
                    existing_cluster_id=d.get('existing_cluster_id', None),
                    git_source=_from_dict(d, 'git_source', GitSource),
-                   libraries=_repeated(d, 'libraries', compute.Library),
+                   libraries=_repeated_dict(d, 'libraries', jobs.compute.Library),
                    new_cluster=_from_dict(d, 'new_cluster', compute.ClusterSpec),
                    notebook_task=_from_dict(d, 'notebook_task', NotebookTask),
                    pipeline_task=_from_dict(d, 'pipeline_task', PipelineTask),
@@ -2093,7 +2094,7 @@ class SqlAlertOutput:
         return cls(alert_state=_enum(d, 'alert_state', SqlAlertState),
                    output_link=d.get('output_link', None),
                    query_text=d.get('query_text', None),
-                   sql_statements=_repeated(d, 'sql_statements', SqlStatementOutput),
+                   sql_statements=_repeated_dict(d, 'sql_statements', SqlStatementOutput),
                    warehouse_id=d.get('warehouse_id', None))
 
 
@@ -2122,7 +2123,7 @@ class SqlDashboardOutput:
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'SqlDashboardOutput':
         return cls(warehouse_id=d.get('warehouse_id', None),
-                   widgets=_repeated(d, 'widgets', SqlDashboardWidgetOutput))
+                   widgets=_repeated_dict(d, 'widgets', SqlDashboardWidgetOutput))
 
 
 @dataclass
@@ -2220,7 +2221,7 @@ class SqlQueryOutput:
     def from_dict(cls, d: Dict[str, any]) -> 'SqlQueryOutput':
         return cls(output_link=d.get('output_link', None),
                    query_text=d.get('query_text', None),
-                   sql_statements=_repeated(d, 'sql_statements', SqlStatementOutput),
+                   sql_statements=_repeated_dict(d, 'sql_statements', SqlStatementOutput),
                    warehouse_id=d.get('warehouse_id', None))
 
 
@@ -2284,7 +2285,7 @@ class SqlTaskAlert:
     def from_dict(cls, d: Dict[str, any]) -> 'SqlTaskAlert':
         return cls(alert_id=d.get('alert_id', None),
                    pause_subscriptions=d.get('pause_subscriptions', None),
-                   subscriptions=_repeated(d, 'subscriptions', SqlTaskSubscription))
+                   subscriptions=_repeated_dict(d, 'subscriptions', SqlTaskSubscription))
 
 
 @dataclass
@@ -2307,7 +2308,7 @@ class SqlTaskDashboard:
         return cls(custom_subject=d.get('custom_subject', None),
                    dashboard_id=d.get('dashboard_id', None),
                    pause_subscriptions=d.get('pause_subscriptions', None),
-                   subscriptions=_repeated(d, 'subscriptions', SqlTaskSubscription))
+                   subscriptions=_repeated_dict(d, 'subscriptions', SqlTaskSubscription))
 
 
 @dataclass
@@ -2386,7 +2387,8 @@ class SubmitRun:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'SubmitRun':
-        return cls(access_control_list=_repeated(d, 'access_control_list', iam.AccessControlRequest),
+        return cls(access_control_list=_repeated_dict(d, 'access_control_list',
+                                                      jobs.iam.AccessControlRequest),
                    email_notifications=_from_dict(d, 'email_notifications', JobEmailNotifications),
                    git_source=_from_dict(d, 'git_source', GitSource),
                    health=_from_dict(d, 'health', JobsHealthRules),
@@ -2394,7 +2396,7 @@ class SubmitRun:
                    notification_settings=_from_dict(d, 'notification_settings', JobNotificationSettings),
                    queue=_from_dict(d, 'queue', QueueSettings),
                    run_name=d.get('run_name', None),
-                   tasks=_repeated(d, 'tasks', SubmitTask),
+                   tasks=_repeated_dict(d, 'tasks', SubmitTask),
                    timeout_seconds=d.get('timeout_seconds', None),
                    webhook_notifications=_from_dict(d, 'webhook_notifications', WebhookNotifications))
 
@@ -2459,11 +2461,11 @@ class SubmitTask:
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'SubmitTask':
         return cls(condition_task=_from_dict(d, 'condition_task', ConditionTask),
-                   depends_on=_repeated(d, 'depends_on', TaskDependency),
+                   depends_on=_repeated_dict(d, 'depends_on', TaskDependency),
                    email_notifications=_from_dict(d, 'email_notifications', JobEmailNotifications),
                    existing_cluster_id=d.get('existing_cluster_id', None),
                    health=_from_dict(d, 'health', JobsHealthRules),
-                   libraries=_repeated(d, 'libraries', compute.Library),
+                   libraries=_repeated_dict(d, 'libraries', jobs.compute.Library),
                    new_cluster=_from_dict(d, 'new_cluster', compute.ClusterSpec),
                    notebook_task=_from_dict(d, 'notebook_task', NotebookTask),
                    notification_settings=_from_dict(d, 'notification_settings', TaskNotificationSettings),
@@ -2545,13 +2547,13 @@ class Task:
         return cls(compute_key=d.get('compute_key', None),
                    condition_task=_from_dict(d, 'condition_task', ConditionTask),
                    dbt_task=_from_dict(d, 'dbt_task', DbtTask),
-                   depends_on=_repeated(d, 'depends_on', TaskDependency),
+                   depends_on=_repeated_dict(d, 'depends_on', TaskDependency),
                    description=d.get('description', None),
                    email_notifications=_from_dict(d, 'email_notifications', TaskEmailNotifications),
                    existing_cluster_id=d.get('existing_cluster_id', None),
                    health=_from_dict(d, 'health', JobsHealthRules),
                    job_cluster_key=d.get('job_cluster_key', None),
-                   libraries=_repeated(d, 'libraries', compute.Library),
+                   libraries=_repeated_dict(d, 'libraries', jobs.compute.Library),
                    max_retries=d.get('max_retries', None),
                    min_retry_interval_millis=d.get('min_retry_interval_millis', None),
                    new_cluster=_from_dict(d, 'new_cluster', compute.ClusterSpec),
@@ -2814,12 +2816,12 @@ class WebhookNotifications:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'WebhookNotifications':
-        return cls(on_duration_warning_threshold_exceeded=_repeated(
+        return cls(on_duration_warning_threshold_exceeded=_repeated_dict(
             d, 'on_duration_warning_threshold_exceeded',
             WebhookNotificationsOnDurationWarningThresholdExceededItem),
-                   on_failure=_repeated(d, 'on_failure', Webhook),
-                   on_start=_repeated(d, 'on_start', Webhook),
-                   on_success=_repeated(d, 'on_success', Webhook))
+                   on_failure=_repeated_dict(d, 'on_failure', Webhook),
+                   on_start=_repeated_dict(d, 'on_start', Webhook),
+                   on_success=_repeated_dict(d, 'on_success', Webhook))
 
 
 @dataclass

--- a/databricks/sdk/service/ml.py
+++ b/databricks/sdk/service/ml.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Dict, Iterator, List, Optional
 
-from ._internal import _enum, _from_dict, _repeated
+from ._internal import _enum, _from_dict, _repeated_dict, _repeated_enum
 
 _LOG = logging.getLogger('databricks.sdk')
 
@@ -165,7 +165,7 @@ class CommentObject:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'CommentObject':
-        return cls(available_actions=d.get('available_actions', None),
+        return cls(available_actions=_repeated_enum(d, 'available_actions', CommentActivityAction),
                    comment=d.get('comment', None),
                    creation_timestamp=d.get('creation_timestamp', None),
                    id=d.get('id', None),
@@ -222,7 +222,7 @@ class CreateExperiment:
     def from_dict(cls, d: Dict[str, any]) -> 'CreateExperiment':
         return cls(artifact_location=d.get('artifact_location', None),
                    name=d.get('name', None),
-                   tags=_repeated(d, 'tags', ExperimentTag))
+                   tags=_repeated_dict(d, 'tags', ExperimentTag))
 
 
 @dataclass
@@ -256,7 +256,7 @@ class CreateModelRequest:
     def from_dict(cls, d: Dict[str, any]) -> 'CreateModelRequest':
         return cls(description=d.get('description', None),
                    name=d.get('name', None),
-                   tags=_repeated(d, 'tags', ModelTag))
+                   tags=_repeated_dict(d, 'tags', ModelTag))
 
 
 @dataclass
@@ -299,7 +299,7 @@ class CreateModelVersionRequest:
                    run_id=d.get('run_id', None),
                    run_link=d.get('run_link', None),
                    source=d.get('source', None),
-                   tags=_repeated(d, 'tags', ModelVersionTag))
+                   tags=_repeated_dict(d, 'tags', ModelVersionTag))
 
 
 @dataclass
@@ -338,7 +338,7 @@ class CreateRegistryWebhook:
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'CreateRegistryWebhook':
         return cls(description=d.get('description', None),
-                   events=d.get('events', None),
+                   events=_repeated_enum(d, 'events', RegistryWebhookEvent),
                    http_url_spec=_from_dict(d, 'http_url_spec', HttpUrlSpec),
                    job_spec=_from_dict(d, 'job_spec', JobSpec),
                    model_name=d.get('model_name', None),
@@ -364,7 +364,7 @@ class CreateRun:
     def from_dict(cls, d: Dict[str, any]) -> 'CreateRun':
         return cls(experiment_id=d.get('experiment_id', None),
                    start_time=d.get('start_time', None),
-                   tags=_repeated(d, 'tags', RunTag),
+                   tags=_repeated_dict(d, 'tags', RunTag),
                    user_id=d.get('user_id', None))
 
 
@@ -475,7 +475,7 @@ class DatasetInput:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'DatasetInput':
-        return cls(dataset=_from_dict(d, 'dataset', Dataset), tags=_repeated(d, 'tags', InputTag))
+        return cls(dataset=_from_dict(d, 'dataset', Dataset), tags=_repeated_dict(d, 'tags', InputTag))
 
 
 @dataclass
@@ -593,7 +593,7 @@ class Experiment:
                    last_update_time=d.get('last_update_time', None),
                    lifecycle_stage=d.get('lifecycle_stage', None),
                    name=d.get('name', None),
-                   tags=_repeated(d, 'tags', ExperimentTag))
+                   tags=_repeated_dict(d, 'tags', ExperimentTag))
 
 
 @dataclass
@@ -640,7 +640,7 @@ class ExperimentAccessControlResponse:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'ExperimentAccessControlResponse':
-        return cls(all_permissions=_repeated(d, 'all_permissions', ExperimentPermission),
+        return cls(all_permissions=_repeated_dict(d, 'all_permissions', ExperimentPermission),
                    display_name=d.get('display_name', None),
                    group_name=d.get('group_name', None),
                    service_principal_name=d.get('service_principal_name', None),
@@ -691,7 +691,8 @@ class ExperimentPermissions:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'ExperimentPermissions':
-        return cls(access_control_list=_repeated(d, 'access_control_list', ExperimentAccessControlResponse),
+        return cls(access_control_list=_repeated_dict(d, 'access_control_list',
+                                                      ExperimentAccessControlResponse),
                    object_id=d.get('object_id', None),
                    object_type=d.get('object_type', None))
 
@@ -727,7 +728,8 @@ class ExperimentPermissionsRequest:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'ExperimentPermissionsRequest':
-        return cls(access_control_list=_repeated(d, 'access_control_list', ExperimentAccessControlRequest),
+        return cls(access_control_list=_repeated_dict(d, 'access_control_list',
+                                                      ExperimentAccessControlRequest),
                    experiment_id=d.get('experiment_id', None))
 
 
@@ -776,7 +778,7 @@ class GetExperimentPermissionLevelsResponse:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'GetExperimentPermissionLevelsResponse':
-        return cls(permission_levels=_repeated(d, 'permission_levels', ExperimentPermissionsDescription))
+        return cls(permission_levels=_repeated_dict(d, 'permission_levels', ExperimentPermissionsDescription))
 
 
 @dataclass
@@ -820,7 +822,7 @@ class GetLatestVersionsResponse:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'GetLatestVersionsResponse':
-        return cls(model_versions=_repeated(d, 'model_versions', ModelVersion))
+        return cls(model_versions=_repeated_dict(d, 'model_versions', ModelVersion))
 
 
 @dataclass
@@ -836,7 +838,8 @@ class GetMetricHistoryResponse:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'GetMetricHistoryResponse':
-        return cls(metrics=_repeated(d, 'metrics', Metric), next_page_token=d.get('next_page_token', None))
+        return cls(metrics=_repeated_dict(d, 'metrics', Metric),
+                   next_page_token=d.get('next_page_token', None))
 
 
 @dataclass
@@ -893,7 +896,8 @@ class GetRegisteredModelPermissionLevelsResponse:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'GetRegisteredModelPermissionLevelsResponse':
-        return cls(permission_levels=_repeated(d, 'permission_levels', RegisteredModelPermissionsDescription))
+        return cls(
+            permission_levels=_repeated_dict(d, 'permission_levels', RegisteredModelPermissionsDescription))
 
 
 @dataclass
@@ -1018,7 +1022,7 @@ class ListArtifactsResponse:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'ListArtifactsResponse':
-        return cls(files=_repeated(d, 'files', FileInfo),
+        return cls(files=_repeated_dict(d, 'files', FileInfo),
                    next_page_token=d.get('next_page_token', None),
                    root_uri=d.get('root_uri', None))
 
@@ -1036,7 +1040,7 @@ class ListExperimentsResponse:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'ListExperimentsResponse':
-        return cls(experiments=_repeated(d, 'experiments', Experiment),
+        return cls(experiments=_repeated_dict(d, 'experiments', Experiment),
                    next_page_token=d.get('next_page_token', None))
 
 
@@ -1054,7 +1058,7 @@ class ListModelsResponse:
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'ListModelsResponse':
         return cls(next_page_token=d.get('next_page_token', None),
-                   registered_models=_repeated(d, 'registered_models', Model))
+                   registered_models=_repeated_dict(d, 'registered_models', Model))
 
 
 @dataclass
@@ -1071,7 +1075,7 @@ class ListRegistryWebhooks:
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'ListRegistryWebhooks':
         return cls(next_page_token=d.get('next_page_token', None),
-                   webhooks=_repeated(d, 'webhooks', RegistryWebhook))
+                   webhooks=_repeated_dict(d, 'webhooks', RegistryWebhook))
 
 
 @dataclass
@@ -1085,7 +1089,7 @@ class ListTransitionRequestsResponse:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'ListTransitionRequestsResponse':
-        return cls(requests=_repeated(d, 'requests', Activity))
+        return cls(requests=_repeated_dict(d, 'requests', Activity))
 
 
 @dataclass
@@ -1105,10 +1109,10 @@ class LogBatch:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'LogBatch':
-        return cls(metrics=_repeated(d, 'metrics', Metric),
-                   params=_repeated(d, 'params', Param),
+        return cls(metrics=_repeated_dict(d, 'metrics', Metric),
+                   params=_repeated_dict(d, 'params', Param),
                    run_id=d.get('run_id', None),
-                   tags=_repeated(d, 'tags', RunTag))
+                   tags=_repeated_dict(d, 'tags', RunTag))
 
 
 @dataclass
@@ -1124,7 +1128,7 @@ class LogInputs:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'LogInputs':
-        return cls(datasets=_repeated(d, 'datasets', DatasetInput), run_id=d.get('run_id', None))
+        return cls(datasets=_repeated_dict(d, 'datasets', DatasetInput), run_id=d.get('run_id', None))
 
 
 @dataclass
@@ -1245,9 +1249,9 @@ class Model:
         return cls(creation_timestamp=d.get('creation_timestamp', None),
                    description=d.get('description', None),
                    last_updated_timestamp=d.get('last_updated_timestamp', None),
-                   latest_versions=_repeated(d, 'latest_versions', ModelVersion),
+                   latest_versions=_repeated_dict(d, 'latest_versions', ModelVersion),
                    name=d.get('name', None),
-                   tags=_repeated(d, 'tags', ModelTag),
+                   tags=_repeated_dict(d, 'tags', ModelTag),
                    user_id=d.get('user_id', None))
 
 
@@ -1283,10 +1287,10 @@ class ModelDatabricks:
                    description=d.get('description', None),
                    id=d.get('id', None),
                    last_updated_timestamp=d.get('last_updated_timestamp', None),
-                   latest_versions=_repeated(d, 'latest_versions', ModelVersion),
+                   latest_versions=_repeated_dict(d, 'latest_versions', ModelVersion),
                    name=d.get('name', None),
                    permission_level=_enum(d, 'permission_level', PermissionLevel),
-                   tags=_repeated(d, 'tags', ModelTag),
+                   tags=_repeated_dict(d, 'tags', ModelTag),
                    user_id=d.get('user_id', None))
 
 
@@ -1352,7 +1356,7 @@ class ModelVersion:
                    source=d.get('source', None),
                    status=_enum(d, 'status', ModelVersionStatus),
                    status_message=d.get('status_message', None),
-                   tags=_repeated(d, 'tags', ModelVersionTag),
+                   tags=_repeated_dict(d, 'tags', ModelVersionTag),
                    user_id=d.get('user_id', None),
                    version=d.get('version', None))
 
@@ -1406,7 +1410,7 @@ class ModelVersionDatabricks:
                    source=d.get('source', None),
                    status=_enum(d, 'status', Status),
                    status_message=d.get('status_message', None),
-                   tags=_repeated(d, 'tags', ModelVersionTag),
+                   tags=_repeated_dict(d, 'tags', ModelVersionTag),
                    user_id=d.get('user_id', None),
                    version=d.get('version', None))
 
@@ -1506,7 +1510,7 @@ class RegisteredModelAccessControlResponse:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'RegisteredModelAccessControlResponse':
-        return cls(all_permissions=_repeated(d, 'all_permissions', RegisteredModelPermission),
+        return cls(all_permissions=_repeated_dict(d, 'all_permissions', RegisteredModelPermission),
                    display_name=d.get('display_name', None),
                    group_name=d.get('group_name', None),
                    service_principal_name=d.get('service_principal_name', None),
@@ -1559,8 +1563,8 @@ class RegisteredModelPermissions:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'RegisteredModelPermissions':
-        return cls(access_control_list=_repeated(d, 'access_control_list',
-                                                 RegisteredModelAccessControlResponse),
+        return cls(access_control_list=_repeated_dict(d, 'access_control_list',
+                                                      RegisteredModelAccessControlResponse),
                    object_id=d.get('object_id', None),
                    object_type=d.get('object_type', None))
 
@@ -1596,8 +1600,8 @@ class RegisteredModelPermissionsRequest:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'RegisteredModelPermissionsRequest':
-        return cls(access_control_list=_repeated(d, 'access_control_list',
-                                                 RegisteredModelAccessControlRequest),
+        return cls(access_control_list=_repeated_dict(d, 'access_control_list',
+                                                      RegisteredModelAccessControlRequest),
                    registered_model_id=d.get('registered_model_id', None))
 
 
@@ -1631,7 +1635,7 @@ class RegistryWebhook:
     def from_dict(cls, d: Dict[str, any]) -> 'RegistryWebhook':
         return cls(creation_timestamp=d.get('creation_timestamp', None),
                    description=d.get('description', None),
-                   events=d.get('events', None),
+                   events=_repeated_enum(d, 'events', RegistryWebhookEvent),
                    http_url_spec=_from_dict(d, 'http_url_spec', HttpUrlSpecWithoutSecret),
                    id=d.get('id', None),
                    job_spec=_from_dict(d, 'job_spec', JobSpecWithoutSecret),
@@ -1834,9 +1838,9 @@ class RunData:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'RunData':
-        return cls(metrics=_repeated(d, 'metrics', Metric),
-                   params=_repeated(d, 'params', Param),
-                   tags=_repeated(d, 'tags', RunTag))
+        return cls(metrics=_repeated_dict(d, 'metrics', Metric),
+                   params=_repeated_dict(d, 'params', Param),
+                   tags=_repeated_dict(d, 'tags', RunTag))
 
 
 @dataclass
@@ -1898,7 +1902,7 @@ class RunInputs:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'RunInputs':
-        return cls(dataset_inputs=_repeated(d, 'dataset_inputs', DatasetInput))
+        return cls(dataset_inputs=_repeated_dict(d, 'dataset_inputs', DatasetInput))
 
 
 @dataclass
@@ -1956,7 +1960,7 @@ class SearchExperimentsResponse:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'SearchExperimentsResponse':
-        return cls(experiments=_repeated(d, 'experiments', Experiment),
+        return cls(experiments=_repeated_dict(d, 'experiments', Experiment),
                    next_page_token=d.get('next_page_token', None))
 
 
@@ -1982,7 +1986,7 @@ class SearchModelVersionsResponse:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'SearchModelVersionsResponse':
-        return cls(model_versions=_repeated(d, 'model_versions', ModelVersion),
+        return cls(model_versions=_repeated_dict(d, 'model_versions', ModelVersion),
                    next_page_token=d.get('next_page_token', None))
 
 
@@ -2000,7 +2004,7 @@ class SearchModelsResponse:
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'SearchModelsResponse':
         return cls(next_page_token=d.get('next_page_token', None),
-                   registered_models=_repeated(d, 'registered_models', Model))
+                   registered_models=_repeated_dict(d, 'registered_models', Model))
 
 
 @dataclass
@@ -2045,7 +2049,7 @@ class SearchRunsResponse:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'SearchRunsResponse':
-        return cls(next_page_token=d.get('next_page_token', None), runs=_repeated(d, 'runs', Run))
+        return cls(next_page_token=d.get('next_page_token', None), runs=_repeated_dict(d, 'runs', Run))
 
 
 class SearchRunsRunViewType(Enum):
@@ -2266,7 +2270,7 @@ class TransitionRequest:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'TransitionRequest':
-        return cls(available_actions=d.get('available_actions', None),
+        return cls(available_actions=_repeated_enum(d, 'available_actions', ActivityAction),
                    comment=d.get('comment', None),
                    creation_timestamp=d.get('creation_timestamp', None),
                    to_stage=_enum(d, 'to_stage', Stage),
@@ -2391,7 +2395,7 @@ class UpdateRegistryWebhook:
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'UpdateRegistryWebhook':
         return cls(description=d.get('description', None),
-                   events=d.get('events', None),
+                   events=_repeated_enum(d, 'events', RegistryWebhookEvent),
                    http_url_spec=_from_dict(d, 'http_url_spec', HttpUrlSpec),
                    id=d.get('id', None),
                    job_spec=_from_dict(d, 'job_spec', JobSpec),

--- a/databricks/sdk/service/oauth2.py
+++ b/databricks/sdk/service/oauth2.py
@@ -4,7 +4,7 @@ import logging
 from dataclasses import dataclass
 from typing import Dict, Iterator, List, Optional
 
-from ._internal import _from_dict, _repeated
+from ._internal import _from_dict, _repeated_dict
 
 _LOG = logging.getLogger('databricks.sdk')
 
@@ -157,7 +157,7 @@ class GetCustomAppIntegrationsOutput:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'GetCustomAppIntegrationsOutput':
-        return cls(apps=_repeated(d, 'apps', GetCustomAppIntegrationOutput))
+        return cls(apps=_repeated_dict(d, 'apps', GetCustomAppIntegrationOutput))
 
 
 @dataclass
@@ -194,7 +194,7 @@ class GetPublishedAppIntegrationsOutput:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'GetPublishedAppIntegrationsOutput':
-        return cls(apps=_repeated(d, 'apps', GetPublishedAppIntegrationOutput))
+        return cls(apps=_repeated_dict(d, 'apps', GetPublishedAppIntegrationOutput))
 
 
 @dataclass
@@ -210,7 +210,7 @@ class GetPublishedAppsOutput:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'GetPublishedAppsOutput':
-        return cls(apps=_repeated(d, 'apps', PublishedAppOutput),
+        return cls(apps=_repeated_dict(d, 'apps', PublishedAppOutput),
                    next_page_token=d.get('next_page_token', None))
 
 
@@ -225,7 +225,7 @@ class ListServicePrincipalSecretsResponse:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'ListServicePrincipalSecretsResponse':
-        return cls(secrets=_repeated(d, 'secrets', SecretInfo))
+        return cls(secrets=_repeated_dict(d, 'secrets', SecretInfo))
 
 
 @dataclass

--- a/databricks/sdk/service/pipelines.py
+++ b/databricks/sdk/service/pipelines.py
@@ -9,7 +9,7 @@ from enum import Enum
 from typing import Any, Callable, Dict, Iterator, List, Optional
 
 from ..errors import OperationFailed
-from ._internal import Wait, _enum, _from_dict, _repeated
+from ._internal import Wait, _enum, _from_dict, _repeated_dict
 
 _LOG = logging.getLogger('databricks.sdk')
 
@@ -68,7 +68,7 @@ class CreatePipeline:
         return cls(allow_duplicate_names=d.get('allow_duplicate_names', None),
                    catalog=d.get('catalog', None),
                    channel=d.get('channel', None),
-                   clusters=_repeated(d, 'clusters', PipelineCluster),
+                   clusters=_repeated_dict(d, 'clusters', PipelineCluster),
                    configuration=d.get('configuration', None),
                    continuous=d.get('continuous', None),
                    development=d.get('development', None),
@@ -76,9 +76,9 @@ class CreatePipeline:
                    edition=d.get('edition', None),
                    filters=_from_dict(d, 'filters', Filters),
                    id=d.get('id', None),
-                   libraries=_repeated(d, 'libraries', PipelineLibrary),
+                   libraries=_repeated_dict(d, 'libraries', PipelineLibrary),
                    name=d.get('name', None),
-                   notifications=_repeated(d, 'notifications', Notifications),
+                   notifications=_repeated_dict(d, 'notifications', Notifications),
                    photon=d.get('photon', None),
                    serverless=d.get('serverless', None),
                    storage=d.get('storage', None),
@@ -189,7 +189,7 @@ class EditPipeline:
         return cls(allow_duplicate_names=d.get('allow_duplicate_names', None),
                    catalog=d.get('catalog', None),
                    channel=d.get('channel', None),
-                   clusters=_repeated(d, 'clusters', PipelineCluster),
+                   clusters=_repeated_dict(d, 'clusters', PipelineCluster),
                    configuration=d.get('configuration', None),
                    continuous=d.get('continuous', None),
                    development=d.get('development', None),
@@ -197,9 +197,9 @@ class EditPipeline:
                    expected_last_modified=d.get('expected_last_modified', None),
                    filters=_from_dict(d, 'filters', Filters),
                    id=d.get('id', None),
-                   libraries=_repeated(d, 'libraries', PipelineLibrary),
+                   libraries=_repeated_dict(d, 'libraries', PipelineLibrary),
                    name=d.get('name', None),
-                   notifications=_repeated(d, 'notifications', Notifications),
+                   notifications=_repeated_dict(d, 'notifications', Notifications),
                    photon=d.get('photon', None),
                    pipeline_id=d.get('pipeline_id', None),
                    serverless=d.get('serverless', None),
@@ -221,7 +221,8 @@ class ErrorDetail:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'ErrorDetail':
-        return cls(exceptions=_repeated(d, 'exceptions', SerializedException), fatal=d.get('fatal', None))
+        return cls(exceptions=_repeated_dict(d, 'exceptions', SerializedException),
+                   fatal=d.get('fatal', None))
 
 
 class EventLevel(Enum):
@@ -274,7 +275,7 @@ class GetPipelinePermissionLevelsResponse:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'GetPipelinePermissionLevelsResponse':
-        return cls(permission_levels=_repeated(d, 'permission_levels', PipelinePermissionsDescription))
+        return cls(permission_levels=_repeated_dict(d, 'permission_levels', PipelinePermissionsDescription))
 
 
 @dataclass
@@ -313,7 +314,7 @@ class GetPipelineResponse:
                    creator_user_name=d.get('creator_user_name', None),
                    health=_enum(d, 'health', GetPipelineResponseHealth),
                    last_modified=d.get('last_modified', None),
-                   latest_updates=_repeated(d, 'latest_updates', UpdateStateInfo),
+                   latest_updates=_repeated_dict(d, 'latest_updates', UpdateStateInfo),
                    name=d.get('name', None),
                    pipeline_id=d.get('pipeline_id', None),
                    run_as_user_name=d.get('run_as_user_name', None),
@@ -357,7 +358,7 @@ class ListPipelineEventsResponse:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'ListPipelineEventsResponse':
-        return cls(events=_repeated(d, 'events', PipelineEvent),
+        return cls(events=_repeated_dict(d, 'events', PipelineEvent),
                    next_page_token=d.get('next_page_token', None),
                    prev_page_token=d.get('prev_page_token', None))
 
@@ -376,7 +377,7 @@ class ListPipelinesResponse:
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'ListPipelinesResponse':
         return cls(next_page_token=d.get('next_page_token', None),
-                   statuses=_repeated(d, 'statuses', PipelineStateInfo))
+                   statuses=_repeated_dict(d, 'statuses', PipelineStateInfo))
 
 
 @dataclass
@@ -396,7 +397,7 @@ class ListUpdatesResponse:
     def from_dict(cls, d: Dict[str, any]) -> 'ListUpdatesResponse':
         return cls(next_page_token=d.get('next_page_token', None),
                    prev_page_token=d.get('prev_page_token', None),
-                   updates=_repeated(d, 'updates', UpdateInfo))
+                   updates=_repeated_dict(d, 'updates', UpdateInfo))
 
 
 class MaturityLevel(Enum):
@@ -543,7 +544,7 @@ class PipelineAccessControlResponse:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'PipelineAccessControlResponse':
-        return cls(all_permissions=_repeated(d, 'all_permissions', PipelinePermission),
+        return cls(all_permissions=_repeated_dict(d, 'all_permissions', PipelinePermission),
                    display_name=d.get('display_name', None),
                    group_name=d.get('group_name', None),
                    service_principal_name=d.get('service_principal_name', None),
@@ -720,7 +721,8 @@ class PipelinePermissions:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'PipelinePermissions':
-        return cls(access_control_list=_repeated(d, 'access_control_list', PipelineAccessControlResponse),
+        return cls(access_control_list=_repeated_dict(d, 'access_control_list',
+                                                      PipelineAccessControlResponse),
                    object_id=d.get('object_id', None),
                    object_type=d.get('object_type', None))
 
@@ -756,7 +758,7 @@ class PipelinePermissionsRequest:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'PipelinePermissionsRequest':
-        return cls(access_control_list=_repeated(d, 'access_control_list', PipelineAccessControlRequest),
+        return cls(access_control_list=_repeated_dict(d, 'access_control_list', PipelineAccessControlRequest),
                    pipeline_id=d.get('pipeline_id', None))
 
 
@@ -805,16 +807,16 @@ class PipelineSpec:
     def from_dict(cls, d: Dict[str, any]) -> 'PipelineSpec':
         return cls(catalog=d.get('catalog', None),
                    channel=d.get('channel', None),
-                   clusters=_repeated(d, 'clusters', PipelineCluster),
+                   clusters=_repeated_dict(d, 'clusters', PipelineCluster),
                    configuration=d.get('configuration', None),
                    continuous=d.get('continuous', None),
                    development=d.get('development', None),
                    edition=d.get('edition', None),
                    filters=_from_dict(d, 'filters', Filters),
                    id=d.get('id', None),
-                   libraries=_repeated(d, 'libraries', PipelineLibrary),
+                   libraries=_repeated_dict(d, 'libraries', PipelineLibrary),
                    name=d.get('name', None),
-                   notifications=_repeated(d, 'notifications', Notifications),
+                   notifications=_repeated_dict(d, 'notifications', Notifications),
                    photon=d.get('photon', None),
                    serverless=d.get('serverless', None),
                    storage=d.get('storage', None),
@@ -861,7 +863,7 @@ class PipelineStateInfo:
     def from_dict(cls, d: Dict[str, any]) -> 'PipelineStateInfo':
         return cls(cluster_id=d.get('cluster_id', None),
                    creator_user_name=d.get('creator_user_name', None),
-                   latest_updates=_repeated(d, 'latest_updates', UpdateStateInfo),
+                   latest_updates=_repeated_dict(d, 'latest_updates', UpdateStateInfo),
                    name=d.get('name', None),
                    pipeline_id=d.get('pipeline_id', None),
                    run_as_user_name=d.get('run_as_user_name', None),
@@ -918,7 +920,7 @@ class SerializedException:
     def from_dict(cls, d: Dict[str, any]) -> 'SerializedException':
         return cls(class_name=d.get('class_name', None),
                    message=d.get('message', None),
-                   stack=_repeated(d, 'stack', StackFrame))
+                   stack=_repeated_dict(d, 'stack', StackFrame))
 
 
 @dataclass

--- a/databricks/sdk/service/provisioning.py
+++ b/databricks/sdk/service/provisioning.py
@@ -9,7 +9,7 @@ from enum import Enum
 from typing import Callable, Dict, Iterator, List, Optional
 
 from ..errors import OperationFailed
-from ._internal import Wait, _enum, _from_dict, _repeated
+from ._internal import Wait, _enum, _from_dict, _repeated_dict, _repeated_enum
 
 _LOG = logging.getLogger('databricks.sdk')
 
@@ -153,7 +153,7 @@ class CreateCustomerManagedKeyRequest:
     def from_dict(cls, d: Dict[str, any]) -> 'CreateCustomerManagedKeyRequest':
         return cls(aws_key_info=_from_dict(d, 'aws_key_info', CreateAwsKeyInfo),
                    gcp_key_info=_from_dict(d, 'gcp_key_info', CreateGcpKeyInfo),
-                   use_cases=d.get('use_cases', None))
+                   use_cases=_repeated_enum(d, 'use_cases', KeyUseCase))
 
 
 @dataclass
@@ -379,7 +379,7 @@ class CustomerManagedKey:
                    creation_time=d.get('creation_time', None),
                    customer_managed_key_id=d.get('customer_managed_key_id', None),
                    gcp_key_info=_from_dict(d, 'gcp_key_info', GcpKeyInfo),
-                   use_cases=d.get('use_cases', None))
+                   use_cases=_repeated_enum(d, 'use_cases', KeyUseCase))
 
 
 class EndpointUseCase(Enum):
@@ -596,7 +596,7 @@ class Network:
     def from_dict(cls, d: Dict[str, any]) -> 'Network':
         return cls(account_id=d.get('account_id', None),
                    creation_time=d.get('creation_time', None),
-                   error_messages=_repeated(d, 'error_messages', NetworkHealth),
+                   error_messages=_repeated_dict(d, 'error_messages', NetworkHealth),
                    gcp_network_info=_from_dict(d, 'gcp_network_info', GcpNetworkInfo),
                    network_id=d.get('network_id', None),
                    network_name=d.get('network_name', None),
@@ -605,7 +605,7 @@ class Network:
                    vpc_endpoints=_from_dict(d, 'vpc_endpoints', NetworkVpcEndpoints),
                    vpc_id=d.get('vpc_id', None),
                    vpc_status=_enum(d, 'vpc_status', VpcStatus),
-                   warning_messages=_repeated(d, 'warning_messages', NetworkWarning),
+                   warning_messages=_repeated_dict(d, 'warning_messages', NetworkWarning),
                    workspace_id=d.get('workspace_id', None))
 
 

--- a/databricks/sdk/service/serving.py
+++ b/databricks/sdk/service/serving.py
@@ -9,7 +9,7 @@ from enum import Enum
 from typing import Any, Callable, Dict, Iterator, List, Optional
 
 from ..errors import OperationFailed
-from ._internal import Wait, _enum, _from_dict, _repeated
+from ._internal import Wait, _enum, _from_dict, _repeated_dict
 
 _LOG = logging.getLogger('databricks.sdk')
 
@@ -125,7 +125,7 @@ class CreateServingEndpoint:
     def from_dict(cls, d: Dict[str, any]) -> 'CreateServingEndpoint':
         return cls(config=_from_dict(d, 'config', EndpointCoreConfigInput),
                    name=d.get('name', None),
-                   tags=_repeated(d, 'tags', EndpointTag))
+                   tags=_repeated_dict(d, 'tags', EndpointTag))
 
 
 @dataclass
@@ -224,7 +224,7 @@ class EndpointCoreConfigInput:
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'EndpointCoreConfigInput':
         return cls(name=d.get('name', None),
-                   served_models=_repeated(d, 'served_models', ServedModelInput),
+                   served_models=_repeated_dict(d, 'served_models', ServedModelInput),
                    traffic_config=_from_dict(d, 'traffic_config', TrafficConfig))
 
 
@@ -244,7 +244,7 @@ class EndpointCoreConfigOutput:
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'EndpointCoreConfigOutput':
         return cls(config_version=d.get('config_version', None),
-                   served_models=_repeated(d, 'served_models', ServedModelOutput),
+                   served_models=_repeated_dict(d, 'served_models', ServedModelOutput),
                    traffic_config=_from_dict(d, 'traffic_config', TrafficConfig))
 
 
@@ -259,7 +259,7 @@ class EndpointCoreConfigSummary:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'EndpointCoreConfigSummary':
-        return cls(served_models=_repeated(d, 'served_models', ServedModelSpec))
+        return cls(served_models=_repeated_dict(d, 'served_models', ServedModelSpec))
 
 
 @dataclass
@@ -280,7 +280,7 @@ class EndpointPendingConfig:
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'EndpointPendingConfig':
         return cls(config_version=d.get('config_version', None),
-                   served_models=_repeated(d, 'served_models', ServedModelOutput),
+                   served_models=_repeated_dict(d, 'served_models', ServedModelOutput),
                    start_time=d.get('start_time', None),
                    traffic_config=_from_dict(d, 'traffic_config', TrafficConfig))
 
@@ -355,9 +355,9 @@ class GetAppResponse:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'GetAppResponse':
-        return cls(current_services=_repeated(d, 'current_services', AppServiceStatus),
+        return cls(current_services=_repeated_dict(d, 'current_services', AppServiceStatus),
                    name=d.get('name', None),
-                   pending_services=_repeated(d, 'pending_services', AppServiceStatus),
+                   pending_services=_repeated_dict(d, 'pending_services', AppServiceStatus),
                    url=d.get('url', None))
 
 
@@ -372,7 +372,8 @@ class GetServingEndpointPermissionLevelsResponse:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'GetServingEndpointPermissionLevelsResponse':
-        return cls(permission_levels=_repeated(d, 'permission_levels', ServingEndpointPermissionsDescription))
+        return cls(
+            permission_levels=_repeated_dict(d, 'permission_levels', ServingEndpointPermissionsDescription))
 
 
 @dataclass
@@ -386,7 +387,7 @@ class ListAppEventsResponse:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'ListAppEventsResponse':
-        return cls(events=_repeated(d, 'events', AppEvents))
+        return cls(events=_repeated_dict(d, 'events', AppEvents))
 
 
 @dataclass
@@ -416,7 +417,7 @@ class ListEndpointsResponse:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'ListEndpointsResponse':
-        return cls(endpoints=_repeated(d, 'endpoints', ServingEndpoint))
+        return cls(endpoints=_repeated_dict(d, 'endpoints', ServingEndpoint))
 
 
 @dataclass
@@ -434,7 +435,7 @@ class PatchServingEndpointTags:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'PatchServingEndpointTags':
-        return cls(add_tags=_repeated(d, 'add_tags', EndpointTag),
+        return cls(add_tags=_repeated_dict(d, 'add_tags', EndpointTag),
                    delete_tags=d.get('delete_tags', None),
                    name=d.get('name', None))
 
@@ -678,7 +679,7 @@ class ServingEndpoint:
                    last_updated_timestamp=d.get('last_updated_timestamp', None),
                    name=d.get('name', None),
                    state=_from_dict(d, 'state', EndpointState),
-                   tags=_repeated(d, 'tags', EndpointTag))
+                   tags=_repeated_dict(d, 'tags', EndpointTag))
 
 
 @dataclass
@@ -725,7 +726,7 @@ class ServingEndpointAccessControlResponse:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'ServingEndpointAccessControlResponse':
-        return cls(all_permissions=_repeated(d, 'all_permissions', ServingEndpointPermission),
+        return cls(all_permissions=_repeated_dict(d, 'all_permissions', ServingEndpointPermission),
                    display_name=d.get('display_name', None),
                    group_name=d.get('group_name', None),
                    service_principal_name=d.get('service_principal_name', None),
@@ -771,7 +772,7 @@ class ServingEndpointDetailed:
                    pending_config=_from_dict(d, 'pending_config', EndpointPendingConfig),
                    permission_level=_enum(d, 'permission_level', ServingEndpointDetailedPermissionLevel),
                    state=_from_dict(d, 'state', EndpointState),
-                   tags=_repeated(d, 'tags', EndpointTag))
+                   tags=_repeated_dict(d, 'tags', EndpointTag))
 
 
 class ServingEndpointDetailedPermissionLevel(Enum):
@@ -826,8 +827,8 @@ class ServingEndpointPermissions:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'ServingEndpointPermissions':
-        return cls(access_control_list=_repeated(d, 'access_control_list',
-                                                 ServingEndpointAccessControlResponse),
+        return cls(access_control_list=_repeated_dict(d, 'access_control_list',
+                                                      ServingEndpointAccessControlResponse),
                    object_id=d.get('object_id', None),
                    object_type=d.get('object_type', None))
 
@@ -863,8 +864,8 @@ class ServingEndpointPermissionsRequest:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'ServingEndpointPermissionsRequest':
-        return cls(access_control_list=_repeated(d, 'access_control_list',
-                                                 ServingEndpointAccessControlRequest),
+        return cls(access_control_list=_repeated_dict(d, 'access_control_list',
+                                                      ServingEndpointAccessControlRequest),
                    serving_endpoint_id=d.get('serving_endpoint_id', None))
 
 
@@ -879,7 +880,7 @@ class TrafficConfig:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'TrafficConfig':
-        return cls(routes=_repeated(d, 'routes', Route))
+        return cls(routes=_repeated_dict(d, 'routes', Route))
 
 
 class AppsAPI:

--- a/databricks/sdk/service/settings.py
+++ b/databricks/sdk/service/settings.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Dict, Iterator, List, Optional
 
-from ._internal import _enum, _from_dict, _repeated
+from ._internal import _enum, _from_dict, _repeated_dict, _repeated_enum
 
 _LOG = logging.getLogger('databricks.sdk')
 
@@ -290,7 +290,7 @@ class ExchangeTokenRequest:
     def from_dict(cls, d: Dict[str, any]) -> 'ExchangeTokenRequest':
         return cls(partition_id=_from_dict(d, 'partitionId', PartitionId),
                    scopes=d.get('scopes', None),
-                   token_type=d.get('tokenType', None))
+                   token_type=_repeated_enum(d, 'tokenType', TokenType))
 
 
 @dataclass
@@ -304,7 +304,7 @@ class ExchangeTokenResponse:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'ExchangeTokenResponse':
-        return cls(values=_repeated(d, 'values', ExchangeToken))
+        return cls(values=_repeated_dict(d, 'values', ExchangeToken))
 
 
 @dataclass
@@ -346,7 +346,7 @@ class GetIpAccessListsResponse:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'GetIpAccessListsResponse':
-        return cls(ip_access_lists=_repeated(d, 'ip_access_lists', IpAccessListInfo))
+        return cls(ip_access_lists=_repeated_dict(d, 'ip_access_lists', IpAccessListInfo))
 
 
 @dataclass
@@ -360,7 +360,7 @@ class GetTokenPermissionLevelsResponse:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'GetTokenPermissionLevelsResponse':
-        return cls(permission_levels=_repeated(d, 'permission_levels', TokenPermissionsDescription))
+        return cls(permission_levels=_repeated_dict(d, 'permission_levels', TokenPermissionsDescription))
 
 
 @dataclass
@@ -415,7 +415,7 @@ class ListIpAccessListResponse:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'ListIpAccessListResponse':
-        return cls(ip_access_lists=_repeated(d, 'ip_access_lists', IpAccessListInfo))
+        return cls(ip_access_lists=_repeated_dict(d, 'ip_access_lists', IpAccessListInfo))
 
 
 @dataclass
@@ -429,7 +429,7 @@ class ListTokensResponse:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'ListTokensResponse':
-        return cls(token_infos=_repeated(d, 'token_infos', TokenInfo))
+        return cls(token_infos=_repeated_dict(d, 'token_infos', TokenInfo))
 
 
 class ListType(Enum):
@@ -591,8 +591,8 @@ class NccEgressTargetRules:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'NccEgressTargetRules':
-        return cls(azure_private_endpoint_rules=_repeated(d, 'azure_private_endpoint_rules',
-                                                          NccAzurePrivateEndpointRule))
+        return cls(azure_private_endpoint_rules=_repeated_dict(d, 'azure_private_endpoint_rules',
+                                                               NccAzurePrivateEndpointRule))
 
 
 @dataclass
@@ -811,7 +811,7 @@ class TokenAccessControlResponse:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'TokenAccessControlResponse':
-        return cls(all_permissions=_repeated(d, 'all_permissions', TokenPermission),
+        return cls(all_permissions=_repeated_dict(d, 'all_permissions', TokenPermission),
                    display_name=d.get('display_name', None),
                    group_name=d.get('group_name', None),
                    service_principal_name=d.get('service_principal_name', None),
@@ -892,7 +892,7 @@ class TokenPermissions:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'TokenPermissions':
-        return cls(access_control_list=_repeated(d, 'access_control_list', TokenAccessControlResponse),
+        return cls(access_control_list=_repeated_dict(d, 'access_control_list', TokenAccessControlResponse),
                    object_id=d.get('object_id', None),
                    object_type=d.get('object_type', None))
 
@@ -926,7 +926,7 @@ class TokenPermissionsRequest:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'TokenPermissionsRequest':
-        return cls(access_control_list=_repeated(d, 'access_control_list', TokenAccessControlRequest))
+        return cls(access_control_list=_repeated_dict(d, 'access_control_list', TokenAccessControlRequest))
 
 
 class TokenType(Enum):

--- a/databricks/sdk/service/sharing.py
+++ b/databricks/sdk/service/sharing.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Dict, Iterator, List, Optional
 
-from ._internal import _enum, _from_dict, _repeated
+from ._internal import _enum, _from_dict, _repeated_dict, _repeated_enum
 
 _LOG = logging.getLogger('databricks.sdk')
 
@@ -40,8 +40,8 @@ class CentralCleanRoomInfo:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'CentralCleanRoomInfo':
-        return cls(clean_room_assets=_repeated(d, 'clean_room_assets', CleanRoomAssetInfo),
-                   collaborators=_repeated(d, 'collaborators', CleanRoomCollaboratorInfo),
+        return cls(clean_room_assets=_repeated_dict(d, 'clean_room_assets', CleanRoomAssetInfo),
+                   collaborators=_repeated_dict(d, 'collaborators', CleanRoomCollaboratorInfo),
                    creator=_from_dict(d, 'creator', CleanRoomCollaboratorInfo),
                    station_cloud=d.get('station_cloud', None),
                    station_region=d.get('station_region', None))
@@ -89,8 +89,8 @@ class CleanRoomCatalog:
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'CleanRoomCatalog':
         return cls(catalog_name=d.get('catalog_name', None),
-                   notebook_files=_repeated(d, 'notebook_files', SharedDataObject),
-                   tables=_repeated(d, 'tables', SharedDataObject))
+                   notebook_files=_repeated_dict(d, 'notebook_files', SharedDataObject),
+                   tables=_repeated_dict(d, 'tables', SharedDataObject))
 
 
 @dataclass
@@ -157,7 +157,7 @@ class CleanRoomInfo:
         return cls(comment=d.get('comment', None),
                    created_at=d.get('created_at', None),
                    created_by=d.get('created_by', None),
-                   local_catalogs=_repeated(d, 'local_catalogs', CleanRoomCatalog),
+                   local_catalogs=_repeated_dict(d, 'local_catalogs', CleanRoomCatalog),
                    name=d.get('name', None),
                    owner=d.get('owner', None),
                    remote_detailed_info=_from_dict(d, 'remote_detailed_info', CentralCleanRoomInfo),
@@ -202,7 +202,7 @@ class CleanRoomTableInfo:
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'CleanRoomTableInfo':
         return cls(catalog_name=d.get('catalog_name', None),
-                   columns=_repeated(d, 'columns', ColumnInfo),
+                   columns=_repeated_dict(d, 'columns', ColumnInfo),
                    full_name=d.get('full_name', None),
                    name=d.get('name', None),
                    schema_name=d.get('schema_name', None))
@@ -404,7 +404,7 @@ class GetRecipientSharePermissionsResponse:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'GetRecipientSharePermissionsResponse':
-        return cls(permissions_out=_repeated(d, 'permissions_out', ShareToPrivilegeAssignment))
+        return cls(permissions_out=_repeated_dict(d, 'permissions_out', ShareToPrivilegeAssignment))
 
 
 @dataclass
@@ -434,7 +434,7 @@ class ListCleanRoomsResponse:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'ListCleanRoomsResponse':
-        return cls(clean_rooms=_repeated(d, 'clean_rooms', CleanRoomInfo),
+        return cls(clean_rooms=_repeated_dict(d, 'clean_rooms', CleanRoomInfo),
                    next_page_token=d.get('next_page_token', None))
 
 
@@ -449,7 +449,7 @@ class ListProviderSharesResponse:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'ListProviderSharesResponse':
-        return cls(shares=_repeated(d, 'shares', ProviderShare))
+        return cls(shares=_repeated_dict(d, 'shares', ProviderShare))
 
 
 @dataclass
@@ -463,7 +463,7 @@ class ListProvidersResponse:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'ListProvidersResponse':
-        return cls(providers=_repeated(d, 'providers', ProviderInfo))
+        return cls(providers=_repeated_dict(d, 'providers', ProviderInfo))
 
 
 @dataclass
@@ -477,7 +477,7 @@ class ListRecipientsResponse:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'ListRecipientsResponse':
-        return cls(recipients=_repeated(d, 'recipients', RecipientInfo))
+        return cls(recipients=_repeated_dict(d, 'recipients', RecipientInfo))
 
 
 @dataclass
@@ -491,7 +491,7 @@ class ListSharesResponse:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'ListSharesResponse':
-        return cls(shares=_repeated(d, 'shares', ShareInfo))
+        return cls(shares=_repeated_dict(d, 'shares', ShareInfo))
 
 
 @dataclass
@@ -505,7 +505,7 @@ class Partition:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'Partition':
-        return cls(values=_repeated(d, 'values', PartitionValue))
+        return cls(values=_repeated_dict(d, 'values', PartitionValue))
 
 
 @dataclass
@@ -597,7 +597,7 @@ class PrivilegeAssignment:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'PrivilegeAssignment':
-        return cls(principal=d.get('principal', None), privileges=d.get('privileges', None))
+        return cls(principal=d.get('principal', None), privileges=_repeated_enum(d, 'privileges', Privilege))
 
 
 @dataclass
@@ -729,7 +729,7 @@ class RecipientInfo:
                    properties_kvpairs=_from_dict(d, 'properties_kvpairs', SecurablePropertiesKvPairs),
                    region=d.get('region', None),
                    sharing_code=d.get('sharing_code', None),
-                   tokens=_repeated(d, 'tokens', RecipientTokenInfo),
+                   tokens=_repeated_dict(d, 'tokens', RecipientTokenInfo),
                    updated_at=d.get('updated_at', None),
                    updated_by=d.get('updated_by', None))
 
@@ -877,7 +877,7 @@ class ShareInfo:
                    created_at=d.get('created_at', None),
                    created_by=d.get('created_by', None),
                    name=d.get('name', None),
-                   objects=_repeated(d, 'objects', SharedDataObject),
+                   objects=_repeated_dict(d, 'objects', SharedDataObject),
                    owner=d.get('owner', None),
                    updated_at=d.get('updated_at', None),
                    updated_by=d.get('updated_by', None))
@@ -897,7 +897,7 @@ class ShareToPrivilegeAssignment:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'ShareToPrivilegeAssignment':
-        return cls(privilege_assignments=_repeated(d, 'privilege_assignments', PrivilegeAssignment),
+        return cls(privilege_assignments=_repeated_dict(d, 'privilege_assignments', PrivilegeAssignment),
                    share_name=d.get('share_name', None))
 
 
@@ -943,7 +943,7 @@ class SharedDataObject:
                    history_data_sharing_status=_enum(d, 'history_data_sharing_status',
                                                      SharedDataObjectHistoryDataSharingStatus),
                    name=d.get('name', None),
-                   partitions=_repeated(d, 'partitions', Partition),
+                   partitions=_repeated_dict(d, 'partitions', Partition),
                    shared_as=d.get('shared_as', None),
                    start_version=d.get('start_version', None),
                    status=_enum(d, 'status', SharedDataObjectStatus),
@@ -1009,7 +1009,7 @@ class UpdateCleanRoom:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'UpdateCleanRoom':
-        return cls(catalog_updates=_repeated(d, 'catalog_updates', CleanRoomCatalogUpdate),
+        return cls(catalog_updates=_repeated_dict(d, 'catalog_updates', CleanRoomCatalogUpdate),
                    comment=d.get('comment', None),
                    name=d.get('name', None),
                    name_arg=d.get('name_arg', None),
@@ -1085,7 +1085,7 @@ class UpdateShare:
         return cls(comment=d.get('comment', None),
                    name=d.get('name', None),
                    owner=d.get('owner', None),
-                   updates=_repeated(d, 'updates', SharedDataObjectUpdate))
+                   updates=_repeated_dict(d, 'updates', SharedDataObjectUpdate))
 
 
 @dataclass
@@ -1101,7 +1101,8 @@ class UpdateSharePermissions:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'UpdateSharePermissions':
-        return cls(changes=_repeated(d, 'changes', catalog.PermissionsChange), name=d.get('name', None))
+        return cls(changes=_repeated_dict(d, 'changes', sharing.catalog.PermissionsChange),
+                   name=d.get('name', None))
 
 
 class CleanRoomsAPI:

--- a/databricks/sdk/service/sql.py
+++ b/databricks/sdk/service/sql.py
@@ -9,7 +9,7 @@ from enum import Enum
 from typing import Any, Callable, Dict, Iterator, List, Optional
 
 from ..errors import OperationFailed
-from ._internal import Wait, _enum, _from_dict, _repeated
+from ._internal import Wait, _enum, _from_dict, _repeated_dict, _repeated_enum
 
 _LOG = logging.getLogger('databricks.sdk')
 
@@ -242,6 +242,7 @@ class ChannelInfo:
 
 
 class ChannelName(Enum):
+    """Name of the channel"""
 
     CHANNEL_NAME_CURRENT = 'CHANNEL_NAME_CURRENT'
     CHANNEL_NAME_CUSTOM = 'CHANNEL_NAME_CUSTOM'
@@ -499,7 +500,7 @@ class Dashboard:
                    updated_at=d.get('updated_at', None),
                    user=_from_dict(d, 'user', User),
                    user_id=d.get('user_id', None),
-                   widgets=_repeated(d, 'widgets', Widget))
+                   widgets=_repeated_dict(d, 'widgets', Widget))
 
 
 @dataclass
@@ -823,7 +824,7 @@ class EndpointTags:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'EndpointTags':
-        return cls(custom_tags=_repeated(d, 'custom_tags', EndpointTagPair))
+        return cls(custom_tags=_repeated_dict(d, 'custom_tags', EndpointTagPair))
 
 
 @dataclass
@@ -862,7 +863,7 @@ class ExecuteStatementRequest:
                    disposition=_enum(d, 'disposition', Disposition),
                    format=_enum(d, 'format', Format),
                    on_wait_timeout=_enum(d, 'on_wait_timeout', ExecuteStatementRequestOnWaitTimeout),
-                   parameters=_repeated(d, 'parameters', StatementParameterListItem),
+                   parameters=_repeated_dict(d, 'parameters', StatementParameterListItem),
                    row_limit=d.get('row_limit', None),
                    schema=d.get('schema', None),
                    statement=d.get('statement', None),
@@ -964,7 +965,7 @@ class GetResponse:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'GetResponse':
-        return cls(access_control_list=_repeated(d, 'access_control_list', AccessControl),
+        return cls(access_control_list=_repeated_dict(d, 'access_control_list', AccessControl),
                    object_id=d.get('object_id', None),
                    object_type=_enum(d, 'object_type', ObjectType))
 
@@ -1003,7 +1004,7 @@ class GetWarehousePermissionLevelsResponse:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'GetWarehousePermissionLevelsResponse':
-        return cls(permission_levels=_repeated(d, 'permission_levels', WarehousePermissionsDescription))
+        return cls(permission_levels=_repeated_dict(d, 'permission_levels', WarehousePermissionsDescription))
 
 
 @dataclass
@@ -1121,8 +1122,8 @@ class GetWorkspaceWarehouseConfigResponse:
     def from_dict(cls, d: Dict[str, any]) -> 'GetWorkspaceWarehouseConfigResponse':
         return cls(channel=_from_dict(d, 'channel', Channel),
                    config_param=_from_dict(d, 'config_param', RepeatedEndpointConfPairs),
-                   data_access_config=_repeated(d, 'data_access_config', EndpointConfPair),
-                   enabled_warehouse_types=_repeated(d, 'enabled_warehouse_types', WarehouseTypePair),
+                   data_access_config=_repeated_dict(d, 'data_access_config', EndpointConfPair),
+                   enabled_warehouse_types=_repeated_dict(d, 'enabled_warehouse_types', WarehouseTypePair),
                    global_param=_from_dict(d, 'global_param', RepeatedEndpointConfPairs),
                    google_service_account=d.get('google_service_account', None),
                    instance_profile_arn=d.get('instance_profile_arn', None),
@@ -1163,7 +1164,7 @@ class ListQueriesResponse:
     def from_dict(cls, d: Dict[str, any]) -> 'ListQueriesResponse':
         return cls(has_next_page=d.get('has_next_page', None),
                    next_page_token=d.get('next_page_token', None),
-                   res=_repeated(d, 'res', QueryInfo))
+                   res=_repeated_dict(d, 'res', QueryInfo))
 
 
 @dataclass
@@ -1186,7 +1187,7 @@ class ListResponse:
         return cls(count=d.get('count', None),
                    page=d.get('page', None),
                    page_size=d.get('page_size', None),
-                   results=_repeated(d, 'results', Dashboard))
+                   results=_repeated_dict(d, 'results', Dashboard))
 
 
 @dataclass
@@ -1200,7 +1201,7 @@ class ListWarehousesResponse:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'ListWarehousesResponse':
-        return cls(warehouses=_repeated(d, 'warehouses', EndpointInfo))
+        return cls(warehouses=_repeated_dict(d, 'warehouses', EndpointInfo))
 
 
 class ObjectType(Enum):
@@ -1383,7 +1384,7 @@ class Query:
                    updated_at=d.get('updated_at', None),
                    user=_from_dict(d, 'user', User),
                    user_id=d.get('user_id', None),
-                   visualizations=_repeated(d, 'visualizations', Visualization))
+                   visualizations=_repeated_dict(d, 'visualizations', Visualization))
 
 
 @dataclass
@@ -1435,7 +1436,7 @@ class QueryFilter:
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'QueryFilter':
         return cls(query_start_time_range=_from_dict(d, 'query_start_time_range', TimeRange),
-                   statuses=d.get('statuses', None),
+                   statuses=_repeated_enum(d, 'statuses', QueryStatus),
                    user_ids=d.get('user_ids', None),
                    warehouse_ids=d.get('warehouse_ids', None))
 
@@ -1541,7 +1542,7 @@ class QueryList:
         return cls(count=d.get('count', None),
                    page=d.get('page', None),
                    page_size=d.get('page_size', None),
-                   results=_repeated(d, 'results', Query))
+                   results=_repeated_dict(d, 'results', Query))
 
 
 @dataclass
@@ -1653,7 +1654,7 @@ class QueryOptions:
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'QueryOptions':
         return cls(moved_to_trash_at=d.get('moved_to_trash_at', None),
-                   parameters=_repeated(d, 'parameters', Parameter))
+                   parameters=_repeated_dict(d, 'parameters', Parameter))
 
 
 @dataclass
@@ -1741,8 +1742,8 @@ class RepeatedEndpointConfPairs:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'RepeatedEndpointConfPairs':
-        return cls(config_pair=_repeated(d, 'config_pair', EndpointConfPair),
-                   configuration_pairs=_repeated(d, 'configuration_pairs', EndpointConfPair))
+        return cls(config_pair=_repeated_dict(d, 'config_pair', EndpointConfPair),
+                   configuration_pairs=_repeated_dict(d, 'configuration_pairs', EndpointConfPair))
 
 
 @dataclass
@@ -1780,7 +1781,7 @@ class ResultData:
         return cls(byte_count=d.get('byte_count', None),
                    chunk_index=d.get('chunk_index', None),
                    data_array=d.get('data_array', None),
-                   external_links=_repeated(d, 'external_links', ExternalLink),
+                   external_links=_repeated_dict(d, 'external_links', ExternalLink),
                    next_chunk_index=d.get('next_chunk_index', None),
                    next_chunk_internal_link=d.get('next_chunk_internal_link', None),
                    row_count=d.get('row_count', None),
@@ -1812,7 +1813,7 @@ class ResultManifest:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'ResultManifest':
-        return cls(chunks=_repeated(d, 'chunks', BaseChunkInfo),
+        return cls(chunks=_repeated_dict(d, 'chunks', BaseChunkInfo),
                    format=_enum(d, 'format', Format),
                    schema=_from_dict(d, 'schema', ResultSchema),
                    total_byte_count=d.get('total_byte_count', None),
@@ -1836,7 +1837,7 @@ class ResultSchema:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'ResultSchema':
-        return cls(column_count=d.get('column_count', None), columns=_repeated(d, 'columns', ColumnInfo))
+        return cls(column_count=d.get('column_count', None), columns=_repeated_dict(d, 'columns', ColumnInfo))
 
 
 class RunAsRole(Enum):
@@ -1896,7 +1897,7 @@ class SetResponse:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'SetResponse':
-        return cls(access_control_list=_repeated(d, 'access_control_list', AccessControl),
+        return cls(access_control_list=_repeated_dict(d, 'access_control_list', AccessControl),
                    object_id=d.get('object_id', None),
                    object_type=_enum(d, 'object_type', ObjectType))
 
@@ -1934,8 +1935,8 @@ class SetWorkspaceWarehouseConfigRequest:
     def from_dict(cls, d: Dict[str, any]) -> 'SetWorkspaceWarehouseConfigRequest':
         return cls(channel=_from_dict(d, 'channel', Channel),
                    config_param=_from_dict(d, 'config_param', RepeatedEndpointConfPairs),
-                   data_access_config=_repeated(d, 'data_access_config', EndpointConfPair),
-                   enabled_warehouse_types=_repeated(d, 'enabled_warehouse_types', WarehouseTypePair),
+                   data_access_config=_repeated_dict(d, 'data_access_config', EndpointConfPair),
+                   enabled_warehouse_types=_repeated_dict(d, 'enabled_warehouse_types', WarehouseTypePair),
                    global_param=_from_dict(d, 'global_param', RepeatedEndpointConfPairs),
                    google_service_account=d.get('google_service_account', None),
                    instance_profile_arn=d.get('instance_profile_arn', None),
@@ -2293,7 +2294,7 @@ class WarehouseAccessControlResponse:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'WarehouseAccessControlResponse':
-        return cls(all_permissions=_repeated(d, 'all_permissions', WarehousePermission),
+        return cls(all_permissions=_repeated_dict(d, 'all_permissions', WarehousePermission),
                    display_name=d.get('display_name', None),
                    group_name=d.get('group_name', None),
                    service_principal_name=d.get('service_principal_name', None),
@@ -2344,7 +2345,8 @@ class WarehousePermissions:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'WarehousePermissions':
-        return cls(access_control_list=_repeated(d, 'access_control_list', WarehouseAccessControlResponse),
+        return cls(access_control_list=_repeated_dict(d, 'access_control_list',
+                                                      WarehouseAccessControlResponse),
                    object_id=d.get('object_id', None),
                    object_type=d.get('object_type', None))
 
@@ -2380,7 +2382,8 @@ class WarehousePermissionsRequest:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'WarehousePermissionsRequest':
-        return cls(access_control_list=_repeated(d, 'access_control_list', WarehouseAccessControlRequest),
+        return cls(access_control_list=_repeated_dict(d, 'access_control_list',
+                                                      WarehouseAccessControlRequest),
                    warehouse_id=d.get('warehouse_id', None))
 
 

--- a/databricks/sdk/service/workspace.py
+++ b/databricks/sdk/service/workspace.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Dict, Iterator, List, Optional
 
-from ._internal import _enum, _from_dict, _repeated
+from ._internal import _enum, _from_dict, _repeated_dict
 
 _LOG = logging.getLogger('databricks.sdk')
 
@@ -255,7 +255,7 @@ class GetCredentialsResponse:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'GetCredentialsResponse':
-        return cls(credentials=_repeated(d, 'credentials', CredentialInfo))
+        return cls(credentials=_repeated_dict(d, 'credentials', CredentialInfo))
 
 
 @dataclass
@@ -269,7 +269,7 @@ class GetRepoPermissionLevelsResponse:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'GetRepoPermissionLevelsResponse':
-        return cls(permission_levels=_repeated(d, 'permission_levels', RepoPermissionsDescription))
+        return cls(permission_levels=_repeated_dict(d, 'permission_levels', RepoPermissionsDescription))
 
 
 @dataclass
@@ -299,7 +299,8 @@ class GetWorkspaceObjectPermissionLevelsResponse:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'GetWorkspaceObjectPermissionLevelsResponse':
-        return cls(permission_levels=_repeated(d, 'permission_levels', WorkspaceObjectPermissionsDescription))
+        return cls(
+            permission_levels=_repeated_dict(d, 'permission_levels', WorkspaceObjectPermissionsDescription))
 
 
 @dataclass
@@ -369,7 +370,7 @@ class ListAclsResponse:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'ListAclsResponse':
-        return cls(items=_repeated(d, 'items', AclItem))
+        return cls(items=_repeated_dict(d, 'items', AclItem))
 
 
 @dataclass
@@ -385,7 +386,7 @@ class ListReposResponse:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'ListReposResponse':
-        return cls(next_page_token=d.get('next_page_token', None), repos=_repeated(d, 'repos', RepoInfo))
+        return cls(next_page_token=d.get('next_page_token', None), repos=_repeated_dict(d, 'repos', RepoInfo))
 
 
 @dataclass
@@ -399,7 +400,7 @@ class ListResponse:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'ListResponse':
-        return cls(objects=_repeated(d, 'objects', ObjectInfo))
+        return cls(objects=_repeated_dict(d, 'objects', ObjectInfo))
 
 
 @dataclass
@@ -413,7 +414,7 @@ class ListScopesResponse:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'ListScopesResponse':
-        return cls(scopes=_repeated(d, 'scopes', SecretScope))
+        return cls(scopes=_repeated_dict(d, 'scopes', SecretScope))
 
 
 @dataclass
@@ -427,7 +428,7 @@ class ListSecretsResponse:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'ListSecretsResponse':
-        return cls(secrets=_repeated(d, 'secrets', SecretMetadata))
+        return cls(secrets=_repeated_dict(d, 'secrets', SecretMetadata))
 
 
 @dataclass
@@ -576,7 +577,7 @@ class RepoAccessControlResponse:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'RepoAccessControlResponse':
-        return cls(all_permissions=_repeated(d, 'all_permissions', RepoPermission),
+        return cls(all_permissions=_repeated_dict(d, 'all_permissions', RepoPermission),
                    display_name=d.get('display_name', None),
                    group_name=d.get('group_name', None),
                    service_principal_name=d.get('service_principal_name', None),
@@ -660,7 +661,7 @@ class RepoPermissions:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'RepoPermissions':
-        return cls(access_control_list=_repeated(d, 'access_control_list', RepoAccessControlResponse),
+        return cls(access_control_list=_repeated_dict(d, 'access_control_list', RepoAccessControlResponse),
                    object_id=d.get('object_id', None),
                    object_type=d.get('object_type', None))
 
@@ -696,7 +697,7 @@ class RepoPermissionsRequest:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'RepoPermissionsRequest':
-        return cls(access_control_list=_repeated(d, 'access_control_list', RepoAccessControlRequest),
+        return cls(access_control_list=_repeated_dict(d, 'access_control_list', RepoAccessControlRequest),
                    repo_id=d.get('repo_id', None))
 
 
@@ -861,7 +862,7 @@ class WorkspaceObjectAccessControlResponse:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'WorkspaceObjectAccessControlResponse':
-        return cls(all_permissions=_repeated(d, 'all_permissions', WorkspaceObjectPermission),
+        return cls(all_permissions=_repeated_dict(d, 'all_permissions', WorkspaceObjectPermission),
                    display_name=d.get('display_name', None),
                    group_name=d.get('group_name', None),
                    service_principal_name=d.get('service_principal_name', None),
@@ -913,8 +914,8 @@ class WorkspaceObjectPermissions:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'WorkspaceObjectPermissions':
-        return cls(access_control_list=_repeated(d, 'access_control_list',
-                                                 WorkspaceObjectAccessControlResponse),
+        return cls(access_control_list=_repeated_dict(d, 'access_control_list',
+                                                      WorkspaceObjectAccessControlResponse),
                    object_id=d.get('object_id', None),
                    object_type=d.get('object_type', None))
 
@@ -952,8 +953,8 @@ class WorkspaceObjectPermissionsRequest:
 
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> 'WorkspaceObjectPermissionsRequest':
-        return cls(access_control_list=_repeated(d, 'access_control_list',
-                                                 WorkspaceObjectAccessControlRequest),
+        return cls(access_control_list=_repeated_dict(d, 'access_control_list',
+                                                      WorkspaceObjectAccessControlRequest),
                    workspace_object_id=d.get('workspace_object_id', None),
                    workspace_object_type=d.get('workspace_object_type', None))
 

--- a/tests/integration/test_iam.py
+++ b/tests/integration/test_iam.py
@@ -16,6 +16,12 @@ def test_scim_error_unmarshall(w, random):
     assert 'Given filter operator is not supported' in str(exc_info.value)
 
 
+def test_scim_get_user_as_dict(w):
+    first_user = next(w.users.list())
+    user = w.users.get(first_user.id)
+    # should not throw
+    user.as_dict()
+
 @pytest.mark.parametrize(
     "path,call",
     [("/api/2.0/preview/scim/v2/Users", lambda w: w.users.list(count=10)),

--- a/tests/integration/test_iam.py
+++ b/tests/integration/test_iam.py
@@ -22,6 +22,7 @@ def test_scim_get_user_as_dict(w):
     # should not throw
     user.as_dict()
 
+
 @pytest.mark.parametrize(
     "path,call",
     [("/api/2.0/preview/scim/v2/Users", lambda w: w.users.list(count=10)),

--- a/tests/test_internal.py
+++ b/tests/test_internal.py
@@ -1,0 +1,38 @@
+from dataclasses import dataclass
+from enum import Enum
+
+import pytest
+
+from databricks.sdk.service._internal import _enum, _from_dict, _repeated_dict, _repeated_enum
+
+class A(Enum):
+    a = 'a'
+    b = 'b'
+
+
+def test_enum():
+    assert _enum({'field': 'a'}, 'field', A) == A.a
+
+def test_enum_unknown():
+    assert _enum({'field': 'c'}, 'field', A) is None
+
+def test_repeated_enum():
+    assert _repeated_enum({'field': ['a', 'b']}, 'field', A) == [A.a, A.b]
+
+def test_repeated_enum_unknown():
+    assert _repeated_enum({'field': ['a', 'c']}, 'field', A) == [A.a]
+
+
+@dataclass
+class B:
+    field: str
+
+    @classmethod
+    def from_dict(cls, d: dict) -> 'B':
+        return cls(d['field'])
+
+def test_from_dict():
+    assert _from_dict({'x': {'field': 'a'}}, 'x', B) == B('a')
+
+def test_repeated_dict():
+    assert _repeated_dict({'x': [{'field': 'a'}, {'field': 'c'}]}, 'x', B) == [B('a'), B('c')]

--- a/tests/test_internal.py
+++ b/tests/test_internal.py
@@ -1,9 +1,9 @@
 from dataclasses import dataclass
 from enum import Enum
 
-import pytest
+from databricks.sdk.service._internal import (_enum, _from_dict,
+                                              _repeated_dict, _repeated_enum)
 
-from databricks.sdk.service._internal import _enum, _from_dict, _repeated_dict, _repeated_enum
 
 class A(Enum):
     a = 'a'
@@ -13,11 +13,14 @@ class A(Enum):
 def test_enum():
     assert _enum({'field': 'a'}, 'field', A) == A.a
 
+
 def test_enum_unknown():
     assert _enum({'field': 'c'}, 'field', A) is None
 
+
 def test_repeated_enum():
     assert _repeated_enum({'field': ['a', 'b']}, 'field', A) == [A.a, A.b]
+
 
 def test_repeated_enum_unknown():
     assert _repeated_enum({'field': ['a', 'c']}, 'field', A) == [A.a]
@@ -31,8 +34,10 @@ class B:
     def from_dict(cls, d: dict) -> 'B':
         return cls(d['field'])
 
+
 def test_from_dict():
     assert _from_dict({'x': {'field': 'a'}}, 'x', B) == B('a')
+
 
 def test_repeated_dict():
     assert _repeated_dict({'x': [{'field': 'a'}, {'field': 'c'}]}, 'x', B) == [B('a'), B('c')]


### PR DESCRIPTION
## Changes
Resolves #449.

We need to handle deserializing repeated enums specially, like we do with handling deserializing plain enums.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

