### PR TITLE
Install local library when generating docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,4 +14,4 @@ sphinx:
 
 python:
   install:
-  - requirements: docs/requirements.txt
+  - requirements: docs-requirements.txt

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -2,3 +2,4 @@ myst_parser
 sphinx-autobuild
 enum_tools
 sphinx-toolbox
+.


### PR DESCRIPTION
## Changes
 #467 changed the docs to require the databricks SDK itself to be installed for Sphinx to generate docs correctly. This PR fixes the requirements file used by readthedocs.org to install the SDK before trying to generate docs. The requirements file is consumed from the root directory by readthedocs.py, so I moved it to the root directory so it's more obvious that it ought to be run from there.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

