### PR TITLE
Don't throw `TimeoutError` but rather the last error of retries

### DIFF
--- a/databricks/sdk/retries.py
+++ b/databricks/sdk/retries.py
@@ -52,7 +52,14 @@ def retried(*,
                     logger.debug(f'Retrying: {retry_reason} (sleeping ~{sleep}s)')
                     time.sleep(sleep + random())
                     attempt += 1
-            raise TimeoutError(f'Timed out after {timeout}') from last_err
+
+            # If we `raise TimeoutError(..) from last_err`, pytest displays the timeout error in the summary
+            # `FAILED ...::test_running_real_assessment_job - TimeoutError: Timed out after 0:06:00`, which
+            # makes troubleshooting harder during the stress time.
+            #
+            # This change will put TimeoutError in the __cause__ attribute of re-raised last error.
+            # See more at https://docs.python.org/3/library/exceptions.html#exception-context
+            raise last_err from TimeoutError(f'Timed out after {timeout}')
 
         return wrapper
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -19,6 +19,7 @@ from databricks.sdk.core import (ApiClient, CliTokenSource, Config,
                                  CredentialsProvider, DatabricksCliTokenSource,
                                  DatabricksError, HeaderFactory,
                                  StreamingResponse, databricks_cli)
+from databricks.sdk.errors import TooManyRequests
 from databricks.sdk.service.catalog import PermissionsChange
 from databricks.sdk.service.iam import AccessControlRequest
 from databricks.sdk.version import __version__
@@ -459,7 +460,7 @@ def test_http_retried_exceed_limit():
 
     with http_fixture_server(inner) as host:
         api_client = ApiClient(Config(host=host, token='_', retry_timeout_seconds=1))
-        with pytest.raises(TimeoutError):
+        with pytest.raises(TooManyRequests):
             api_client.do('GET', '/foo')
 
     assert len(requests) == 1

--- a/tests/test_retries.py
+++ b/tests/test_retries.py
@@ -23,7 +23,7 @@ def test_match_retry_condition_on_conflict():
 
 
 def test_match_retry_always():
-    with pytest.raises(TimeoutError):
+    with pytest.raises(StopIteration):
 
         @retried(is_retryable=lambda _: 'always', timeout=timedelta(seconds=1))
         def foo():
@@ -33,7 +33,7 @@ def test_match_retry_always():
 
 
 def test_match_on_errors():
-    with pytest.raises(TimeoutError):
+    with pytest.raises(KeyError):
 
         @retried(on=[KeyError, AttributeError], timeout=timedelta(seconds=0.5))
         def foo():
@@ -43,13 +43,16 @@ def test_match_on_errors():
 
 
 def test_match_on_subclass():
-    with pytest.raises(TimeoutError):
+    calls = []
+    with pytest.raises(NotFound):
 
-        @retried(on=[NotFound], timeout=timedelta(seconds=0.5))
+        @retried(on=[NotFound], timeout=timedelta(seconds=3))
         def foo():
+            calls.append(1)
             raise ResourceDoesNotExist(...)
 
         foo()
+    assert len(calls) > 1
 
 
 def test_propagates_outside_exception():


### PR DESCRIPTION
## Changes
If we `raise TimeoutError(..) from last_err`, pytest displays the timeout error in the summary `FAILED ...::test_running_real_assessment_job - TimeoutError: Timed out after 0:06:00`, which makes troubleshooting harder during the stress time.

This change will put TimeoutError in the __cause__ attribute of re-raised last error. See more at https://docs.python.org/3/library/exceptions.html#exception-context

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

