### PR TITLE
Show undocumented fields in dataclasses

### DIFF
--- a/docs/dbdataclasses/billing.rst
+++ b/docs/dbdataclasses/billing.rst
@@ -6,31 +6,46 @@ These dataclasses are used in the SDK to represent API requests and responses fo
 .. py:currentmodule:: databricks.sdk.service.billing
 .. autoclass:: Budget
    :members:
+   :undoc-members:
 .. autoclass:: BudgetAlert
    :members:
+   :undoc-members:
 .. autoclass:: BudgetList
    :members:
+   :undoc-members:
 .. autoclass:: BudgetWithStatus
    :members:
+   :undoc-members:
 .. autoclass:: BudgetWithStatusStatusDailyItem
    :members:
+   :undoc-members:
 .. autoclass:: CreateLogDeliveryConfigurationParams
    :members:
+   :undoc-members:
 .. autoclass:: DownloadResponse
    :members:
+   :undoc-members:
 .. autoclass:: LogDeliveryConfiguration
    :members:
+   :undoc-members:
 .. autoclass:: LogDeliveryStatus
    :members:
+   :undoc-members:
 .. autoclass:: UpdateLogDeliveryConfigurationStatusRequest
    :members:
+   :undoc-members:
 .. autoclass:: WrappedBudget
    :members:
+   :undoc-members:
 .. autoclass:: WrappedBudgetWithStatus
    :members:
+   :undoc-members:
 .. autoclass:: WrappedCreateLogDeliveryConfiguration
    :members:
+   :undoc-members:
 .. autoclass:: WrappedLogDeliveryConfiguration
    :members:
+   :undoc-members:
 .. autoclass:: WrappedLogDeliveryConfigurations
    :members:
+   :undoc-members:

--- a/docs/dbdataclasses/catalog.rst
+++ b/docs/dbdataclasses/catalog.rst
@@ -6,209 +6,313 @@ These dataclasses are used in the SDK to represent API requests and responses fo
 .. py:currentmodule:: databricks.sdk.service.catalog
 .. autoclass:: AccountsCreateMetastore
    :members:
+   :undoc-members:
 .. autoclass:: AccountsCreateMetastoreAssignment
    :members:
+   :undoc-members:
 .. autoclass:: AccountsCreateStorageCredential
    :members:
+   :undoc-members:
 .. autoclass:: AccountsMetastoreAssignment
    :members:
+   :undoc-members:
 .. autoclass:: AccountsMetastoreInfo
    :members:
+   :undoc-members:
 .. autoclass:: AccountsStorageCredentialInfo
    :members:
+   :undoc-members:
 .. autoclass:: AccountsUpdateMetastore
    :members:
+   :undoc-members:
 .. autoclass:: AccountsUpdateMetastoreAssignment
    :members:
+   :undoc-members:
 .. autoclass:: AccountsUpdateStorageCredential
    :members:
+   :undoc-members:
 .. autoclass:: ArtifactAllowlistInfo
    :members:
+   :undoc-members:
 .. autoclass:: ArtifactMatcher
    :members:
+   :undoc-members:
 .. autoclass:: AwsIamRole
    :members:
+   :undoc-members:
 .. autoclass:: AzureManagedIdentity
    :members:
+   :undoc-members:
 .. autoclass:: AzureServicePrincipal
    :members:
+   :undoc-members:
 .. autoclass:: CatalogInfo
    :members:
+   :undoc-members:
 .. autoclass:: CloudflareApiToken
    :members:
+   :undoc-members:
 .. autoclass:: ColumnInfo
    :members:
+   :undoc-members:
 .. autoclass:: ColumnMask
    :members:
+   :undoc-members:
 .. autoclass:: ConnectionInfo
    :members:
+   :undoc-members:
 .. autoclass:: CreateCatalog
    :members:
+   :undoc-members:
 .. autoclass:: CreateConnection
    :members:
+   :undoc-members:
 .. autoclass:: CreateExternalLocation
    :members:
+   :undoc-members:
 .. autoclass:: CreateFunction
    :members:
+   :undoc-members:
 .. autoclass:: CreateFunctionRequest
    :members:
+   :undoc-members:
 .. autoclass:: CreateMetastore
    :members:
+   :undoc-members:
 .. autoclass:: CreateMetastoreAssignment
    :members:
+   :undoc-members:
 .. autoclass:: CreateRegisteredModelRequest
    :members:
+   :undoc-members:
 .. autoclass:: CreateSchema
    :members:
+   :undoc-members:
 .. autoclass:: CreateStorageCredential
    :members:
+   :undoc-members:
 .. autoclass:: CreateTableConstraint
    :members:
+   :undoc-members:
 .. autoclass:: CreateVolumeRequestContent
    :members:
+   :undoc-members:
 .. autoclass:: CurrentWorkspaceBindings
    :members:
+   :undoc-members:
 .. autoclass:: DatabricksGcpServiceAccountResponse
    :members:
+   :undoc-members:
 .. autoclass:: DeltaRuntimePropertiesKvPairs
    :members:
+   :undoc-members:
 .. autoclass:: Dependency
    :members:
+   :undoc-members:
 .. autoclass:: DependencyList
    :members:
+   :undoc-members:
 .. autoclass:: EffectivePermissionsList
    :members:
+   :undoc-members:
 .. autoclass:: EffectivePredictiveOptimizationFlag
    :members:
+   :undoc-members:
 .. autoclass:: EffectivePrivilege
    :members:
+   :undoc-members:
 .. autoclass:: EffectivePrivilegeAssignment
    :members:
+   :undoc-members:
 .. autoclass:: EncryptionDetails
    :members:
+   :undoc-members:
 .. autoclass:: ExternalLocationInfo
    :members:
+   :undoc-members:
 .. autoclass:: ForeignKeyConstraint
    :members:
+   :undoc-members:
 .. autoclass:: FunctionDependency
    :members:
+   :undoc-members:
 .. autoclass:: FunctionInfo
    :members:
+   :undoc-members:
 .. autoclass:: FunctionParameterInfo
    :members:
+   :undoc-members:
 .. autoclass:: FunctionParameterInfos
    :members:
+   :undoc-members:
 .. autoclass:: GetMetastoreSummaryResponse
    :members:
+   :undoc-members:
 .. autoclass:: ListAccountMetastoreAssignmentsResponse
    :members:
+   :undoc-members:
 .. autoclass:: ListCatalogsResponse
    :members:
+   :undoc-members:
 .. autoclass:: ListConnectionsResponse
    :members:
+   :undoc-members:
 .. autoclass:: ListExternalLocationsResponse
    :members:
+   :undoc-members:
 .. autoclass:: ListFunctionsResponse
    :members:
+   :undoc-members:
 .. autoclass:: ListMetastoresResponse
    :members:
+   :undoc-members:
 .. autoclass:: ListModelVersionsResponse
    :members:
+   :undoc-members:
 .. autoclass:: ListRegisteredModelsResponse
    :members:
+   :undoc-members:
 .. autoclass:: ListSchemasResponse
    :members:
+   :undoc-members:
 .. autoclass:: ListStorageCredentialsResponse
    :members:
+   :undoc-members:
 .. autoclass:: ListSystemSchemasResponse
    :members:
+   :undoc-members:
 .. autoclass:: ListTableSummariesResponse
    :members:
+   :undoc-members:
 .. autoclass:: ListTablesResponse
    :members:
+   :undoc-members:
 .. autoclass:: ListVolumesResponseContent
    :members:
+   :undoc-members:
 .. autoclass:: MetastoreAssignment
    :members:
+   :undoc-members:
 .. autoclass:: MetastoreInfo
    :members:
+   :undoc-members:
 .. autoclass:: ModelVersionInfo
    :members:
+   :undoc-members:
 .. autoclass:: NamedTableConstraint
    :members:
+   :undoc-members:
 .. autoclass:: PermissionsChange
    :members:
+   :undoc-members:
 .. autoclass:: PermissionsList
    :members:
+   :undoc-members:
 .. autoclass:: PrimaryKeyConstraint
    :members:
+   :undoc-members:
 .. autoclass:: PrivilegeAssignment
    :members:
+   :undoc-members:
 .. autoclass:: ProvisioningInfo
    :members:
+   :undoc-members:
 .. autoclass:: RegisteredModelAlias
    :members:
+   :undoc-members:
 .. autoclass:: RegisteredModelInfo
    :members:
+   :undoc-members:
 .. autoclass:: SchemaInfo
    :members:
+   :undoc-members:
 .. autoclass:: SetArtifactAllowlist
    :members:
+   :undoc-members:
 .. autoclass:: SetRegisteredModelAliasRequest
    :members:
+   :undoc-members:
 .. autoclass:: SseEncryptionDetails
    :members:
+   :undoc-members:
 .. autoclass:: StorageCredentialInfo
    :members:
+   :undoc-members:
 .. autoclass:: SystemSchemaInfo
    :members:
+   :undoc-members:
 .. autoclass:: TableConstraint
    :members:
+   :undoc-members:
 .. autoclass:: TableDependency
    :members:
+   :undoc-members:
 .. autoclass:: TableInfo
    :members:
+   :undoc-members:
 .. autoclass:: TableRowFilter
    :members:
+   :undoc-members:
 .. autoclass:: TableSummary
    :members:
+   :undoc-members:
 .. autoclass:: UpdateCatalog
    :members:
+   :undoc-members:
 .. autoclass:: UpdateConnection
    :members:
+   :undoc-members:
 .. autoclass:: UpdateExternalLocation
    :members:
+   :undoc-members:
 .. autoclass:: UpdateFunction
    :members:
+   :undoc-members:
 .. autoclass:: UpdateMetastore
    :members:
+   :undoc-members:
 .. autoclass:: UpdateMetastoreAssignment
    :members:
+   :undoc-members:
 .. autoclass:: UpdateModelVersionRequest
    :members:
+   :undoc-members:
 .. autoclass:: UpdatePermissions
    :members:
