### PR TITLE
Update GCP auth readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,8 @@ w = WorkspaceClient(host=input('Databricks Workspace URL: '),
                     azure_client_secret=input('AAD Client Secret: '))
 ```
 
+Please see more examples in [this document](./docs/azure-ad.md).
+
 ### Google Cloud Platform native authentication
 
 By default, the Databricks SDK for Python first tries GCP credentials authentication (`auth_type='google-credentials'`, argument). If the SDK is unsuccessful, it then tries Google Cloud Platform (GCP) ID authentication (`auth_type='google-id'`, argument).
@@ -228,8 +230,6 @@ w = WorkspaceClient(host=input('Databricks Workspace URL: '),
                     google_service_account=input('Google Service Account: '))
 
 ```
-
-Please see more examples in [this document](./docs/azure-ad.md).
 
 ### Overriding `.databrickscfg`
 


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
- The azure doc link was misplaced. Moving it up under the azure auth section

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

