### PR TITLE
Change the name of retries logger to `databricks.sdk.retries`

### DIFF
--- a/databricks/sdk/retries.py
+++ b/databricks/sdk/retries.py
@@ -5,7 +5,7 @@ from datetime import timedelta
 from random import random
 from typing import Callable, List, Optional, Type
 
-logger = logging.getLogger('databricks.sdk')
+logger = logging.getLogger(__name__)
 
 
 def retried(*,


### PR DESCRIPTION
This PR makes it possible to set custom logging rules just for retries.