+   :undoc-members:
 .. autoclass:: UpdateRegisteredModelRequest
    :members:
+   :undoc-members:
 .. autoclass:: UpdateSchema
    :members:
+   :undoc-members:
 .. autoclass:: UpdateStorageCredential
    :members:
+   :undoc-members:
 .. autoclass:: UpdateVolumeRequestContent
    :members:
+   :undoc-members:
 .. autoclass:: UpdateWorkspaceBindings
    :members:
+   :undoc-members:
 .. autoclass:: UpdateWorkspaceBindingsParameters
    :members:
+   :undoc-members:
 .. autoclass:: ValidateStorageCredential
    :members:
+   :undoc-members:
 .. autoclass:: ValidateStorageCredentialResponse
    :members:
+   :undoc-members:
 .. autoclass:: ValidationResult
    :members:
+   :undoc-members:
 .. autoclass:: VolumeInfo
    :members:
+   :undoc-members:
 .. autoclass:: WorkspaceBinding
    :members:
+   :undoc-members:
 .. autoclass:: WorkspaceBindingsResponse
    :members:
+   :undoc-members:

--- a/docs/dbdataclasses/compute.rst
+++ b/docs/dbdataclasses/compute.rst
@@ -6,247 +6,370 @@ These dataclasses are used in the SDK to represent API requests and responses fo
 .. py:currentmodule:: databricks.sdk.service.compute
 .. autoclass:: AddInstanceProfile
    :members:
+   :undoc-members:
 .. autoclass:: AutoScale
    :members:
+   :undoc-members:
 .. autoclass:: AwsAttributes
    :members:
+   :undoc-members:
 .. autoclass:: AzureAttributes
    :members:
+   :undoc-members:
 .. autoclass:: CancelCommand
    :members:
+   :undoc-members:
 .. autoclass:: ChangeClusterOwner
    :members:
+   :undoc-members:
 .. autoclass:: ClientsTypes
    :members:
+   :undoc-members:
 .. autoclass:: CloudProviderNodeInfo
    :members:
+   :undoc-members:
 .. autoclass:: ClusterAccessControlRequest
    :members:
+   :undoc-members:
 .. autoclass:: ClusterAccessControlResponse
    :members:
+   :undoc-members:
 .. autoclass:: ClusterAttributes
    :members:
+   :undoc-members:
 .. autoclass:: ClusterDetails
    :members:
+   :undoc-members:
 .. autoclass:: ClusterEvent
    :members:
+   :undoc-members:
 .. autoclass:: ClusterLibraryStatuses
    :members:
+   :undoc-members:
 .. autoclass:: ClusterLogConf
    :members:
+   :undoc-members:
 .. autoclass:: ClusterPermission
    :members:
+   :undoc-members:
 .. autoclass:: ClusterPermissions
    :members:
+   :undoc-members:
 .. autoclass:: ClusterPermissionsDescription
    :members:
+   :undoc-members:
 .. autoclass:: ClusterPermissionsRequest
    :members:
+   :undoc-members:
 .. autoclass:: ClusterPolicyAccessControlRequest
    :members:
+   :undoc-members:
 .. autoclass:: ClusterPolicyAccessControlResponse
    :members:
+   :undoc-members:
 .. autoclass:: ClusterPolicyPermission
    :members:
+   :undoc-members:
 .. autoclass:: ClusterPolicyPermissions
    :members:
+   :undoc-members:
 .. autoclass:: ClusterPolicyPermissionsDescription
    :members:
+   :undoc-members:
 .. autoclass:: ClusterPolicyPermissionsRequest
    :members:
+   :undoc-members:
 .. autoclass:: ClusterSize
    :members:
+   :undoc-members:
 .. autoclass:: ClusterSpec
    :members:
+   :undoc-members:
 .. autoclass:: Command
    :members:
+   :undoc-members:
 .. autoclass:: CommandStatusResponse
    :members:
+   :undoc-members:
 .. autoclass:: ComputeSpec
    :members:
+   :undoc-members:
 .. autoclass:: ContextStatusResponse
    :members:
+   :undoc-members:
 .. autoclass:: CreateCluster
    :members:
+   :undoc-members:
 .. autoclass:: CreateClusterResponse
    :members:
+   :undoc-members:
 .. autoclass:: CreateContext
    :members:
+   :undoc-members:
 .. autoclass:: CreateInstancePool
    :members:
+   :undoc-members:
 .. autoclass:: CreateInstancePoolResponse
    :members:
+   :undoc-members:
 .. autoclass:: CreatePolicy
    :members:
+   :undoc-members:
 .. autoclass:: CreatePolicyResponse
    :members:
+   :undoc-members:
 .. autoclass:: CreateResponse
    :members:
+   :undoc-members:
 .. autoclass:: Created
    :members:
+   :undoc-members:
 .. autoclass:: DataPlaneEventDetails
    :members:
+   :undoc-members:
 .. autoclass:: DbfsStorageInfo
    :members:
+   :undoc-members:
 .. autoclass:: DeleteCluster
    :members:
+   :undoc-members:
 .. autoclass:: DeleteInstancePool
    :members:
+   :undoc-members:
 .. autoclass:: DeletePolicy
    :members:
+   :undoc-members:
 .. autoclass:: DestroyContext
    :members:
+   :undoc-members:
 .. autoclass:: DiskSpec
    :members:
+   :undoc-members:
 .. autoclass:: DiskType
    :members:
+   :undoc-members:
 .. autoclass:: DockerBasicAuth
    :members:
+   :undoc-members:
 .. autoclass:: DockerImage
    :members:
+   :undoc-members:
 .. autoclass:: EditCluster
    :members:
+   :undoc-members:
 .. autoclass:: EditInstancePool
    :members:
+   :undoc-members:
 .. autoclass:: EditPolicy
    :members:
+   :undoc-members:
 .. autoclass:: EventDetails
    :members:
+   :undoc-members:
 .. autoclass:: GcpAttributes
    :members:
+   :undoc-members:
 .. autoclass:: GetClusterPermissionLevelsResponse
    :members:
+   :undoc-members:
 .. autoclass:: GetClusterPolicyPermissionLevelsResponse
    :members:
+   :undoc-members:
 .. autoclass:: GetEvents
    :members:
+   :undoc-members:
 .. autoclass:: GetEventsResponse
    :members:
+   :undoc-members:
 .. autoclass:: GetInstancePool
    :members:
+   :undoc-members:
 .. autoclass:: GetInstancePoolPermissionLevelsResponse
    :members:
+   :undoc-members:
 .. autoclass:: GetSparkVersionsResponse
    :members:
+   :undoc-members:
 .. autoclass:: GlobalInitScriptCreateRequest
    :members:
+   :undoc-members:
 .. autoclass:: GlobalInitScriptDetails
    :members:
+   :undoc-members:
 .. autoclass:: GlobalInitScriptDetailsWithContent
    :members:
+   :undoc-members:
 .. autoclass:: GlobalInitScriptUpdateRequest
    :members:
+   :undoc-members:
 .. autoclass:: InitScriptEventDetails
    :members:
+   :undoc-members:
 .. autoclass:: InitScriptExecutionDetails
    :members:
+   :undoc-members:
 .. autoclass:: InitScriptInfo
    :members:
+   :undoc-members:
 .. autoclass:: InitScriptInfoAndExecutionDetails
    :members:
+   :undoc-members:
 .. autoclass:: InstallLibraries
    :members:
+   :undoc-members:
 .. autoclass:: InstancePoolAccessControlRequest
    :members:
+   :undoc-members:
 .. autoclass:: InstancePoolAccessControlResponse
    :members:
+   :undoc-members:
 .. autoclass:: InstancePoolAndStats
    :members:
+   :undoc-members:
 .. autoclass:: InstancePoolAwsAttributes
    :members:
+   :undoc-members:
 .. autoclass:: InstancePoolAzureAttributes
    :members:
+   :undoc-members:
 .. autoclass:: InstancePoolGcpAttributes
    :members:
+   :undoc-members:
 .. autoclass:: InstancePoolPermission
    :members:
+   :undoc-members:
 .. autoclass:: InstancePoolPermissions
    :members:
+   :undoc-members:
 .. autoclass:: InstancePoolPermissionsDescription
    :members:
+   :undoc-members:
 .. autoclass:: InstancePoolPermissionsRequest
    :members:
+   :undoc-members:
 .. autoclass:: InstancePoolStats
    :members:
+   :undoc-members:
 .. autoclass:: InstancePoolStatus
    :members:
+   :undoc-members:
 .. autoclass:: InstanceProfile
    :members:
+   :undoc-members:
 .. autoclass:: Library
    :members:
+   :undoc-members:
 .. autoclass:: LibraryFullStatus
    :members:
+   :undoc-members:
 .. autoclass:: ListAllClusterLibraryStatusesResponse
    :members:
+   :undoc-members:
 .. autoclass:: ListAvailableZonesResponse
    :members:
+   :undoc-members:
 .. autoclass:: ListClustersResponse
    :members:
+   :undoc-members:
 .. autoclass:: ListGlobalInitScriptsResponse
    :members:
+   :undoc-members:
 .. autoclass:: ListInstancePools
    :members:
+   :undoc-members:
 .. autoclass:: ListInstanceProfilesResponse
    :members:
+   :undoc-members:
 .. autoclass:: ListNodeTypesResponse
    :members:
+   :undoc-members:
 .. autoclass:: ListPoliciesResponse
    :members:
+   :undoc-members:
 .. autoclass:: ListPolicyFamiliesResponse
    :members:
+   :undoc-members:
 .. autoclass:: LocalFileInfo
    :members:
+   :undoc-members:
 .. autoclass:: LogAnalyticsInfo
    :members:
+   :undoc-members:
 .. autoclass:: LogSyncStatus
    :members:
+   :undoc-members:
 .. autoclass:: MavenLibrary
    :members:
+   :undoc-members:
 .. autoclass:: NodeInstanceType
    :members:
