### PR TITLE
Make contents of `__init__.py` equal across projects

### DIFF
--- a/databricks/__init__.py
+++ b/databricks/__init__.py
@@ -1,3 +1,7 @@
-# DO NOT ADD ANYTHING ELSE TO THIS FILE FOR COMPATIBILITY WITH OTHER databricks.* PACKAGES
-# SEE https://packaging.python.org/guides/packaging-namespace-packages/#pkgutil-style-namespace-packages
+# See: https://packaging.python.org/guides/packaging-namespace-packages/#pkgutil-style-namespace-packages
+#
+# This file must only contain the following line, or other packages in the databricks.* namespace
+# may not be importable. The contents of this file must be byte-for-byte equivalent across all packages.
+# If they are not, parallel package installation may lead to clobbered and invalid files.
+# Also see https://github.com/databricks/databricks-sdk-py/issues/343.
 __path__ = __import__('pkgutil').extend_path(__path__, __name__)

--- a/databricks/__init__.py
+++ b/databricks/__init__.py
@@ -4,4 +4,4 @@
 # may not be importable. The contents of this file must be byte-for-byte equivalent across all packages.
 # If they are not, parallel package installation may lead to clobbered and invalid files.
 # Also see https://github.com/databricks/databricks-sdk-py/issues/343.
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/tests/test_init_file.py
+++ b/tests/test_init_file.py
@@ -1,0 +1,17 @@
+import hashlib
+
+
+def test_init_file_contents():
+    """
+    Micro test to confirm the contents of `databricks/__init__.py` does not change.
+
+    Also see https://github.com/databricks/databricks-sdk-py/issues/343#issuecomment-1866029118.
+    """
+    with open('databricks/__init__.py') as f:
+        init_file_contents = f.read()
+
+    # This hash is the expected hash of the contents of `src/databricks/__init__.py`.
+    # It must not change, or else parallel package installation may lead to clobbered and invalid files.
+    expected_sha1 = '7f60afe4b2d493117af3e076a5c6ec7f792e2515'
+    actual_sha1 = hashlib.sha1(init_file_contents.encode('utf-8')).hexdigest()
+    assert expected_sha1 == actual_sha1

--- a/tests/test_init_file.py
+++ b/tests/test_init_file.py
@@ -12,6 +12,6 @@ def test_init_file_contents():
 
     # This hash is the expected hash of the contents of `src/databricks/__init__.py`.
     # It must not change, or else parallel package installation may lead to clobbered and invalid files.
-    expected_sha1 = '7f60afe4b2d493117af3e076a5c6ec7f792e2515'
+    expected_sha1 = '2772edbf52e517542acf8c039479c4b57b6ca2cd'
     actual_sha1 = hashlib.sha1(init_file_contents.encode('utf-8')).hexdigest()
     assert expected_sha1 == actual_sha1


### PR DESCRIPTION
## Changes

See https://github.com/databricks/databricks-sdk-py/issues/343#issuecomment-1866029118.

Corresponding PR in the SQL connector: https://github.com/databricks/databricks-sql-python/pull/304

## Tests

Unit test to confirm the SHA1 of the file contents.