### PR TITLE
Construct workspace client from account client

### DIFF
--- a/.codegen/__init__.py.tmpl
+++ b/.codegen/__init__.py.tmpl
@@ -141,7 +141,7 @@ class AccountClient:
             if len(wss) == 0:
                 pytest.skip("no workspaces")
             w = a.get_workspace_client(wss[0])
-            assert w.current_user.me().activ
+            assert w.current_user.me().active
 
         :param workspace: The workspace to construct a client for.
         :return: A ``WorkspaceClient`` for the given workspace.

--- a/.codegen/__init__.py.tmpl
+++ b/.codegen/__init__.py.tmpl
@@ -7,6 +7,8 @@ from databricks.sdk.mixins.compute import ClustersExt
 from databricks.sdk.mixins.workspace import WorkspaceExt
 {{- range .Services}}
 from databricks.sdk.service.{{.Package.Name}} import {{.PascalName}}API{{end}}
+from databricks.sdk.service.provisioning import Workspace
+from databricks.sdk import azure
 
 {{$args := list "host" "account_id" "username" "password" "client_id" "client_secret"
   "token" "profile" "config_file" "azure_workspace_resource_id" "azure_client_secret"
@@ -121,6 +123,24 @@ class AccountClient:
         """{{.Summary}}"""{{end}}
         return self._{{(.TrimPrefix "account").SnakeName}}
     {{end -}}{{end}}
+
+    def get_workspace_client(self, workspace: Workspace) -> WorkspaceClient:
+        """Constructs a ``WorkspaceClient`` for the given workspace.
+
+        Returns a ``WorkspaceClient`` that is configured to use the same
+        credentials as this ``AccountClient``. The underlying config is
+        copied from this ``AccountClient``, but the ``host`` and
+        ``azure_workspace_resource_id`` are overridden to match the
+        given workspace, and the ``account_id`` field is cleared.
+
+        :param workspace: The workspace to construct a client for.
+        :return: A ``WorkspaceClient`` for the given workspace.
+        """
+        config = self._config.copy()
+        config.host = config.environment.deployment_url(workspace.deployment_name)
+        config.azure_workspace_resource_id = azure.get_azure_resource_id(workspace)
+        config.account_id = None
+        return WorkspaceClient(config=config)
 
     def __repr__(self):
         return f"AccountClient(account_id='{self._config.account_id}', auth_type='{self._config.auth_type}', ...)"

--- a/.codegen/__init__.py.tmpl
+++ b/.codegen/__init__.py.tmpl
@@ -133,6 +133,16 @@ class AccountClient:
         ``azure_workspace_resource_id`` are overridden to match the
         given workspace, and the ``account_id`` field is cleared.
 
+        Usage:
+
+        .. code-block::
+
+            wss = list(a.workspaces.list())
+            if len(wss) == 0:
+                pytest.skip("no workspaces")
+            w = a.get_workspace_client(wss[0])
+            assert w.current_user.me().activ
+
         :param workspace: The workspace to construct a client for.
         :return: A ``WorkspaceClient`` for the given workspace.
         """

--- a/databricks/sdk/__init__.py
+++ b/databricks/sdk/__init__.py
@@ -797,7 +797,7 @@ class AccountClient:
             if len(wss) == 0:
                 pytest.skip("no workspaces")
             w = a.get_workspace_client(wss[0])
-            assert w.current_user.me().activ
+            assert w.current_user.me().active
 
         :param workspace: The workspace to construct a client for.
         :return: A ``WorkspaceClient`` for the given workspace.

--- a/databricks/sdk/__init__.py
+++ b/databricks/sdk/__init__.py
@@ -789,6 +789,16 @@ class AccountClient:
         ``azure_workspace_resource_id`` are overridden to match the
         given workspace, and the ``account_id`` field is cleared.
 
+        Usage:
+
+        .. code-block::
+
+            wss = list(a.workspaces.list())
+            if len(wss) == 0:
+                pytest.skip("no workspaces")
+            w = a.get_workspace_client(wss[0])
+            assert w.current_user.me().activ
+
         :param workspace: The workspace to construct a client for.
         :return: A ``WorkspaceClient`` for the given workspace.
         """

--- a/databricks/sdk/azure.py
+++ b/databricks/sdk/azure.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 from typing import Dict
 
 from .oauth import TokenSource
+from .service.provisioning import Workspace
 
 
 @dataclass
@@ -38,3 +39,18 @@ def add_workspace_id_header(cfg: 'Config', headers: Dict[str, str]):
 def add_sp_management_token(token_source: 'TokenSource', headers: Dict[str, str]):
     mgmt_token = token_source.token()
     headers['X-Databricks-Azure-SP-Management-Token'] = mgmt_token.access_token
+
+
+def get_azure_resource_id(workspace: Workspace):
+    """
+    Returns the Azure Resource ID for the given workspace, if it is an Azure workspace.
+    :param workspace:
+    :return:
+    """
+    if workspace.azure_workspace_info is None:
+        return None
+    return (
+        f'/subscriptions/{workspace.azure_workspace_info.subscription_id}'
+        f'/resourceGroups/{workspace.azure_workspace_info.resource_group}'
+        f'/providers/Microsoft.Databricks/workspaces/{workspace.workspace_name}'
+    )

--- a/databricks/sdk/azure.py
+++ b/databricks/sdk/azure.py
@@ -49,8 +49,6 @@ def get_azure_resource_id(workspace: Workspace):
     """
     if workspace.azure_workspace_info is None:
         return None
-    return (
-        f'/subscriptions/{workspace.azure_workspace_info.subscription_id}'
-        f'/resourceGroups/{workspace.azure_workspace_info.resource_group}'
-        f'/providers/Microsoft.Databricks/workspaces/{workspace.workspace_name}'
-    )
+    return (f'/subscriptions/{workspace.azure_workspace_info.subscription_id}'
+            f'/resourceGroups/{workspace.azure_workspace_info.resource_group}'
+            f'/providers/Microsoft.Databricks/workspaces/{workspace.workspace_name}')

--- a/databricks/sdk/environments.py
+++ b/databricks/sdk/environments.py
@@ -19,7 +19,7 @@ class DatabricksEnvironment:
     azure_environment: Optional[AzureEnvironment] = None
 
     def deployment_url(self, name: str) -> str:
-        return f"https://{name}.{self.dns_zone}"
+        return f"https://{name}{self.dns_zone}"
 
     @property
     def azure_service_management_endpoint(self) -> Optional[str]:

--- a/databricks/sdk/service/sql.py
+++ b/databricks/sdk/service/sql.py
@@ -346,7 +346,6 @@ class ChannelInfo:
 
 
 class ChannelName(Enum):
-    """Name of the channel"""
 
     CHANNEL_NAME_CURRENT = 'CHANNEL_NAME_CURRENT'
     CHANNEL_NAME_CUSTOM = 'CHANNEL_NAME_CUSTOM'

--- a/docs/gen-client-docs.py
+++ b/docs/gen-client-docs.py
@@ -278,7 +278,7 @@ class Generator:
 
     def service_docs(self, client_inst) -> list[ServiceDoc]:
         client_prefix = 'w' if isinstance(client_inst, WorkspaceClient) else 'a'
-        ignore_client_fields = ('config', 'dbutils', 'api_client', 'files')
+        ignore_client_fields = ('config', 'dbutils', 'api_client', 'files', 'get_workspace_client')
         all = []
         for service_name, service_inst in inspect.getmembers(client_inst):
             if service_name.startswith('_'):

--- a/tests/integration/test_client.py
+++ b/tests/integration/test_client.py
@@ -1,5 +1,6 @@
 import pytest
 
+
 def test_get_workspace_client(a):
     wss = list(a.workspaces.list())
     if len(wss) == 0:

--- a/tests/integration/test_client.py
+++ b/tests/integration/test_client.py
@@ -1,0 +1,8 @@
+import pytest
+
+def test_get_workspace_client(a):
+    wss = list(a.workspaces.list())
+    if len(wss) == 0:
+        pytest.skip("no workspaces")
+    w = a.get_workspace_client(wss[0])
+    assert w.current_user.me().active

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,10 @@
+from databricks.sdk.config import Config
+
+from .conftest import noop_credentials
+
+
+def test_config_copy_preserves_product_and_product_version():
+    c = Config(credentials_provider=noop_credentials, product='foo', product_version='1.2.3')
+    c2 = c.copy()
+    assert c2._product == 'foo'
+    assert c2._product_version == '1.2.3'


### PR DESCRIPTION
## Changes
Port of https://github.com/databricks/databricks-sdk-go/pull/792/files to the Python SDK.

<img width="746" alt="Screenshot 2024-02-01 at 14 23 47" src="https://github.com/databricks/databricks-sdk-py/assets/1850319/a47ec1cb-d324-4f8d-add6-00d97239bd68">



## Tests
Integration test to verify that we can get a workspace client from an account client with the new method.

