### PR TITLE
Add `py.typed` to support PEP-561

### DIFF
--- a/databricks/sdk/py.typed
+++ b/databricks/sdk/py.typed
@@ -1,0 +1,1 @@
+# Marker file for PEP 561.  The databricks-sdk package uses inline types.

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ with version_file.open('r') as f:
 setup(name="databricks-sdk",
       version=version_data['__version__'],
       packages=find_packages(exclude=["tests", "*tests.*", "*tests"]),
+      package_data = {"databricks.sdk": ["py.typed"]},
       python_requires=">=3.7",
       install_requires=["requests>=2.28.1,<3", "google-auth~=2.0"],
       extras_require={"dev": ["pytest", "pytest-cov", "pytest-xdist", "pytest-mock",


### PR DESCRIPTION
## Changes
This PR adds support for `mypy` checker in downstream projects.

Without this file, `mypy` shows `Skipping analyzing "databricks.sdk": module is installed, but missing library stubs or py.typed marker` errors:
```
tests/integration/hive_metastore/verify_tacl_access.py:4: error: Skipping analyzing "databricks.sdk.service.compute": module is installed, but missing library stubs or py.typed marker  [import-untyped]
tests/integration/hive_metastore/verify_tacl_access.py:8: error: Skipping analyzing "databricks.sdk": module is installed, but missing library stubs or py.typed marker  [import-untyped]
src/databricks/labs/ucx/mixins/redash.py:5: error: Skipping analyzing "databricks.sdk.service._internal": module is installed, but missing library stubs or py.typed marker  [import-untyped]
```

Once this file is added to a virtual env, `mypy` starts picking up type information from SDK as expected:
<img width="909" alt="image" src="https://github.com/databricks/databricks-sdk-py/assets/259697/1d126711-f1f5-409d-8ed5-beaa2aa97d8f">


## Tests

Confirming that `py.typed` gets to a wheel:
```
$ make dist | grep py.typed
copying databricks/sdk/py.typed -> build/lib/databricks/sdk
...
copying build/lib/databricks/sdk/py.typed -> build/bdist.macosx-13-arm64/wheel/databricks/sdk
adding 'databricks/sdk/py.typed'
copying databricks/sdk/py.typed -> databricks-sdk-0.15.0/databricks/sdk
```

- [x] `make test` run locally
- [x] `make fmt` applied
- [ ] relevant integration tests applied