+   :undoc-members:
 .. autoclass:: NodeType
    :members:
+   :undoc-members:
 .. autoclass:: PendingInstanceError
    :members:
+   :undoc-members:
 .. autoclass:: PermanentDeleteCluster
    :members:
+   :undoc-members:
 .. autoclass:: PinCluster
    :members:
+   :undoc-members:
 .. autoclass:: Policy
    :members:
+   :undoc-members:
 .. autoclass:: PolicyFamily
    :members:
+   :undoc-members:
 .. autoclass:: PythonPyPiLibrary
    :members:
+   :undoc-members:
 .. autoclass:: RCranLibrary
    :members:
+   :undoc-members:
 .. autoclass:: RemoveInstanceProfile
    :members:
+   :undoc-members:
 .. autoclass:: ResizeCluster
    :members:
+   :undoc-members:
 .. autoclass:: RestartCluster
    :members:
+   :undoc-members:
 .. autoclass:: Results
    :members:
+   :undoc-members:
 .. autoclass:: S3StorageInfo
    :members:
+   :undoc-members:
 .. autoclass:: SparkNode
    :members:
+   :undoc-members:
 .. autoclass:: SparkNodeAwsAttributes
    :members:
+   :undoc-members:
 .. autoclass:: SparkVersion
    :members:
+   :undoc-members:
 .. autoclass:: StartCluster
    :members:
+   :undoc-members:
 .. autoclass:: TerminationReason
    :members:
+   :undoc-members:
 .. autoclass:: UninstallLibraries
    :members:
+   :undoc-members:
 .. autoclass:: UnpinCluster
    :members:
+   :undoc-members:
 .. autoclass:: VolumesStorageInfo
    :members:
+   :undoc-members:
 .. autoclass:: WorkloadType
    :members:
+   :undoc-members:
 .. autoclass:: WorkspaceStorageInfo
    :members:
+   :undoc-members:

--- a/docs/dbdataclasses/dashboards.rst
+++ b/docs/dbdataclasses/dashboards.rst
@@ -6,3 +6,4 @@ These dataclasses are used in the SDK to represent API requests and responses fo
 .. py:currentmodule:: databricks.sdk.service.dashboards
 .. autoclass:: PublishRequest
    :members:
+   :undoc-members:

--- a/docs/dbdataclasses/files.rst
+++ b/docs/dbdataclasses/files.rst
@@ -6,25 +6,37 @@ These dataclasses are used in the SDK to represent API requests and responses fo
 .. py:currentmodule:: databricks.sdk.service.files
 .. autoclass:: AddBlock
    :members:
+   :undoc-members:
 .. autoclass:: Close
    :members:
+   :undoc-members:
 .. autoclass:: Create
    :members:
+   :undoc-members:
 .. autoclass:: CreateResponse
    :members:
+   :undoc-members:
 .. autoclass:: Delete
    :members:
+   :undoc-members:
 .. autoclass:: DownloadResponse
    :members:
+   :undoc-members:
 .. autoclass:: FileInfo
    :members:
+   :undoc-members:
 .. autoclass:: ListStatusResponse
    :members:
+   :undoc-members:
 .. autoclass:: MkDirs
    :members:
+   :undoc-members:
 .. autoclass:: Move
    :members:
+   :undoc-members:
 .. autoclass:: Put
    :members:
+   :undoc-members:
 .. autoclass:: ReadResponse
    :members:
+   :undoc-members:

--- a/docs/dbdataclasses/iam.rst
+++ b/docs/dbdataclasses/iam.rst
@@ -6,75 +6,112 @@ These dataclasses are used in the SDK to represent API requests and responses fo
 .. py:currentmodule:: databricks.sdk.service.iam
 .. autoclass:: AccessControlRequest
    :members:
+   :undoc-members:
 .. autoclass:: AccessControlResponse
    :members:
+   :undoc-members:
 .. autoclass:: ComplexValue
    :members:
+   :undoc-members:
 .. autoclass:: GetAssignableRolesForResourceResponse
    :members:
+   :undoc-members:
 .. autoclass:: GetPasswordPermissionLevelsResponse
    :members:
+   :undoc-members:
 .. autoclass:: GetPermissionLevelsResponse
    :members:
+   :undoc-members:
 .. autoclass:: GrantRule
    :members:
+   :undoc-members:
 .. autoclass:: Group
    :members:
+   :undoc-members:
 .. autoclass:: ListGroupsResponse
    :members:
+   :undoc-members:
 .. autoclass:: ListServicePrincipalResponse
    :members:
+   :undoc-members:
 .. autoclass:: ListUsersResponse
    :members:
+   :undoc-members:
 .. autoclass:: Name
    :members:
+   :undoc-members:
 .. autoclass:: ObjectPermissions
    :members:
+   :undoc-members:
 .. autoclass:: PartialUpdate
    :members:
+   :undoc-members:
 .. autoclass:: PasswordAccessControlRequest
    :members:
+   :undoc-members:
 .. autoclass:: PasswordAccessControlResponse
    :members:
+   :undoc-members:
 .. autoclass:: PasswordPermission
    :members:
+   :undoc-members:
 .. autoclass:: PasswordPermissions
    :members:
+   :undoc-members:
 .. autoclass:: PasswordPermissionsDescription
    :members:
+   :undoc-members:
 .. autoclass:: PasswordPermissionsRequest
    :members:
+   :undoc-members:
 .. autoclass:: Patch
    :members:
+   :undoc-members:
 .. autoclass:: Permission
    :members:
+   :undoc-members:
 .. autoclass:: PermissionAssignment
    :members:
+   :undoc-members:
 .. autoclass:: PermissionAssignments
    :members:
+   :undoc-members:
 .. autoclass:: PermissionOutput
    :members:
+   :undoc-members:
 .. autoclass:: PermissionsDescription
    :members:
+   :undoc-members:
 .. autoclass:: PermissionsRequest
    :members:
+   :undoc-members:
 .. autoclass:: PrincipalOutput
    :members:
+   :undoc-members:
 .. autoclass:: ResourceMeta
    :members:
+   :undoc-members:
 .. autoclass:: Role
    :members:
+   :undoc-members:
 .. autoclass:: RuleSetResponse
    :members:
+   :undoc-members:
 .. autoclass:: RuleSetUpdateRequest
    :members:
+   :undoc-members:
 .. autoclass:: ServicePrincipal
    :members:
+   :undoc-members:
 .. autoclass:: UpdateRuleSetRequest
    :members:
+   :undoc-members:
 .. autoclass:: UpdateWorkspaceAssignments
    :members:
+   :undoc-members:
 .. autoclass:: User
    :members:
+   :undoc-members:
 .. autoclass:: WorkspacePermissions
    :members:
+   :undoc-members:

--- a/docs/dbdataclasses/jobs.rst
+++ b/docs/dbdataclasses/jobs.rst
@@ -6,203 +6,304 @@ These dataclasses are used in the SDK to represent API requests and responses fo
 .. py:currentmodule:: databricks.sdk.service.jobs
 .. autoclass:: BaseJob
    :members:
+   :undoc-members:
 .. autoclass:: BaseRun
    :members:
+   :undoc-members:
 .. autoclass:: CancelAllRuns
    :members:
+   :undoc-members:
 .. autoclass:: CancelRun
    :members:
+   :undoc-members:
 .. autoclass:: ClusterInstance
    :members:
+   :undoc-members:
 .. autoclass:: ClusterSpec
    :members:
+   :undoc-members:
 .. autoclass:: ConditionTask
    :members:
+   :undoc-members:
 .. autoclass:: Continuous
    :members:
+   :undoc-members:
 .. autoclass:: CreateJob
    :members:
+   :undoc-members:
 .. autoclass:: CreateResponse
    :members:
+   :undoc-members:
 .. autoclass:: CronSchedule
    :members:
+   :undoc-members:
 .. autoclass:: DbtOutput
    :members:
+   :undoc-members:
 .. autoclass:: DbtTask
    :members:
+   :undoc-members:
 .. autoclass:: DeleteJob
    :members:
+   :undoc-members:
 .. autoclass:: DeleteRun
    :members:
+   :undoc-members:
 .. autoclass:: ExportRunOutput
    :members:
+   :undoc-members:
 .. autoclass:: FileArrivalTriggerConfiguration
    :members:
+   :undoc-members:
 .. autoclass:: GetJobPermissionLevelsResponse
    :members:
+   :undoc-members:
 .. autoclass:: GitSnapshot
    :members:
+   :undoc-members:
 .. autoclass:: GitSource
    :members:
+   :undoc-members:
 .. autoclass:: Job
    :members:
+   :undoc-members:
 .. autoclass:: JobAccessControlRequest
    :members:
+   :undoc-members:
 .. autoclass:: JobAccessControlResponse
    :members:
+   :undoc-members:
 .. autoclass:: JobCluster
    :members:
+   :undoc-members:
 .. autoclass:: JobCompute
    :members:
+   :undoc-members:
 .. autoclass:: JobDeployment
    :members:
+   :undoc-members:
 .. autoclass:: JobEmailNotifications
    :members:
+   :undoc-members:
 .. autoclass:: JobNotificationSettings
    :members:
+   :undoc-members:
 .. autoclass:: JobParameter
    :members:
+   :undoc-members:
 .. autoclass:: JobParameterDefinition
    :members:
+   :undoc-members:
 .. autoclass:: JobPermission
    :members:
+   :undoc-members:
 .. autoclass:: JobPermissions
    :members:
+   :undoc-members:
 .. autoclass:: JobPermissionsDescription
    :members:
+   :undoc-members:
 .. autoclass:: JobPermissionsRequest
    :members:
+   :undoc-members:
 .. autoclass:: JobRunAs
    :members:
+   :undoc-members:
 .. autoclass:: JobSettings
    :members:
+   :undoc-members:
 .. autoclass:: JobSource
    :members:
+   :undoc-members:
 .. autoclass:: JobsHealthRule
    :members:
+   :undoc-members:
 .. autoclass:: JobsHealthRules
    :members:
