### PR TITLE
Use covariant type for `@retried(on=[...])`

### DIFF
--- a/databricks/sdk/retries.py
+++ b/databricks/sdk/retries.py
@@ -3,13 +3,13 @@ import logging
 import time
 from datetime import timedelta
 from random import random
-from typing import Callable, List, Optional, Type
+from typing import Callable, Optional, Type, Sequence
 
 logger = logging.getLogger(__name__)
 
 
 def retried(*,
-            on: List[Type[BaseException]] = None,
+            on: Sequence[Type[BaseException]] = None,
             is_retryable: Callable[[BaseException], Optional[str]] = None,
             timeout=timedelta(minutes=20)):
     has_allowlist = on is not None

--- a/databricks/sdk/retries.py
+++ b/databricks/sdk/retries.py
@@ -3,7 +3,7 @@ import logging
 import time
 from datetime import timedelta
 from random import random
-from typing import Callable, Optional, Type, Sequence
+from typing import Callable, Optional, Sequence, Type
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Changes
This PR fixes `mypy` error in downstream projects:

```
src/databricks/labs/ucx/workspace_access/scim.py:121: error: Argument "on" to "retried" has incompatible type "list[type[DatabricksError]]"; expected "list[type[BaseException]]"  [arg-type]
src/databricks/labs/ucx/workspace_access/scim.py:121: note: "List" is invariant -- see https://mypy.readthedocs.io/en/stable/common_issues.html#variance
src/databricks/labs/ucx/workspace_access/scim.py:121: note: Consider using "Sequence" instead, which is covariant
src/databricks/labs/ucx/workspace_access/generic.py:143: error: Argument "on" to "retried" has incompatible type "list[type[DatabricksError]]"; expected "list[type[BaseException]]"  [arg-type]
src/databricks/labs/ucx/workspace_access/generic.py:143: note: "List" is invariant -- see https://mypy.readthedocs.io/en/stable/common_issues.html#variance
src/databricks/labs/ucx/workspace_access/generic.py:143: note: Consider using "Sequence" instead, which is covariant
```

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] `make fmt` applied
- [x] relevant integration tests applied

