### PR TITLE
Sort imports in service template

### DIFF
--- a/.codegen/service.py.tmpl
+++ b/.codegen/service.py.tmpl
@@ -1,5 +1,6 @@
 # Code generated from OpenAPI specs by Databricks SDK Generator. DO NOT EDIT.
 
+from __future__ import annotations
 from dataclasses import dataclass
 from datetime import timedelta
 from enum import Enum
@@ -9,7 +10,6 @@ import random
 import logging
 from ..errors import OperationTimeout, OperationFailed
 from ._internal import _enum, _from_dict, _repeated_dict, _repeated_enum, Wait
-from __future__ import annotations
 
 _LOG = logging.getLogger('databricks.sdk')
 


### PR DESCRIPTION
## Changes
Sort imports in service template. The following line must be the first command in a Python file:
`from __future__ import annotations` 
Usually this is sorted by the linter. But if the file generated is not syntactically correct, it won't be sorted and it will cause a error which will mask the real error with the generated file.

## Tests
`deco openapi generate-sdk py --openapi-spec master`

- [ ] `make test` run locally
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