+   :undoc-members:
 .. autoclass:: ListJobsResponse
    :members:
+   :undoc-members:
 .. autoclass:: ListRunsResponse
    :members:
+   :undoc-members:
 .. autoclass:: NotebookOutput
    :members:
+   :undoc-members:
 .. autoclass:: NotebookTask
    :members:
+   :undoc-members:
 .. autoclass:: PipelineParams
    :members:
+   :undoc-members:
 .. autoclass:: PipelineTask
    :members:
+   :undoc-members:
 .. autoclass:: PythonWheelTask
    :members:
+   :undoc-members:
 .. autoclass:: QueueSettings
    :members:
+   :undoc-members:
 .. autoclass:: RepairHistoryItem
    :members:
+   :undoc-members:
 .. autoclass:: RepairRun
    :members:
+   :undoc-members:
 .. autoclass:: RepairRunResponse
    :members:
+   :undoc-members:
 .. autoclass:: ResetJob
    :members:
+   :undoc-members:
 .. autoclass:: ResolvedConditionTaskValues
    :members:
+   :undoc-members:
 .. autoclass:: ResolvedDbtTaskValues
    :members:
+   :undoc-members:
 .. autoclass:: ResolvedNotebookTaskValues
    :members:
+   :undoc-members:
 .. autoclass:: ResolvedParamPairValues
    :members:
+   :undoc-members:
 .. autoclass:: ResolvedPythonWheelTaskValues
    :members:
+   :undoc-members:
 .. autoclass:: ResolvedRunJobTaskValues
    :members:
+   :undoc-members:
 .. autoclass:: ResolvedStringParamsValues
    :members:
+   :undoc-members:
 .. autoclass:: ResolvedValues
    :members:
+   :undoc-members:
 .. autoclass:: Run
    :members:
+   :undoc-members:
 .. autoclass:: RunConditionTask
    :members:
+   :undoc-members:
 .. autoclass:: RunJobOutput
    :members:
+   :undoc-members:
 .. autoclass:: RunJobTask
    :members:
+   :undoc-members:
 .. autoclass:: RunNow
    :members:
+   :undoc-members:
 .. autoclass:: RunNowResponse
    :members:
+   :undoc-members:
 .. autoclass:: RunOutput
    :members:
+   :undoc-members:
 .. autoclass:: RunParameters
    :members:
+   :undoc-members:
 .. autoclass:: RunState
    :members:
+   :undoc-members:
 .. autoclass:: RunTask
    :members:
+   :undoc-members:
 .. autoclass:: SparkJarTask
    :members:
+   :undoc-members:
 .. autoclass:: SparkPythonTask
    :members:
+   :undoc-members:
 .. autoclass:: SparkSubmitTask
    :members:
+   :undoc-members:
 .. autoclass:: SqlAlertOutput
    :members:
+   :undoc-members:
 .. autoclass:: SqlDashboardOutput
    :members:
+   :undoc-members:
 .. autoclass:: SqlDashboardWidgetOutput
    :members:
+   :undoc-members:
 .. autoclass:: SqlOutput
    :members:
+   :undoc-members:
 .. autoclass:: SqlOutputError
    :members:
+   :undoc-members:
 .. autoclass:: SqlQueryOutput
    :members:
+   :undoc-members:
 .. autoclass:: SqlStatementOutput
    :members:
+   :undoc-members:
 .. autoclass:: SqlTask
    :members:
+   :undoc-members:
 .. autoclass:: SqlTaskAlert
    :members:
+   :undoc-members:
 .. autoclass:: SqlTaskDashboard
    :members:
+   :undoc-members:
 .. autoclass:: SqlTaskFile
    :members:
+   :undoc-members:
 .. autoclass:: SqlTaskQuery
    :members:
+   :undoc-members:
 .. autoclass:: SqlTaskSubscription
    :members:
+   :undoc-members:
 .. autoclass:: SubmitRun
    :members:
+   :undoc-members:
 .. autoclass:: SubmitRunResponse
    :members:
+   :undoc-members:
 .. autoclass:: SubmitTask
    :members:
+   :undoc-members:
 .. autoclass:: Task
    :members:
+   :undoc-members:
 .. autoclass:: TaskDependency
    :members:
+   :undoc-members:
 .. autoclass:: TaskEmailNotifications
    :members:
+   :undoc-members:
 .. autoclass:: TaskNotificationSettings
    :members:
+   :undoc-members:
 .. autoclass:: TriggerEvaluation
    :members:
+   :undoc-members:
 .. autoclass:: TriggerHistory
    :members:
+   :undoc-members:
 .. autoclass:: TriggerInfo
    :members:
+   :undoc-members:
 .. autoclass:: TriggerSettings
    :members:
+   :undoc-members:
 .. autoclass:: UpdateJob
    :members:
+   :undoc-members:
 .. autoclass:: ViewItem
    :members:
+   :undoc-members:
 .. autoclass:: Webhook
    :members:
+   :undoc-members:
 .. autoclass:: WebhookNotifications
    :members:
+   :undoc-members:
 .. autoclass:: WebhookNotificationsOnDurationWarningThresholdExceededItem
    :members:
+   :undoc-members:

--- a/docs/dbdataclasses/ml.rst
+++ b/docs/dbdataclasses/ml.rst
@@ -6,223 +6,334 @@ These dataclasses are used in the SDK to represent API requests and responses fo
 .. py:currentmodule:: databricks.sdk.service.ml
 .. autoclass:: Activity
    :members:
+   :undoc-members:
 .. autoclass:: ApproveTransitionRequest
    :members:
+   :undoc-members:
 .. autoclass:: ApproveTransitionRequestResponse
    :members:
+   :undoc-members:
 .. autoclass:: CommentObject
    :members:
+   :undoc-members:
 .. autoclass:: CreateComment
    :members:
+   :undoc-members:
 .. autoclass:: CreateCommentResponse
    :members:
+   :undoc-members:
 .. autoclass:: CreateExperiment
    :members:
+   :undoc-members:
 .. autoclass:: CreateExperimentResponse
    :members:
+   :undoc-members:
 .. autoclass:: CreateModelRequest
    :members:
+   :undoc-members:
 .. autoclass:: CreateModelResponse
    :members:
+   :undoc-members:
 .. autoclass:: CreateModelVersionRequest
    :members:
+   :undoc-members:
 .. autoclass:: CreateModelVersionResponse
    :members:
+   :undoc-members:
 .. autoclass:: CreateRegistryWebhook
    :members:
+   :undoc-members:
 .. autoclass:: CreateRun
    :members:
+   :undoc-members:
 .. autoclass:: CreateRunResponse
    :members:
+   :undoc-members:
 .. autoclass:: CreateTransitionRequest
    :members:
+   :undoc-members:
 .. autoclass:: CreateTransitionRequestResponse
    :members:
+   :undoc-members:
 .. autoclass:: CreateWebhookResponse
    :members:
+   :undoc-members:
 .. autoclass:: Dataset
    :members:
+   :undoc-members:
 .. autoclass:: DatasetInput
    :members:
+   :undoc-members:
 .. autoclass:: DeleteExperiment
    :members:
+   :undoc-members:
 .. autoclass:: DeleteRun
    :members:
+   :undoc-members:
 .. autoclass:: DeleteRuns
    :members:
+   :undoc-members:
 .. autoclass:: DeleteRunsResponse
    :members:
+   :undoc-members:
 .. autoclass:: DeleteTag
    :members:
+   :undoc-members:
 .. autoclass:: Experiment
    :members:
+   :undoc-members:
 .. autoclass:: ExperimentAccessControlRequest
    :members:
+   :undoc-members:
 .. autoclass:: ExperimentAccessControlResponse
    :members:
+   :undoc-members:
 .. autoclass:: ExperimentPermission
    :members:
+   :undoc-members:
 .. autoclass:: ExperimentPermissions
    :members:
+   :undoc-members:
 .. autoclass:: ExperimentPermissionsDescription
    :members:
+   :undoc-members:
 .. autoclass:: ExperimentPermissionsRequest
    :members:
+   :undoc-members:
 .. autoclass:: ExperimentTag
    :members:
+   :undoc-members:
 .. autoclass:: FileInfo
    :members:
+   :undoc-members:
 .. autoclass:: GetExperimentPermissionLevelsResponse
    :members:
+   :undoc-members:
 .. autoclass:: GetExperimentResponse
    :members:
+   :undoc-members:
 .. autoclass:: GetLatestVersionsRequest
    :members:
+   :undoc-members:
 .. autoclass:: GetLatestVersionsResponse
    :members:
+   :undoc-members:
 .. autoclass:: GetMetricHistoryResponse
    :members:
+   :undoc-members:
 .. autoclass:: GetModelResponse
    :members:
+   :undoc-members:
 .. autoclass:: GetModelVersionDownloadUriResponse
    :members:
+   :undoc-members:
 .. autoclass:: GetModelVersionResponse
    :members:
+   :undoc-members:
 .. autoclass:: GetRegisteredModelPermissionLevelsResponse
    :members:
+   :undoc-members:
 .. autoclass:: GetRunResponse
    :members:
+   :undoc-members:
 .. autoclass:: HttpUrlSpec
    :members:
+   :undoc-members:
 .. autoclass:: HttpUrlSpecWithoutSecret
    :members:
+   :undoc-members:
 .. autoclass:: InputTag
    :members:
+   :undoc-members:
 .. autoclass:: JobSpec
    :members:
+   :undoc-members:
 .. autoclass:: JobSpecWithoutSecret
    :members:
+   :undoc-members:
 .. autoclass:: ListArtifactsResponse
    :members:
+   :undoc-members:
 .. autoclass:: ListExperimentsResponse
    :members:
+   :undoc-members:
 .. autoclass:: ListModelsResponse
    :members:
+   :undoc-members:
 .. autoclass:: ListRegistryWebhooks
    :members:
+   :undoc-members:
 .. autoclass:: ListTransitionRequestsResponse
    :members:
