### PR TITLE
Fixed bug in `@retried` when exception subtypes were not respected

### DIFF
--- a/databricks/sdk/retries.py
+++ b/databricks/sdk/retries.py
@@ -39,8 +39,11 @@ def retried(*,
                         retry_reason = 'throttled by platform'
                     elif is_retryable is not None:
                         retry_reason = is_retryable(err)
-                    elif type(err) in on:
-                        retry_reason = f'{type(err).__name__} is allowed to retry'
+                    elif on is not None:
+                        for err_type in on:
+                            if not isinstance(err, err_type):
+                                continue
+                            retry_reason = f'{type(err).__name__} is allowed to retry'
 
                     if retry_reason is None:
                         # raise if exception is not retryable

--- a/tests/test_retries.py
+++ b/tests/test_retries.py
@@ -2,6 +2,7 @@ from datetime import timedelta
 
 import pytest
 
+from databricks.sdk.errors import NotFound, ResourceDoesNotExist
 from databricks.sdk.retries import retried
 
 
@@ -37,6 +38,16 @@ def test_match_on_errors():
         @retried(on=[KeyError, AttributeError], timeout=timedelta(seconds=0.5))
         def foo():
             raise KeyError(1)
+
+        foo()
+
+
+def test_match_on_subclass():
+    with pytest.raises(TimeoutError):
+
+        @retried(on=[NotFound], timeout=timedelta(seconds=0.5))
+        def foo():
+            raise ResourceDoesNotExist(...)
 
         foo()
 


### PR DESCRIPTION
## Changes
This PR adds fixes retries on exception subclasses.

## Tests

- [x] `make test` run locally
- [x] `make fmt` applied
- [x] relevant integration tests applied

