### PR TITLE
Configure request timeout using existing parameter from Config

### DIFF
--- a/databricks/sdk/core.py
+++ b/databricks/sdk/core.py
@@ -1082,6 +1082,9 @@ class ApiClient:
                                    pool_block=pool_block)
         self._session.mount("https://", http_adapter)
 
+        # Default to 60 seconds
+        self._http_timeout_seconds = cfg.http_timeout_seconds if cfg.http_timeout_seconds else 60
+
     @property
     def account_id(self) -> str:
         return self._cfg.account_id
@@ -1226,7 +1229,8 @@ class ApiClient:
                                          headers=headers,
                                          files=files,
                                          data=data,
-                                         stream=raw)
+                                         stream=raw,
+                                         timeout=self._http_timeout_seconds)
         try:
             self._record_request_log(response, raw=raw or data is not None or files is not None)
             if not response.ok: # internally calls response.raise_for_status()

--- a/databricks/sdk/core.py
+++ b/databricks/sdk/core.py
@@ -676,7 +676,7 @@ class Config:
     cluster_id: str = ConfigAttribute(env='DATABRICKS_CLUSTER_ID')
     warehouse_id: str = ConfigAttribute(env='DATABRICKS_WAREHOUSE_ID')
     skip_verify: bool = ConfigAttribute()
-    http_timeout_seconds: int = ConfigAttribute()
+    http_timeout_seconds: float = ConfigAttribute()
     debug_truncate_bytes: int = ConfigAttribute(env='DATABRICKS_DEBUG_TRUNCATE_BYTES')
     debug_headers: bool = ConfigAttribute(env='DATABRICKS_DEBUG_HEADERS')
     rate_limit: int = ConfigAttribute(env='DATABRICKS_RATE_LIMIT')


### PR DESCRIPTION
## Changes
This PR configures the request timeout to the value specified by the user. The config attribute existed before this change but was not used anywhere. 60s default matches what we do in the [Go SDK](https://github.com/databricks/databricks-sdk-go/blob/main/client/client.go#L30).

Closes #487.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