+   :undoc-members:
 .. autoclass:: LogBatch
    :members:
+   :undoc-members:
 .. autoclass:: LogInputs
    :members:
+   :undoc-members:
 .. autoclass:: LogMetric
    :members:
+   :undoc-members:
 .. autoclass:: LogModel
    :members:
+   :undoc-members:
 .. autoclass:: LogParam
    :members:
+   :undoc-members:
 .. autoclass:: Metric
    :members:
+   :undoc-members:
 .. autoclass:: Model
    :members:
+   :undoc-members:
 .. autoclass:: ModelDatabricks
    :members:
+   :undoc-members:
 .. autoclass:: ModelTag
    :members:
+   :undoc-members:
 .. autoclass:: ModelVersion
    :members:
+   :undoc-members:
 .. autoclass:: ModelVersionDatabricks
    :members:
+   :undoc-members:
 .. autoclass:: ModelVersionTag
    :members:
+   :undoc-members:
 .. autoclass:: Param
    :members:
+   :undoc-members:
 .. autoclass:: RegisteredModelAccessControlRequest
    :members:
+   :undoc-members:
 .. autoclass:: RegisteredModelAccessControlResponse
    :members:
+   :undoc-members:
 .. autoclass:: RegisteredModelPermission
    :members:
+   :undoc-members:
 .. autoclass:: RegisteredModelPermissions
    :members:
+   :undoc-members:
 .. autoclass:: RegisteredModelPermissionsDescription
    :members:
+   :undoc-members:
 .. autoclass:: RegisteredModelPermissionsRequest
    :members:
+   :undoc-members:
 .. autoclass:: RegistryWebhook
    :members:
+   :undoc-members:
 .. autoclass:: RejectTransitionRequest
    :members:
+   :undoc-members:
 .. autoclass:: RejectTransitionRequestResponse
    :members:
+   :undoc-members:
 .. autoclass:: RenameModelRequest
    :members:
+   :undoc-members:
 .. autoclass:: RenameModelResponse
    :members:
+   :undoc-members:
 .. autoclass:: RestoreExperiment
    :members:
+   :undoc-members:
 .. autoclass:: RestoreRun
    :members:
+   :undoc-members:
 .. autoclass:: RestoreRuns
    :members:
+   :undoc-members:
 .. autoclass:: RestoreRunsResponse
    :members:
+   :undoc-members:
 .. autoclass:: Run
    :members:
+   :undoc-members:
 .. autoclass:: RunData
    :members:
+   :undoc-members:
 .. autoclass:: RunInfo
    :members:
+   :undoc-members:
 .. autoclass:: RunInputs
    :members:
+   :undoc-members:
 .. autoclass:: RunTag
    :members:
+   :undoc-members:
 .. autoclass:: SearchExperiments
    :members:
+   :undoc-members:
 .. autoclass:: SearchExperimentsResponse
    :members:
+   :undoc-members:
 .. autoclass:: SearchModelVersionsResponse
    :members:
+   :undoc-members:
 .. autoclass:: SearchModelsResponse
    :members:
+   :undoc-members:
 .. autoclass:: SearchRuns
    :members:
+   :undoc-members:
 .. autoclass:: SearchRunsResponse
    :members:
+   :undoc-members:
 .. autoclass:: SetExperimentTag
    :members:
+   :undoc-members:
 .. autoclass:: SetModelTagRequest
    :members:
+   :undoc-members:
 .. autoclass:: SetModelVersionTagRequest
    :members:
+   :undoc-members:
 .. autoclass:: SetTag
    :members:
+   :undoc-members:
 .. autoclass:: TestRegistryWebhook
    :members:
+   :undoc-members:
 .. autoclass:: TestRegistryWebhookRequest
    :members:
+   :undoc-members:
 .. autoclass:: TestRegistryWebhookResponse
    :members:
+   :undoc-members:
 .. autoclass:: TransitionModelVersionStageDatabricks
    :members:
+   :undoc-members:
 .. autoclass:: TransitionRequest
    :members:
+   :undoc-members:
 .. autoclass:: TransitionStageResponse
    :members:
+   :undoc-members:
 .. autoclass:: UpdateComment
    :members:
+   :undoc-members:
 .. autoclass:: UpdateCommentResponse
    :members:
+   :undoc-members:
 .. autoclass:: UpdateExperiment
    :members:
+   :undoc-members:
 .. autoclass:: UpdateModelRequest
    :members:
+   :undoc-members:
 .. autoclass:: UpdateModelVersionRequest
    :members:
+   :undoc-members:
 .. autoclass:: UpdateRegistryWebhook
    :members:
+   :undoc-members:
 .. autoclass:: UpdateRun
    :members:
+   :undoc-members:
 .. autoclass:: UpdateRunResponse
    :members:
+   :undoc-members:

--- a/docs/dbdataclasses/oauth2.rst
+++ b/docs/dbdataclasses/oauth2.rst
@@ -6,33 +6,49 @@ These dataclasses are used in the SDK to represent API requests and responses fo
 .. py:currentmodule:: databricks.sdk.service.oauth2
 .. autoclass:: CreateCustomAppIntegration
    :members:
+   :undoc-members:
 .. autoclass:: CreateCustomAppIntegrationOutput
    :members:
+   :undoc-members:
 .. autoclass:: CreatePublishedAppIntegration
    :members:
+   :undoc-members:
 .. autoclass:: CreatePublishedAppIntegrationOutput
    :members:
+   :undoc-members:
 .. autoclass:: CreateServicePrincipalSecretResponse
    :members:
+   :undoc-members:
 .. autoclass:: GetCustomAppIntegrationOutput
    :members:
+   :undoc-members:
 .. autoclass:: GetCustomAppIntegrationsOutput
    :members:
+   :undoc-members:
 .. autoclass:: GetPublishedAppIntegrationOutput
    :members:
+   :undoc-members:
 .. autoclass:: GetPublishedAppIntegrationsOutput
    :members:
+   :undoc-members:
 .. autoclass:: GetPublishedAppsOutput
    :members:
+   :undoc-members:
 .. autoclass:: ListServicePrincipalSecretsResponse
    :members:
+   :undoc-members:
 .. autoclass:: PublishedAppOutput
    :members:
+   :undoc-members:
 .. autoclass:: SecretInfo
    :members:
+   :undoc-members:
 .. autoclass:: TokenAccessPolicy
    :members:
+   :undoc-members:
 .. autoclass:: UpdateCustomAppIntegration
    :members:
+   :undoc-members:
 .. autoclass:: UpdatePublishedAppIntegration
    :members:
+   :undoc-members:

--- a/docs/dbdataclasses/pipelines.rst
+++ b/docs/dbdataclasses/pipelines.rst
@@ -6,73 +6,109 @@ These dataclasses are used in the SDK to represent API requests and responses fo
 .. py:currentmodule:: databricks.sdk.service.pipelines
 .. autoclass:: CreatePipeline
    :members:
+   :undoc-members:
 .. autoclass:: CreatePipelineResponse
    :members:
+   :undoc-members:
 .. autoclass:: CronTrigger
    :members:
+   :undoc-members:
 .. autoclass:: DataPlaneId
    :members:
+   :undoc-members:
 .. autoclass:: EditPipeline
    :members:
+   :undoc-members:
 .. autoclass:: ErrorDetail
    :members:
+   :undoc-members:
 .. autoclass:: FileLibrary
    :members:
+   :undoc-members:
 .. autoclass:: Filters
    :members:
+   :undoc-members:
 .. autoclass:: GetPipelinePermissionLevelsResponse
    :members:
+   :undoc-members:
 .. autoclass:: GetPipelineResponse
    :members:
+   :undoc-members:
 .. autoclass:: GetUpdateResponse
    :members:
+   :undoc-members:
 .. autoclass:: ListPipelineEventsResponse
    :members:
+   :undoc-members:
 .. autoclass:: ListPipelinesResponse
    :members:
+   :undoc-members:
 .. autoclass:: ListUpdatesResponse
    :members:
+   :undoc-members:
 .. autoclass:: NotebookLibrary
    :members:
+   :undoc-members:
 .. autoclass:: Notifications
    :members:
+   :undoc-members:
 .. autoclass:: Origin
    :members:
+   :undoc-members:
 .. autoclass:: PipelineAccessControlRequest
    :members:
+   :undoc-members:
 .. autoclass:: PipelineAccessControlResponse
    :members:
+   :undoc-members:
 .. autoclass:: PipelineCluster
    :members:
+   :undoc-members:
 .. autoclass:: PipelineEvent
    :members:
+   :undoc-members:
 .. autoclass:: PipelineLibrary
    :members:
+   :undoc-members:
 .. autoclass:: PipelinePermission
    :members:
+   :undoc-members:
 .. autoclass:: PipelinePermissions
    :members:
+   :undoc-members:
 .. autoclass:: PipelinePermissionsDescription
    :members:
+   :undoc-members:
 .. autoclass:: PipelinePermissionsRequest
    :members:
+   :undoc-members:
 .. autoclass:: PipelineSpec
    :members:
+   :undoc-members:
 .. autoclass:: PipelineStateInfo
    :members:
+   :undoc-members:
 .. autoclass:: PipelineTrigger
    :members:
+   :undoc-members:
 .. autoclass:: Sequencing
    :members:
+   :undoc-members:
 .. autoclass:: SerializedException
    :members:
+   :undoc-members:
 .. autoclass:: StackFrame
    :members:
+   :undoc-members:
 .. autoclass:: StartUpdate
    :members:
+   :undoc-members:
 .. autoclass:: StartUpdateResponse
    :members:
+   :undoc-members:
 .. autoclass:: UpdateInfo
    :members:
+   :undoc-members:
 .. autoclass:: UpdateStateInfo
    :members:
+   :undoc-members:

