### PR TITLE
Fix execution examples, run fmte

### DIFF
--- a/examples/command_context/execute_commands.py
+++ b/examples/command_context/execute_commands.py
@@ -2,4 +2,4 @@ from databricks.sdk import WorkspaceClient
 
 w = WorkspaceClient()
 
-res = w.command_context.execute("print(1)")
+res = w.command_execution.execute(command="print(1)")

--- a/examples/command_executor/execute_commands.py
+++ b/examples/command_executor/execute_commands.py
@@ -1,10 +1,11 @@
 import os
 
 from databricks.sdk import WorkspaceClient
+from databricks.sdk.service.compute import Language
 
 w = WorkspaceClient()
 
 cluster_id = w.clusters.ensure_cluster_is_running(
     os.environ["DATABRICKS_CLUSTER_ID"]) and os.environ["DATABRICKS_CLUSTER_ID"]
 
-res = w.command_executor.execute(cluster_id, "python", "print(1)")
+res = w.command_execution.execute(cluster_id=cluster_id, language=Language.PYTHON, command="print(1)")

--- a/examples/flask_app_with_oauth.py
+++ b/examples/flask_app_with_oauth.py
@@ -110,7 +110,9 @@ def register_custom_app(oauth_client: OAuthClient, args: argparse.Namespace) -> 
                                    )
 
     custom_app = account_client.custom_app_integration.create(
-        name=APP_NAME, redirect_urls=[f"http://localhost:{args.port}/callback"], confidential=True,
+        name=APP_NAME,
+        redirect_urls=[f"http://localhost:{args.port}/callback"],
+        confidential=True,
         scopes=["all-apis"],
     )
     logging.info(f"Created new custom app: "

--- a/examples/grants/get_effective_tables.py
+++ b/examples/grants/get_effective_tables.py
@@ -12,10 +12,11 @@ created_catalog = w.catalogs.create(name=f'sdk-{time.time_ns()}')
 
 created_schema = w.schemas.create(name=f'sdk-{time.time_ns()}', catalog_name=created_catalog.name)
 
-_ = w.statement_execution.execute(warehouse_id=os.environ["TEST_DEFAULT_WAREHOUSE_ID"],
-                                  catalog=created_catalog.name,
-                                  schema=created_schema.name,
-                                  statement="CREATE TABLE %s AS SELECT 2+2 as four" % (table_name)).result()
+_ = w.statement_execution.execute_statement(warehouse_id=os.environ["TEST_DEFAULT_WAREHOUSE_ID"],
+                                            catalog=created_catalog.name,
+                                            schema=created_schema.name,
+                                            statement="CREATE TABLE %s AS SELECT 2+2 as four" %
+                                            (table_name)).result()
 
 table_full_name = "%s.%s.%s" % (created_catalog.name, created_schema.name, table_name)
 

--- a/examples/grants/update_tables.py
+++ b/examples/grants/update_tables.py
@@ -12,10 +12,11 @@ created_catalog = w.catalogs.create(name=f'sdk-{time.time_ns()}')
 
 created_schema = w.schemas.create(name=f'sdk-{time.time_ns()}', catalog_name=created_catalog.name)
 
-_ = w.statement_execution.execute(warehouse_id=os.environ["TEST_DEFAULT_WAREHOUSE_ID"],
-                                  catalog=created_catalog.name,
-                                  schema=created_schema.name,
-                                  statement="CREATE TABLE %s AS SELECT 2+2 as four" % (table_name)).result()
+_ = w.statement_execution.execute_statement(warehouse_id=os.environ["TEST_DEFAULT_WAREHOUSE_ID"],
+                                            catalog=created_catalog.name,
+                                            schema=created_schema.name,
+                                            statement="CREATE TABLE %s AS SELECT 2+2 as four" %
+                                            (table_name)).result()
 
 table_full_name = "%s.%s.%s" % (created_catalog.name, created_schema.name, table_name)
 

--- a/examples/shares/update_shares.py
+++ b/examples/shares/update_shares.py
@@ -12,10 +12,11 @@ created_catalog = w.catalogs.create(name=f'sdk-{time.time_ns()}')
 
 created_schema = w.schemas.create(name=f'sdk-{time.time_ns()}', catalog_name=created_catalog.name)
 
-_ = w.statement_execution.execute(warehouse_id=os.environ["TEST_DEFAULT_WAREHOUSE_ID"],
-                                  catalog=created_catalog.name,
-                                  schema=created_schema.name,
-                                  statement="CREATE TABLE %s AS SELECT 2+2 as four" % (table_name)).result()
+_ = w.statement_execution.execute_statement(warehouse_id=os.environ["TEST_DEFAULT_WAREHOUSE_ID"],
+                                            catalog=created_catalog.name,
+                                            schema=created_schema.name,
+                                            statement="CREATE TABLE %s AS SELECT 2+2 as four" %
+                                            (table_name)).result()
 
 table_full_name = "%s.%s.%s" % (created_catalog.name, created_schema.name, table_name)
 

--- a/examples/starting_job_and_waiting.py
+++ b/examples/starting_job_and_waiting.py
@@ -39,8 +39,8 @@ import logging
 import sys
 import time
 
-from databricks.sdk.service import compute, jobs
 from databricks.sdk import WorkspaceClient
+from databricks.sdk.service import compute, jobs
 
 if __name__ == "__main__":
     logging.basicConfig(stream=sys.stdout,

--- a/examples/statement_execution/execute_shares.py
+++ b/examples/statement_execution/execute_shares.py
@@ -11,10 +11,11 @@ created_catalog = w.catalogs.create(name=f'sdk-{time.time_ns()}')
 
 created_schema = w.schemas.create(name=f'sdk-{time.time_ns()}', catalog_name=created_catalog.name)
 
-_ = w.statement_execution.execute(warehouse_id=os.environ["TEST_DEFAULT_WAREHOUSE_ID"],
-                                  catalog=created_catalog.name,
-                                  schema=created_schema.name,
-                                  statement="CREATE TABLE %s AS SELECT 2+2 as four" % (table_name)).result()
+_ = w.statement_execution.execute_statement(warehouse_id=os.environ["TEST_DEFAULT_WAREHOUSE_ID"],
+                                            catalog=created_catalog.name,
+                                            schema=created_schema.name,
+                                            statement="CREATE TABLE %s AS SELECT 2+2 as four" %
+                                            (table_name)).result()
 
 # cleanup
 w.schemas.delete(full_name=created_schema.full_name)

--- a/examples/statement_execution/execute_tables.py
+++ b/examples/statement_execution/execute_tables.py
@@ -11,10 +11,11 @@ created_catalog = w.catalogs.create(name=f'sdk-{time.time_ns()}')
 
 created_schema = w.schemas.create(name=f'sdk-{time.time_ns()}', catalog_name=created_catalog.name)
 
-_ = w.statement_execution.execute(warehouse_id=os.environ["TEST_DEFAULT_WAREHOUSE_ID"],
-                                  catalog=created_catalog.name,
-                                  schema=created_schema.name,
-                                  statement="CREATE TABLE %s AS SELECT 2+2 as four" % (table_name)).result()
+_ = w.statement_execution.execute_statement(warehouse_id=os.environ["TEST_DEFAULT_WAREHOUSE_ID"],
+                                            catalog=created_catalog.name,
+                                            schema=created_schema.name,
+                                            statement="CREATE TABLE %s AS SELECT 2+2 as four" %
+                                            (table_name)).result()
 
 # cleanup
 w.schemas.delete(full_name=created_schema.full_name)

--- a/examples/tables/get_tables.py
+++ b/examples/tables/get_tables.py
@@ -11,10 +11,11 @@ created_catalog = w.catalogs.create(name=f'sdk-{time.time_ns()}')
 
 created_schema = w.schemas.create(name=f'sdk-{time.time_ns()}', catalog_name=created_catalog.name)
 
-_ = w.statement_execution.execute(warehouse_id=os.environ["TEST_DEFAULT_WAREHOUSE_ID"],
-                                  catalog=created_catalog.name,
-                                  schema=created_schema.name,
-                                  statement="CREATE TABLE %s AS SELECT 2+2 as four" % (table_name)).result()
+_ = w.statement_execution.execute_statement(warehouse_id=os.environ["TEST_DEFAULT_WAREHOUSE_ID"],
+                                            catalog=created_catalog.name,
+                                            schema=created_schema.name,
+                                            statement="CREATE TABLE %s AS SELECT 2+2 as four" %
+                                            (table_name)).result()
 
 table_full_name = "%s.%s.%s" % (created_catalog.name, created_schema.name, table_name)
 


### PR DESCRIPTION
## Changes
We fix broken examples with old command or statement execution calls. In addition, we run `make fmte`.

Closes #341 
Closes #267 

## Tests
We have fixed function calls in the examples. Therefore, production code is not affected.

- [x] `make test` run locally
- [x] `make fmt` applied (also `make fmte`)
- [x] relevant integration tests applied
