### PR TITLE
Enable Databricks OAuth also for Azure and GCP

### DIFF
--- a/databricks/sdk/credentials_provider.py
+++ b/databricks/sdk/credentials_provider.py
@@ -516,7 +516,7 @@ class DatabricksCliTokenSource(CliTokenSource):
         raise err
 
 
-@credentials_provider('databricks-cli', ['host', 'is_aws'])
+@credentials_provider('databricks-cli', ['host'])
 def databricks_cli(cfg: 'Config') -> Optional[HeaderFactory]:
     try:
         token_source = DatabricksCliTokenSource(cfg)


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

## Tests
Manually tested with a profile that uses `databricks-cli` with a GCP workspace

- [x] `make test` run locally
- [x] `make fmt` applied
- [x] relevant integration tests applied