--- a/docs/dbdataclasses/provisioning.rst
+++ b/docs/dbdataclasses/provisioning.rst
@@ -6,69 +6,103 @@ These dataclasses are used in the SDK to represent API requests and responses fo
 .. py:currentmodule:: databricks.sdk.service.provisioning
 .. autoclass:: AwsCredentials
    :members:
+   :undoc-members:
 .. autoclass:: AwsKeyInfo
    :members:
+   :undoc-members:
 .. autoclass:: AzureWorkspaceInfo
    :members:
+   :undoc-members:
 .. autoclass:: CloudResourceContainer
    :members:
+   :undoc-members:
 .. autoclass:: CreateAwsKeyInfo
    :members:
+   :undoc-members:
 .. autoclass:: CreateCredentialAwsCredentials
    :members:
+   :undoc-members:
 .. autoclass:: CreateCredentialRequest
    :members:
+   :undoc-members:
 .. autoclass:: CreateCredentialStsRole
    :members:
+   :undoc-members:
 .. autoclass:: CreateCustomerManagedKeyRequest
    :members:
+   :undoc-members:
 .. autoclass:: CreateGcpKeyInfo
    :members:
+   :undoc-members:
 .. autoclass:: CreateNetworkRequest
    :members:
+   :undoc-members:
 .. autoclass:: CreateStorageConfigurationRequest
    :members:
+   :undoc-members:
 .. autoclass:: CreateVpcEndpointRequest
    :members:
+   :undoc-members:
 .. autoclass:: CreateWorkspaceRequest
    :members:
+   :undoc-members:
 .. autoclass:: Credential
    :members:
+   :undoc-members:
 .. autoclass:: CustomerFacingGcpCloudResourceContainer
    :members:
+   :undoc-members:
 .. autoclass:: CustomerManagedKey
    :members:
+   :undoc-members:
 .. autoclass:: GcpKeyInfo
    :members:
+   :undoc-members:
 .. autoclass:: GcpManagedNetworkConfig
    :members:
+   :undoc-members:
 .. autoclass:: GcpNetworkInfo
    :members:
+   :undoc-members:
 .. autoclass:: GcpVpcEndpointInfo
    :members:
+   :undoc-members:
 .. autoclass:: GkeConfig
    :members:
+   :undoc-members:
 .. autoclass:: Network
    :members:
+   :undoc-members:
 .. autoclass:: NetworkHealth
    :members:
+   :undoc-members:
 .. autoclass:: NetworkVpcEndpoints
    :members:
+   :undoc-members:
 .. autoclass:: NetworkWarning
    :members:
+   :undoc-members:
 .. autoclass:: PrivateAccessSettings
    :members:
+   :undoc-members:
 .. autoclass:: RootBucketInfo
    :members:
+   :undoc-members:
 .. autoclass:: StorageConfiguration
    :members:
+   :undoc-members:
 .. autoclass:: StsRole
    :members:
+   :undoc-members:
 .. autoclass:: UpdateWorkspaceRequest
    :members:
+   :undoc-members:
 .. autoclass:: UpsertPrivateAccessSettingsRequest
    :members:
+   :undoc-members:
 .. autoclass:: VpcEndpoint
    :members:
+   :undoc-members:
 .. autoclass:: Workspace
    :members:
+   :undoc-members:

--- a/docs/dbdataclasses/serving.rst
+++ b/docs/dbdataclasses/serving.rst
@@ -6,123 +6,184 @@ These dataclasses are used in the SDK to represent API requests and responses fo
 .. py:currentmodule:: databricks.sdk.service.serving
 .. autoclass:: Ai21LabsConfig
    :members:
+   :undoc-members:
 .. autoclass:: AnthropicConfig
    :members:
+   :undoc-members:
 .. autoclass:: AppEvents
    :members:
+   :undoc-members:
 .. autoclass:: AppManifest
    :members:
+   :undoc-members:
 .. autoclass:: AppServiceStatus
    :members:
+   :undoc-members:
 .. autoclass:: AutoCaptureConfigInput
    :members:
+   :undoc-members:
 .. autoclass:: AutoCaptureConfigOutput
    :members:
+   :undoc-members:
 .. autoclass:: AutoCaptureState
    :members:
+   :undoc-members:
 .. autoclass:: AwsBedrockConfig
    :members:
+   :undoc-members:
 .. autoclass:: BuildLogsResponse
    :members:
+   :undoc-members:
 .. autoclass:: ChatMessage
    :members:
+   :undoc-members:
 .. autoclass:: CohereConfig
    :members:
+   :undoc-members:
 .. autoclass:: CreateServingEndpoint
    :members:
+   :undoc-members:
 .. autoclass:: DatabricksModelServingConfig
    :members:
+   :undoc-members:
 .. autoclass:: DataframeSplitInput
    :members:
+   :undoc-members:
 .. autoclass:: DeleteAppResponse
    :members:
+   :undoc-members:
 .. autoclass:: DeployAppRequest
    :members:
+   :undoc-members:
 .. autoclass:: DeploymentStatus
    :members:
+   :undoc-members:
 .. autoclass:: EmbeddingsV1ResponseEmbeddingElement
    :members:
+   :undoc-members:
 .. autoclass:: EndpointCoreConfigInput
    :members:
+   :undoc-members:
 .. autoclass:: EndpointCoreConfigOutput
    :members:
+   :undoc-members:
 .. autoclass:: EndpointCoreConfigSummary
    :members:
+   :undoc-members:
 .. autoclass:: EndpointPendingConfig
    :members:
+   :undoc-members:
 .. autoclass:: EndpointState
    :members:
+   :undoc-members:
 .. autoclass:: EndpointTag
    :members:
+   :undoc-members:
 .. autoclass:: ExternalModel
    :members:
+   :undoc-members:
 .. autoclass:: ExternalModelConfig
    :members:
+   :undoc-members:
 .. autoclass:: ExternalModelUsageElement
    :members:
+   :undoc-members:
 .. autoclass:: FoundationModel
    :members:
+   :undoc-members:
 .. autoclass:: GetAppResponse
    :members:
+   :undoc-members:
 .. autoclass:: GetServingEndpointPermissionLevelsResponse
    :members:
+   :undoc-members:
 .. autoclass:: ListAppEventsResponse
    :members:
+   :undoc-members:
 .. autoclass:: ListAppsResponse
    :members:
+   :undoc-members:
 .. autoclass:: ListEndpointsResponse
    :members:
+   :undoc-members:
 .. autoclass:: OpenAiConfig
    :members:
+   :undoc-members:
 .. autoclass:: PaLmConfig
    :members:
+   :undoc-members:
 .. autoclass:: PatchServingEndpointTags
    :members:
+   :undoc-members:
 .. autoclass:: PayloadTable
    :members:
+   :undoc-members:
 .. autoclass:: PutResponse
    :members:
+   :undoc-members:
 .. autoclass:: QueryEndpointInput
    :members:
+   :undoc-members:
 .. autoclass:: QueryEndpointResponse
    :members:
+   :undoc-members:
 .. autoclass:: RateLimit
    :members:
+   :undoc-members:
 .. autoclass:: Route
    :members:
+   :undoc-members:
 .. autoclass:: ServedEntityInput
    :members:
+   :undoc-members:
 .. autoclass:: ServedEntityOutput
    :members:
+   :undoc-members:
 .. autoclass:: ServedEntitySpec
    :members:
+   :undoc-members:
 .. autoclass:: ServedModelInput
    :members:
+   :undoc-members:
 .. autoclass:: ServedModelOutput
    :members:
+   :undoc-members:
 .. autoclass:: ServedModelSpec
    :members:
+   :undoc-members:
 .. autoclass:: ServedModelState
    :members:
+   :undoc-members:
 .. autoclass:: ServerLogsResponse
    :members:
+   :undoc-members:
 .. autoclass:: ServingEndpoint
    :members:
+   :undoc-members:
 .. autoclass:: ServingEndpointAccessControlRequest
    :members:
+   :undoc-members:
 .. autoclass:: ServingEndpointAccessControlResponse
    :members:
+   :undoc-members:
 .. autoclass:: ServingEndpointDetailed
    :members:
+   :undoc-members:
 .. autoclass:: ServingEndpointPermission
    :members:
+   :undoc-members:
 .. autoclass:: ServingEndpointPermissions
    :members:
+   :undoc-members:
 .. autoclass:: ServingEndpointPermissionsDescription
    :members:
+   :undoc-members:
 .. autoclass:: ServingEndpointPermissionsRequest
    :members:
+   :undoc-members:
 .. autoclass:: TrafficConfig
    :members:
+   :undoc-members:
 .. autoclass:: V1ResponseChoiceElement
    :members:
+   :undoc-members:

--- a/docs/dbdataclasses/settings.rst
+++ b/docs/dbdataclasses/settings.rst
@@ -6,91 +6,136 @@ These dataclasses are used in the SDK to represent API requests and responses fo
 .. py:currentmodule:: databricks.sdk.service.settings
 .. autoclass:: CreateIpAccessList
    :members:
+   :undoc-members:
 .. autoclass:: CreateIpAccessListResponse
    :members:
+   :undoc-members:
 .. autoclass:: CreateNetworkConnectivityConfigRequest
    :members:
+   :undoc-members:
 .. autoclass:: CreateOboTokenRequest
    :members:
+   :undoc-members:
 .. autoclass:: CreateOboTokenResponse
    :members:
+   :undoc-members:
 .. autoclass:: CreatePrivateEndpointRuleRequest
    :members:
+   :undoc-members:
 .. autoclass:: CreateTokenRequest
    :members:
+   :undoc-members:
 .. autoclass:: CreateTokenResponse
    :members:
+   :undoc-members:
 .. autoclass:: DefaultNamespaceSetting
    :members:
+   :undoc-members:
 .. autoclass:: DeleteDefaultWorkspaceNamespaceResponse
    :members:
+   :undoc-members:
 .. autoclass:: DeletePersonalComputeSettingResponse
    :members:
+   :undoc-members:
 .. autoclass:: ExchangeToken
    :members:
+   :undoc-members:
 .. autoclass:: ExchangeTokenRequest
    :members:
