### PR TITLE
refactor: add Union to content (2nd) parameter in upload function

### DIFF
--- a/databricks/sdk/mixins/workspace.py
+++ b/databricks/sdk/mixins/workspace.py
@@ -1,4 +1,4 @@
-from typing import BinaryIO, Iterator, Optional
+from typing import BinaryIO, Iterator, Optional, Union
 
 from ..core import DatabricksError
 from ..service.workspace import (ExportFormat, ImportFormat, Language,
@@ -37,7 +37,7 @@ class WorkspaceExt(WorkspaceAPI):
 
     def upload(self,
                path: str,
-               content: BinaryIO,
+               content: Union[bytes, BinaryIO],
                *,
                format: Optional[ImportFormat] = None,
                language: Optional[Language] = None,


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
Added `Union[bytes, BinaryIO]` to upload parameter to help fix this issue #482
## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] `make fmt` applied
- [x] relevant integration tests applied

