### PR TITLE
Capture stdout and stderr separately when calling Azure CLI

### DIFF
--- a/tests/test_auth_manual_tests.py
+++ b/tests/test_auth_manual_tests.py
@@ -36,3 +36,12 @@ def test_azure_cli_fallback(monkeypatch):
     resource_id = '/subscriptions/123/resourceGroups/abc/providers/Microsoft.Databricks/workspaces/abc123'
     cfg = Config(auth_type='azure-cli', host='x', azure_workspace_resource_id=resource_id)
     assert 'X-Databricks-Azure-SP-Management-Token' in cfg.authenticate()
+
+
+def test_azure_cli_with_warning_on_stderr(monkeypatch):
+    monkeypatch.setenv('HOME', __tests__ + '/testdata/azure')
+    monkeypatch.setenv('PATH', __tests__ + '/testdata:/bin')
+    monkeypatch.setenv('WARN', 'this is a warning')
+    resource_id = '/subscriptions/123/resourceGroups/abc/providers/Microsoft.Databricks/workspaces/abc123'
+    cfg = Config(auth_type='azure-cli', host='x', azure_workspace_resource_id=resource_id)
+    assert 'X-Databricks-Azure-SP-Management-Token' in cfg.authenticate()

--- a/tests/testdata/az
+++ b/tests/testdata/az
@@ -1,16 +1,20 @@
 #!/bin/bash
 
-if [ "yes" == "$FAIL" ]; then 
+if [ -n "$WARN" ]; then
+    >&2 /bin/echo "WARNING: ${WARN}"
+fi
+
+if [ "yes" == "$FAIL" ]; then
     >&2 /bin/echo "This is just a failing script."
     exit 1
 fi
 
-if [ "logout" == "$FAIL" ]; then 
+if [ "logout" == "$FAIL" ]; then
     >&2 /bin/echo "No subscription found. Run 'az account set' to select a subscription."
     exit 1
 fi
 
-if [ "corrupt" == "$FAIL" ]; then 
+if [ "corrupt" == "$FAIL" ]; then
     /bin/echo "{accessToken: ..corrupt"
     exit
 fi


### PR DESCRIPTION
## Changes

They were captured together such that any warnings emitted to stderr would turn the output of the command into malformed JSON and raise an error.

Traces all the way back to #30.

## Tests

- [x] `make test` run locally
- [x] `make fmt` applied
- [ ] relevant integration tests applied