+   :undoc-members:
 .. autoclass:: ExchangeTokenResponse
    :members:
+   :undoc-members:
 .. autoclass:: FetchIpAccessListResponse
    :members:
+   :undoc-members:
 .. autoclass:: GetIpAccessListResponse
    :members:
+   :undoc-members:
 .. autoclass:: GetIpAccessListsResponse
    :members:
+   :undoc-members:
 .. autoclass:: GetTokenPermissionLevelsResponse
    :members:
+   :undoc-members:
 .. autoclass:: IpAccessListInfo
    :members:
+   :undoc-members:
 .. autoclass:: ListIpAccessListResponse
    :members:
+   :undoc-members:
 .. autoclass:: ListNccAzurePrivateEndpointRulesResponse
    :members:
+   :undoc-members:
 .. autoclass:: ListNetworkConnectivityConfigurationsResponse
    :members:
+   :undoc-members:
 .. autoclass:: ListPublicTokensResponse
    :members:
+   :undoc-members:
 .. autoclass:: ListTokensResponse
    :members:
+   :undoc-members:
 .. autoclass:: NccAzurePrivateEndpointRule
    :members:
+   :undoc-members:
 .. autoclass:: NccAzureServiceEndpointRule
    :members:
+   :undoc-members:
 .. autoclass:: NccEgressConfig
    :members:
+   :undoc-members:
 .. autoclass:: NccEgressDefaultRules
    :members:
+   :undoc-members:
 .. autoclass:: NccEgressTargetRules
    :members:
+   :undoc-members:
 .. autoclass:: NetworkConnectivityConfiguration
    :members:
+   :undoc-members:
 .. autoclass:: PartitionId
    :members:
+   :undoc-members:
 .. autoclass:: PersonalComputeMessage
    :members:
+   :undoc-members:
 .. autoclass:: PersonalComputeSetting
    :members:
+   :undoc-members:
 .. autoclass:: PublicTokenInfo
    :members:
+   :undoc-members:
 .. autoclass:: ReplaceIpAccessList
    :members:
+   :undoc-members:
 .. autoclass:: RevokeTokenRequest
    :members:
+   :undoc-members:
 .. autoclass:: StringMessage
    :members:
+   :undoc-members:
 .. autoclass:: TokenAccessControlRequest
    :members:
+   :undoc-members:
 .. autoclass:: TokenAccessControlResponse
    :members:
+   :undoc-members:
 .. autoclass:: TokenInfo
    :members:
+   :undoc-members:
 .. autoclass:: TokenPermission
    :members:
+   :undoc-members:
 .. autoclass:: TokenPermissions
    :members:
+   :undoc-members:
 .. autoclass:: TokenPermissionsDescription
    :members:
+   :undoc-members:
 .. autoclass:: TokenPermissionsRequest
    :members:
+   :undoc-members:
 .. autoclass:: UpdateIpAccessList
    :members:
+   :undoc-members:

--- a/docs/dbdataclasses/sharing.rst
+++ b/docs/dbdataclasses/sharing.rst
@@ -6,83 +6,124 @@ These dataclasses are used in the SDK to represent API requests and responses fo
 .. py:currentmodule:: databricks.sdk.service.sharing
 .. autoclass:: CentralCleanRoomInfo
    :members:
+   :undoc-members:
 .. autoclass:: CleanRoomAssetInfo
    :members:
+   :undoc-members:
 .. autoclass:: CleanRoomCatalog
    :members:
+   :undoc-members:
 .. autoclass:: CleanRoomCatalogUpdate
    :members:
+   :undoc-members:
 .. autoclass:: CleanRoomCollaboratorInfo
    :members:
+   :undoc-members:
 .. autoclass:: CleanRoomInfo
    :members:
+   :undoc-members:
 .. autoclass:: CleanRoomNotebookInfo
    :members:
+   :undoc-members:
 .. autoclass:: CleanRoomTableInfo
    :members:
+   :undoc-members:
 .. autoclass:: ColumnInfo
    :members:
+   :undoc-members:
 .. autoclass:: ColumnMask
    :members:
+   :undoc-members:
 .. autoclass:: CreateCleanRoom
    :members:
+   :undoc-members:
 .. autoclass:: CreateProvider
    :members:
+   :undoc-members:
 .. autoclass:: CreateRecipient
    :members:
+   :undoc-members:
 .. autoclass:: CreateShare
    :members:
+   :undoc-members:
 .. autoclass:: GetRecipientSharePermissionsResponse
    :members:
+   :undoc-members:
 .. autoclass:: IpAccessList
    :members:
+   :undoc-members:
 .. autoclass:: ListCleanRoomsResponse
    :members:
+   :undoc-members:
 .. autoclass:: ListProviderSharesResponse
    :members:
+   :undoc-members:
 .. autoclass:: ListProvidersResponse
    :members:
+   :undoc-members:
 .. autoclass:: ListRecipientsResponse
    :members:
+   :undoc-members:
 .. autoclass:: ListSharesResponse
    :members:
+   :undoc-members:
 .. autoclass:: Partition
    :members:
+   :undoc-members:
 .. autoclass:: PartitionValue
    :members:
+   :undoc-members:
 .. autoclass:: PrivilegeAssignment
    :members:
+   :undoc-members:
 .. autoclass:: ProviderInfo
    :members:
+   :undoc-members:
 .. autoclass:: ProviderShare
    :members:
+   :undoc-members:
 .. autoclass:: RecipientInfo
    :members:
+   :undoc-members:
 .. autoclass:: RecipientProfile
    :members:
+   :undoc-members:
 .. autoclass:: RecipientTokenInfo
    :members:
+   :undoc-members:
 .. autoclass:: RetrieveTokenResponse
    :members:
+   :undoc-members:
 .. autoclass:: RotateRecipientToken
    :members:
+   :undoc-members:
 .. autoclass:: SecurablePropertiesKvPairs
    :members:
+   :undoc-members:
 .. autoclass:: ShareInfo
    :members:
+   :undoc-members:
 .. autoclass:: ShareToPrivilegeAssignment
    :members:
+   :undoc-members:
 .. autoclass:: SharedDataObject
    :members:
+   :undoc-members:
 .. autoclass:: SharedDataObjectUpdate
    :members:
+   :undoc-members:
 .. autoclass:: UpdateCleanRoom
    :members:
+   :undoc-members:
 .. autoclass:: UpdateProvider
    :members:
+   :undoc-members:
 .. autoclass:: UpdateRecipient
    :members:
+   :undoc-members:
 .. autoclass:: UpdateShare
    :members:
+   :undoc-members:
 .. autoclass:: UpdateSharePermissions
    :members:
+   :undoc-members:

--- a/docs/dbdataclasses/sql.rst
+++ b/docs/dbdataclasses/sql.rst
@@ -6,141 +6,211 @@ These dataclasses are used in the SDK to represent API requests and responses fo
 .. py:currentmodule:: databricks.sdk.service.sql
 .. autoclass:: AccessControl
    :members:
+   :undoc-members:
 .. autoclass:: Alert
    :members:
+   :undoc-members:
 .. autoclass:: AlertOptions
    :members:
+   :undoc-members:
 .. autoclass:: AlertQuery
    :members:
+   :undoc-members:
 .. autoclass:: BaseChunkInfo
    :members:
+   :undoc-members:
 .. autoclass:: Channel
    :members:
+   :undoc-members:
 .. autoclass:: ChannelInfo
    :members:
+   :undoc-members:
 .. autoclass:: ColumnInfo
    :members:
+   :undoc-members:
 .. autoclass:: CreateAlert
    :members:
+   :undoc-members:
 .. autoclass:: CreateWarehouseRequest
    :members:
+   :undoc-members:
 .. autoclass:: CreateWarehouseResponse
    :members:
+   :undoc-members:
 .. autoclass:: CreateWidget
    :members:
+   :undoc-members:
 .. autoclass:: Dashboard
    :members:
+   :undoc-members:
 .. autoclass:: DashboardEditContent
    :members:
+   :undoc-members:
 .. autoclass:: DashboardOptions
    :members:
+   :undoc-members:
 .. autoclass:: DashboardPostContent
    :members:
+   :undoc-members:
 .. autoclass:: DataSource
    :members:
+   :undoc-members:
 .. autoclass:: EditAlert
    :members:
+   :undoc-members:
 .. autoclass:: EditWarehouseRequest
    :members:
+   :undoc-members:
 .. autoclass:: EndpointConfPair
    :members:
+   :undoc-members:
 .. autoclass:: EndpointHealth
    :members:
+   :undoc-members:
 .. autoclass:: EndpointInfo
    :members:
+   :undoc-members:
 .. autoclass:: EndpointTagPair
    :members:
+   :undoc-members:
 .. autoclass:: EndpointTags
    :members:
+   :undoc-members:
 .. autoclass:: ExecuteStatementRequest
    :members:
+   :undoc-members:
 .. autoclass:: ExecuteStatementResponse
    :members:
+   :undoc-members:
 .. autoclass:: ExternalLink
    :members:
+   :undoc-members:
 .. autoclass:: GetResponse
    :members:
+   :undoc-members:
 .. autoclass:: GetStatementResponse
    :members:
+   :undoc-members:
 .. autoclass:: GetWarehousePermissionLevelsResponse
    :members:
+   :undoc-members:
 .. autoclass:: GetWarehouseResponse
    :members:
+   :undoc-members:
 .. autoclass:: GetWorkspaceWarehouseConfigResponse
    :members:
+   :undoc-members:
 .. autoclass:: ListQueriesResponse
    :members:
+   :undoc-members:
 .. autoclass:: ListResponse
    :members:
+   :undoc-members:
 .. autoclass:: ListWarehousesResponse
    :members:
+   :undoc-members:
 .. autoclass:: OdbcParams
    :members:
+   :undoc-members:
 .. autoclass:: Parameter
    :members:
+   :undoc-members:
 .. autoclass:: Query
    :members:
