### PR TITLE
Skip test_get_workspace_client in Azure and GCP

### DIFF
--- a/tests/integration/test_client.py
+++ b/tests/integration/test_client.py
@@ -2,6 +2,8 @@ import pytest
 
 
 def test_get_workspace_client(a):
+    if a.config.is_azure or a.config.is_gcp:
+        pytest.skip('not available on Azure and GCP currently')
     wss = list(a.workspaces.list())
     if len(wss) == 0:
         pytest.skip("no workspaces")

--- a/tests/integration/test_client.py
+++ b/tests/integration/test_client.py
@@ -3,7 +3,7 @@ import pytest
 
 def test_get_workspace_client(a):
     if a.config.is_azure or a.config.is_gcp:
-        pytest.skip('not available on Azure and GCP currently')
+        pytest.skip('Not available on Azure and GCP currently')
     wss = list(a.workspaces.list())
     if len(wss) == 0:
         pytest.skip("no workspaces")


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
We skip this test since it doesn't work currently in Azure and GCP

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