+   :undoc-members:
 .. autoclass:: QueryEditContent
    :members:
+   :undoc-members:
 .. autoclass:: QueryFilter
    :members:
+   :undoc-members:
 .. autoclass:: QueryInfo
    :members:
+   :undoc-members:
 .. autoclass:: QueryList
    :members:
+   :undoc-members:
 .. autoclass:: QueryMetrics
    :members:
+   :undoc-members:
 .. autoclass:: QueryOptions
    :members:
+   :undoc-members:
 .. autoclass:: QueryPostContent
    :members:
+   :undoc-members:
 .. autoclass:: RepeatedEndpointConfPairs
    :members:
+   :undoc-members:
 .. autoclass:: ResultData
    :members:
+   :undoc-members:
 .. autoclass:: ResultManifest
    :members:
+   :undoc-members:
 .. autoclass:: ResultSchema
    :members:
+   :undoc-members:
 .. autoclass:: ServiceError
    :members:
+   :undoc-members:
 .. autoclass:: SetResponse
    :members:
+   :undoc-members:
 .. autoclass:: SetWorkspaceWarehouseConfigRequest
    :members:
+   :undoc-members:
 .. autoclass:: StatementParameterListItem
    :members:
+   :undoc-members:
 .. autoclass:: StatementStatus
    :members:
+   :undoc-members:
 .. autoclass:: Success
    :members:
+   :undoc-members:
 .. autoclass:: TerminationReason
    :members:
+   :undoc-members:
 .. autoclass:: TimeRange
    :members:
+   :undoc-members:
 .. autoclass:: TransferOwnershipObjectId
    :members:
+   :undoc-members:
 .. autoclass:: User
    :members:
+   :undoc-members:
 .. autoclass:: Visualization
    :members:
+   :undoc-members:
 .. autoclass:: WarehouseAccessControlRequest
    :members:
+   :undoc-members:
 .. autoclass:: WarehouseAccessControlResponse
    :members:
+   :undoc-members:
 .. autoclass:: WarehousePermission
    :members:
+   :undoc-members:
 .. autoclass:: WarehousePermissions
    :members:
+   :undoc-members:
 .. autoclass:: WarehousePermissionsDescription
    :members:
+   :undoc-members:
 .. autoclass:: WarehousePermissionsRequest
    :members:
+   :undoc-members:
 .. autoclass:: WarehouseTypePair
    :members:
+   :undoc-members:
 .. autoclass:: Widget
    :members:
+   :undoc-members:
 .. autoclass:: WidgetOptions
    :members:
+   :undoc-members:
 .. autoclass:: WidgetPosition
    :members:
+   :undoc-members:

--- a/docs/dbdataclasses/vectorsearch.rst
+++ b/docs/dbdataclasses/vectorsearch.rst
@@ -6,55 +6,82 @@ These dataclasses are used in the SDK to represent API requests and responses fo
 .. py:currentmodule:: databricks.sdk.service.vectorsearch
 .. autoclass:: ColumnInfo
    :members:
+   :undoc-members:
 .. autoclass:: CreateEndpoint
    :members:
+   :undoc-members:
 .. autoclass:: CreateVectorIndexRequest
    :members:
+   :undoc-members:
 .. autoclass:: CreateVectorIndexResponse
    :members:
+   :undoc-members:
 .. autoclass:: DeleteDataResult
    :members:
+   :undoc-members:
 .. autoclass:: DeleteDataVectorIndexRequest
    :members:
+   :undoc-members:
 .. autoclass:: DeleteDataVectorIndexResponse
    :members:
+   :undoc-members:
 .. autoclass:: DeltaSyncVectorIndexSpecRequest
    :members:
+   :undoc-members:
 .. autoclass:: DeltaSyncVectorIndexSpecResponse
    :members:
+   :undoc-members:
 .. autoclass:: DirectAccessVectorIndexSpec
    :members:
+   :undoc-members:
 .. autoclass:: EmbeddingConfig
    :members:
+   :undoc-members:
 .. autoclass:: EmbeddingSourceColumn
    :members:
+   :undoc-members:
 .. autoclass:: EmbeddingVectorColumn
    :members:
+   :undoc-members:
 .. autoclass:: EndpointInfo
    :members:
+   :undoc-members:
 .. autoclass:: EndpointStatus
    :members:
+   :undoc-members:
 .. autoclass:: ListEndpointResponse
    :members:
+   :undoc-members:
 .. autoclass:: ListVectorIndexesResponse
    :members:
+   :undoc-members:
 .. autoclass:: MiniVectorIndex
    :members:
+   :undoc-members:
 .. autoclass:: QueryVectorIndexRequest
    :members:
+   :undoc-members:
 .. autoclass:: QueryVectorIndexResponse
    :members:
+   :undoc-members:
 .. autoclass:: ResultData
    :members:
+   :undoc-members:
 .. autoclass:: ResultManifest
    :members:
+   :undoc-members:
 .. autoclass:: UpsertDataResult
    :members:
+   :undoc-members:
 .. autoclass:: UpsertDataVectorIndexRequest
    :members:
+   :undoc-members:
 .. autoclass:: UpsertDataVectorIndexResponse
    :members:
+   :undoc-members:
 .. autoclass:: VectorIndex
    :members:
+   :undoc-members:
 .. autoclass:: VectorIndexStatus
    :members:
+   :undoc-members:

--- a/docs/dbdataclasses/workspace.rst
+++ b/docs/dbdataclasses/workspace.rst
@@ -6,91 +6,136 @@ These dataclasses are used in the SDK to represent API requests and responses fo
 .. py:currentmodule:: databricks.sdk.service.workspace
 .. autoclass:: AclItem
    :members:
+   :undoc-members:
 .. autoclass:: AzureKeyVaultSecretScopeMetadata
    :members:
+   :undoc-members:
 .. autoclass:: CreateCredentials
    :members:
+   :undoc-members:
 .. autoclass:: CreateCredentialsResponse
    :members:
+   :undoc-members:
 .. autoclass:: CreateRepo
    :members:
+   :undoc-members:
 .. autoclass:: CreateScope
    :members:
+   :undoc-members:
 .. autoclass:: CredentialInfo
    :members:
+   :undoc-members:
 .. autoclass:: Delete
    :members:
+   :undoc-members:
 .. autoclass:: DeleteAcl
    :members:
+   :undoc-members:
 .. autoclass:: DeleteScope
    :members:
+   :undoc-members:
 .. autoclass:: DeleteSecret
    :members:
+   :undoc-members:
 .. autoclass:: ExportResponse
    :members:
+   :undoc-members:
 .. autoclass:: GetCredentialsResponse
    :members:
+   :undoc-members:
 .. autoclass:: GetRepoPermissionLevelsResponse
    :members:
+   :undoc-members:
 .. autoclass:: GetSecretResponse
    :members:
+   :undoc-members:
 .. autoclass:: GetWorkspaceObjectPermissionLevelsResponse
    :members:
+   :undoc-members:
 .. autoclass:: Import
    :members:
+   :undoc-members:
 .. autoclass:: ListAclsResponse
    :members:
+   :undoc-members:
 .. autoclass:: ListReposResponse
    :members:
+   :undoc-members:
 .. autoclass:: ListResponse
    :members:
+   :undoc-members:
 .. autoclass:: ListScopesResponse
    :members:
+   :undoc-members:
 .. autoclass:: ListSecretsResponse
    :members:
+   :undoc-members:
 .. autoclass:: Mkdirs
    :members:
+   :undoc-members:
 .. autoclass:: ObjectInfo
    :members:
+   :undoc-members:
 .. autoclass:: PutAcl
    :members:
+   :undoc-members:
 .. autoclass:: PutSecret
    :members:
+   :undoc-members:
 .. autoclass:: RepoAccessControlRequest
    :members:
+   :undoc-members:
 .. autoclass:: RepoAccessControlResponse
    :members:
+   :undoc-members:
 .. autoclass:: RepoInfo
    :members:
+   :undoc-members:
 .. autoclass:: RepoPermission
    :members:
+   :undoc-members:
 .. autoclass:: RepoPermissions
    :members:
+   :undoc-members:
 .. autoclass:: RepoPermissionsDescription
    :members:
+   :undoc-members:
 .. autoclass:: RepoPermissionsRequest
    :members:
+   :undoc-members:
 .. autoclass:: SecretMetadata
    :members:
+   :undoc-members:
 .. autoclass:: SecretScope
    :members:
+   :undoc-members:
 .. autoclass:: SparseCheckout
    :members:
+   :undoc-members:
 .. autoclass:: SparseCheckoutUpdate
    :members:
+   :undoc-members:
 .. autoclass:: UpdateCredentials
    :members:
+   :undoc-members:
 .. autoclass:: UpdateRepo
    :members:
+   :undoc-members:
 .. autoclass:: WorkspaceObjectAccessControlRequest
    :members:
+   :undoc-members:
 .. autoclass:: WorkspaceObjectAccessControlResponse
    :members:
+   :undoc-members:
 .. autoclass:: WorkspaceObjectPermission
    :members:
+   :undoc-members:
 .. autoclass:: WorkspaceObjectPermissions
    :members:
+   :undoc-members:
 .. autoclass:: WorkspaceObjectPermissionsDescription
    :members:
+   :undoc-members:
 .. autoclass:: WorkspaceObjectPermissionsRequest
    :members:
+   :undoc-members:

--- a/docs/gen-client-docs.py
+++ b/docs/gen-client-docs.py
@@ -167,7 +167,8 @@ class DataclassesDoc:
         else:
             out = [
                 f'.. autoclass:: {cls}',
-                '   :members:'
+                '   :members:',
+                '   :undoc-members:',
                 ''
             ]
         return "\n".join(out)


### PR DESCRIPTION
## Changes
Some fields are undocumented in dataclasses. Those are hidden by default with `autoclass`. This PR makes sure that all public fields are shown, even those with no documentation.

https://databricks-sdk-py--520.org.readthedocs.build/en/520/

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

