### PR TITLE
Use fake clock for faster unit tests

### DIFF
--- a/databricks/sdk/clock.py
+++ b/databricks/sdk/clock.py
@@ -1,0 +1,50 @@
+import abc
+import time
+
+
+class Clock(metaclass=abc.ABCMeta):
+    @abc.abstractmethod
+    def time(self) -> float:
+        """
+        Return the current time in seconds since the Epoch.
+        Fractions of a second may be present if the system clock provides them.
+
+        :return: The current time in seconds since the Epoch.
+        """
+        pass
+
+    @abc.abstractmethod
+    def sleep(self, seconds: float) -> None:
+        """
+        Return the current time in seconds since the Epoch.
+        Fractions of a second may be present if the system clock provides them.
+
+        :param seconds: The duration to sleep in seconds.
+        :return:
+        """
+        pass
+
+
+class RealClock(Clock):
+    """
+    A real clock that uses the ``time`` module to get the current time and sleep.
+    """
+
+    def time(self) -> float:
+        """
+        Return the current time in seconds since the Epoch.
+        Fractions of a second may be present if the system clock provides them.
+
+        :return: The current time in seconds since the Epoch.
+        """
+        return time.time()
+
+    def sleep(self, seconds: float) -> None:
+        """
+        Return the current time in seconds since the Epoch.
+        Fractions of a second may be present if the system clock provides them.
+
+        :param seconds: The duration to sleep in seconds.
+        :return:
+        """
+        time.sleep(seconds)

--- a/databricks/sdk/clock.py
+++ b/databricks/sdk/clock.py
@@ -16,8 +16,8 @@ class Clock(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def sleep(self, seconds: float) -> None:
         """
-        Return the current time in seconds since the Epoch.
-        Fractions of a second may be present if the system clock provides them.
+        Delay execution for a given number of seconds.  The argument may be
+        a floating point number for subsecond precision.
 
         :param seconds: The duration to sleep in seconds.
         :return:
@@ -40,8 +40,8 @@ class RealClock(Clock):
 
     def sleep(self, seconds: float) -> None:
         """
-        Return the current time in seconds since the Epoch.
-        Fractions of a second may be present if the system clock provides them.
+        Delay execution for a given number of seconds.  The argument may be
+        a floating point number for subsecond precision.
 
         :param seconds: The duration to sleep in seconds.
         :return:

--- a/databricks/sdk/clock.py
+++ b/databricks/sdk/clock.py
@@ -3,6 +3,7 @@ import time
 
 
 class Clock(metaclass=abc.ABCMeta):
+
     @abc.abstractmethod
     def time(self) -> float:
         """
@@ -11,7 +12,6 @@ class Clock(metaclass=abc.ABCMeta):
 
         :return: The current time in seconds since the Epoch.
         """
-        pass
 
     @abc.abstractmethod
     def sleep(self, seconds: float) -> None:
@@ -22,7 +22,6 @@ class Clock(metaclass=abc.ABCMeta):
         :param seconds: The duration to sleep in seconds.
         :return:
         """
-        pass
 
 
 class RealClock(Clock):

--- a/databricks/sdk/config.py
+++ b/databricks/sdk/config.py
@@ -85,7 +85,7 @@ class Config:
                  credentials_provider: CredentialsProvider = None,
                  product="unknown",
                  product_version="0.0.0",
-                 clock: Clock=None,
+                 clock: Clock = None,
                  **kwargs):
         self._inner = {}
         self._user_agent_other_info = []

--- a/databricks/sdk/config.py
+++ b/databricks/sdk/config.py
@@ -11,6 +11,7 @@ from typing import Dict, Iterable, Optional
 import requests
 
 from .azure import AzureEnvironment
+from .clock import Clock, RealClock
 from .credentials_provider import CredentialsProvider, DefaultCredentials
 from .environments import (ALL_ENVS, DEFAULT_ENVIRONMENT, Cloud,
                            DatabricksEnvironment)
@@ -84,6 +85,7 @@ class Config:
                  credentials_provider: CredentialsProvider = None,
                  product="unknown",
                  product_version="0.0.0",
+                 clock: Clock=None,
                  **kwargs):
         self._inner = {}
         self._user_agent_other_info = []
@@ -91,6 +93,7 @@ class Config:
         if 'databricks_environment' in kwargs:
             self.databricks_environment = kwargs['databricks_environment']
             del kwargs['databricks_environment']
+        self._clock = clock if clock is not None else RealClock()
         try:
             self._set_inner_config(kwargs)
             self._load_from_env()
@@ -316,6 +319,10 @@ class Config:
             return f'sql/protocolv1/o/{workspace_id}/{self.cluster_id}'
         if self.warehouse_id:
             return f'/sql/1.0/warehouses/{self.warehouse_id}'
+
+    @property
+    def clock(self) -> Clock:
+        return self._clock
 
     @classmethod
     def attributes(cls) -> Iterable[ConfigAttribute]:

--- a/databricks/sdk/core.py
+++ b/databricks/sdk/core.py
@@ -7,7 +7,6 @@ from typing import Any, BinaryIO, Iterator, Type
 
 from requests.adapters import HTTPAdapter
 
-from .clock import Clock, RealClock
 from .config import *
 # To preserve backwards compatibility (as these definitions were previously in this module)
 from .credentials_provider import *

--- a/databricks/sdk/core.py
+++ b/databricks/sdk/core.py
@@ -7,12 +7,12 @@ from typing import Any, BinaryIO, Iterator, Type
 
 from requests.adapters import HTTPAdapter
 
+from .clock import Clock, RealClock
 from .config import *
 # To preserve backwards compatibility (as these definitions were previously in this module)
 from .credentials_provider import *
 from .errors import DatabricksError, error_mapper
 from .retries import retried
-from .clock import Clock, RealClock
 
 __all__ = ['Config', 'DatabricksError']
 
@@ -23,7 +23,7 @@ class ApiClient:
     _cfg: Config
     _RETRY_AFTER_DEFAULT: int = 1
 
-    def __init__(self, cfg: Config = None, clock: Clock=None):
+    def __init__(self, cfg: Config = None, clock: Clock = None):
 
         if cfg is None:
             cfg = Config()

--- a/databricks/sdk/core.py
+++ b/databricks/sdk/core.py
@@ -23,16 +23,12 @@ class ApiClient:
     _cfg: Config
     _RETRY_AFTER_DEFAULT: int = 1
 
-    def __init__(self, cfg: Config = None, clock: Clock = None):
+    def __init__(self, cfg: Config = None):
 
         if cfg is None:
             cfg = Config()
 
-        if clock is None:
-            clock = RealClock()
-
         self._cfg = cfg
-        self._clock = clock
         # See https://github.com/databricks/databricks-sdk-go/blob/main/client/client.go#L34-L35
         self._debug_truncate_bytes = cfg.debug_truncate_bytes if cfg.debug_truncate_bytes else 96
         self._retry_timeout_seconds = cfg.retry_timeout_seconds if cfg.retry_timeout_seconds else 300
@@ -129,7 +125,7 @@ class ApiClient:
         headers['User-Agent'] = self._user_agent_base
         retryable = retried(timeout=timedelta(seconds=self._retry_timeout_seconds),
                             is_retryable=self._is_retryable,
-                            clock=self._clock)
+                            clock=self._cfg.clock)
         return retryable(self._perform)(method,
                                         path,
                                         query=query,

--- a/databricks/sdk/retries.py
+++ b/databricks/sdk/retries.py
@@ -1,9 +1,10 @@
 import functools
 import logging
-import time
 from datetime import timedelta
 from random import random
 from typing import Callable, Optional, Sequence, Type
+
+from .clock import Clock, RealClock
 
 logger = logging.getLogger(__name__)
 
@@ -11,20 +12,23 @@ logger = logging.getLogger(__name__)
 def retried(*,
             on: Sequence[Type[BaseException]] = None,
             is_retryable: Callable[[BaseException], Optional[str]] = None,
-            timeout=timedelta(minutes=20)):
+            timeout=timedelta(minutes=20),
+            clock: Clock=None):
     has_allowlist = on is not None
     has_callback = is_retryable is not None
     if not (has_allowlist or has_callback) or (has_allowlist and has_callback):
         raise SyntaxError('either on=[Exception] or callback=lambda x: .. is required')
+    if clock is None:
+        clock = RealClock()
 
     def decorator(func):
 
         @functools.wraps(func)
         def wrapper(*args, **kwargs):
-            deadline = time.time() + timeout.total_seconds()
+            deadline = clock.time() + timeout.total_seconds()
             attempt = 1
             last_err = None
-            while time.time() < deadline:
+            while clock.time() < deadline:
                 try:
                     return func(*args, **kwargs)
                 except Exception as err:
@@ -50,7 +54,7 @@ def retried(*,
                         raise err
 
                     logger.debug(f'Retrying: {retry_reason} (sleeping ~{sleep}s)')
-                    time.sleep(sleep + random())
+                    clock.sleep(sleep + random())
                     attempt += 1
             raise TimeoutError(f'Timed out after {timeout}') from last_err
 

--- a/databricks/sdk/retries.py
+++ b/databricks/sdk/retries.py
@@ -13,7 +13,7 @@ def retried(*,
             on: Sequence[Type[BaseException]] = None,
             is_retryable: Callable[[BaseException], Optional[str]] = None,
             timeout=timedelta(minutes=20),
-            clock: Clock=None):
+            clock: Clock = None):
     has_allowlist = on is not None
     has_callback = is_retryable is not None
     if not (has_allowlist or has_callback) or (has_allowlist and has_callback):

--- a/tests/clock.py
+++ b/tests/clock.py
@@ -1,0 +1,14 @@
+from databricks.sdk.clock import Clock
+
+class FakeClock(Clock):
+    """
+    A simple clock that can be used to mock time in tests.
+    """
+    def __init__(self, start_time: float = 0.0):
+        self._start_time = start_time
+
+    def time(self) -> float:
+        return self._start_time
+
+    def sleep(self, seconds: float) -> None:
+        self._start_time += seconds

--- a/tests/clock.py
+++ b/tests/clock.py
@@ -1,9 +1,11 @@
 from databricks.sdk.clock import Clock
 
+
 class FakeClock(Clock):
     """
     A simple clock that can be used to mock time in tests.
     """
+
     def __init__(self, start_time: float = 0.0):
         self._start_time = start_time
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -26,8 +26,8 @@ from databricks.sdk.service.catalog import PermissionsChange
 from databricks.sdk.service.iam import AccessControlRequest
 from databricks.sdk.version import __version__
 
-from .conftest import noop_credentials
 from .clock import FakeClock
+from .conftest import noop_credentials
 
 
 def test_parse_dsn():

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -423,7 +423,7 @@ def test_http_retry_after(status_code, include_retry_after):
         requests.append(h.requestline)
 
     with http_fixture_server(inner) as host:
-        api_client = ApiClient(Config(host=host, token='_'), clock=FakeClock())
+        api_client = ApiClient(Config(host=host, token='_', clock=FakeClock()))
         res = api_client.do('GET', '/foo')
         assert 'foo' in res
 
@@ -446,7 +446,7 @@ def test_http_retry_after_wrong_format():
         requests.append(h.requestline)
 
     with http_fixture_server(inner) as host:
-        api_client = ApiClient(Config(host=host, token='_'), clock=FakeClock())
+        api_client = ApiClient(Config(host=host, token='_', clock=FakeClock()))
         res = api_client.do('GET', '/foo')
         assert 'foo' in res
 
@@ -463,7 +463,7 @@ def test_http_retried_exceed_limit():
         requests.append(h.requestline)
 
     with http_fixture_server(inner) as host:
-        api_client = ApiClient(Config(host=host, token='_', retry_timeout_seconds=1), clock=FakeClock())
+        api_client = ApiClient(Config(host=host, token='_', retry_timeout_seconds=1, clock=FakeClock()))
         with pytest.raises(TimeoutError):
             api_client.do('GET', '/foo')
 
@@ -485,7 +485,7 @@ def test_http_retried_on_match():
         requests.append(h.requestline)
 
     with http_fixture_server(inner) as host:
-        api_client = ApiClient(Config(host=host, token='_'), clock=FakeClock())
+        api_client = ApiClient(Config(host=host, token='_', clock=FakeClock()))
         res = api_client.do('GET', '/foo')
         assert 'foo' in res
 
@@ -503,7 +503,7 @@ def test_http_not_retried_on_normal_errors():
         requests.append(h.requestline)
 
     with http_fixture_server(inner) as host:
-        api_client = ApiClient(Config(host=host, token='_'), clock=FakeClock())
+        api_client = ApiClient(Config(host=host, token='_', clock=FakeClock()))
         with pytest.raises(DatabricksError):
             api_client.do('GET', '/foo')
 
@@ -521,7 +521,7 @@ def test_http_retried_on_connection_error():
         requests.append(h.requestline)
 
     with http_fixture_server(inner) as host:
-        api_client = ApiClient(Config(host=host, token='_'), clock=FakeClock())
+        api_client = ApiClient(Config(host=host, token='_', clock=FakeClock()))
         res = api_client.do('GET', '/foo')
         assert 'foo' in res
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -27,6 +27,7 @@ from databricks.sdk.service.iam import AccessControlRequest
 from databricks.sdk.version import __version__
 
 from .conftest import noop_credentials
+from .clock import FakeClock
 
 
 def test_parse_dsn():
@@ -422,7 +423,7 @@ def test_http_retry_after(status_code, include_retry_after):
         requests.append(h.requestline)
 
     with http_fixture_server(inner) as host:
-        api_client = ApiClient(Config(host=host, token='_'))
+        api_client = ApiClient(Config(host=host, token='_'), clock=FakeClock())
         res = api_client.do('GET', '/foo')
         assert 'foo' in res
 
@@ -445,7 +446,7 @@ def test_http_retry_after_wrong_format():
         requests.append(h.requestline)
 
     with http_fixture_server(inner) as host:
-        api_client = ApiClient(Config(host=host, token='_'))
+        api_client = ApiClient(Config(host=host, token='_'), clock=FakeClock())
         res = api_client.do('GET', '/foo')
         assert 'foo' in res
 
@@ -462,7 +463,7 @@ def test_http_retried_exceed_limit():
         requests.append(h.requestline)
 
     with http_fixture_server(inner) as host:
-        api_client = ApiClient(Config(host=host, token='_', retry_timeout_seconds=1))
+        api_client = ApiClient(Config(host=host, token='_', retry_timeout_seconds=1), clock=FakeClock())
         with pytest.raises(TimeoutError):
             api_client.do('GET', '/foo')
 
@@ -484,7 +485,7 @@ def test_http_retried_on_match():
         requests.append(h.requestline)
 
     with http_fixture_server(inner) as host:
-        api_client = ApiClient(Config(host=host, token='_'))
+        api_client = ApiClient(Config(host=host, token='_'), clock=FakeClock())
         res = api_client.do('GET', '/foo')
         assert 'foo' in res
 
@@ -502,7 +503,7 @@ def test_http_not_retried_on_normal_errors():
         requests.append(h.requestline)
 
     with http_fixture_server(inner) as host:
-        api_client = ApiClient(Config(host=host, token='_'))
+        api_client = ApiClient(Config(host=host, token='_'), clock=FakeClock())
         with pytest.raises(DatabricksError):
             api_client.do('GET', '/foo')
 
@@ -520,7 +521,7 @@ def test_http_retried_on_connection_error():
         requests.append(h.requestline)
 
     with http_fixture_server(inner) as host:
-        api_client = ApiClient(Config(host=host, token='_'))
+        api_client = ApiClient(Config(host=host, token='_'), clock=FakeClock())
         res = api_client.do('GET', '/foo')
         assert 'foo' in res
 

--- a/tests/test_retries.py
+++ b/tests/test_retries.py
@@ -4,6 +4,7 @@ import pytest
 
 from databricks.sdk.errors import NotFound, ResourceDoesNotExist
 from databricks.sdk.retries import retried
+from tests.clock import FakeClock
 
 
 def test_match_retry_condition_on_no_qualifier():
@@ -17,7 +18,7 @@ def test_match_retry_condition_on_no_qualifier():
 def test_match_retry_condition_on_conflict():
     with pytest.raises(SyntaxError):
 
-        @retried(on=[IOError], is_retryable=lambda _: 'always')
+        @retried(on=[IOError], is_retryable=lambda _: 'always', clock=FakeClock())
         def foo():
             return 1
 
@@ -25,7 +26,7 @@ def test_match_retry_condition_on_conflict():
 def test_match_retry_always():
     with pytest.raises(TimeoutError):
 
-        @retried(is_retryable=lambda _: 'always', timeout=timedelta(seconds=1))
+        @retried(is_retryable=lambda _: 'always', timeout=timedelta(seconds=1), clock=FakeClock())
         def foo():
             raise StopIteration()
 
@@ -35,7 +36,7 @@ def test_match_retry_always():
 def test_match_on_errors():
     with pytest.raises(TimeoutError):
 
-        @retried(on=[KeyError, AttributeError], timeout=timedelta(seconds=0.5))
+        @retried(on=[KeyError, AttributeError], timeout=timedelta(seconds=0.5), clock=FakeClock())
         def foo():
             raise KeyError(1)
 
@@ -45,7 +46,7 @@ def test_match_on_errors():
 def test_match_on_subclass():
     with pytest.raises(TimeoutError):
 
-        @retried(on=[NotFound], timeout=timedelta(seconds=0.5))
+        @retried(on=[NotFound], timeout=timedelta(seconds=0.5), clock=FakeClock())
         def foo():
             raise ResourceDoesNotExist(...)
 
@@ -55,7 +56,7 @@ def test_match_on_subclass():
 def test_propagates_outside_exception():
     with pytest.raises(KeyError):
 
-        @retried(on=[AttributeError], timeout=timedelta(seconds=0.5))
+        @retried(on=[AttributeError], timeout=timedelta(seconds=0.5), clock=FakeClock())
         def foo():
             raise KeyError(1)
 


### PR DESCRIPTION
## Changes
Some unit tests of retry logic are slow because they sleep for a second or two. This PR changes ApiClient to accept a Clock which supplies the time for retries and waiting. In unit tests, we use a fake clock that doesn't tick until sleep() is called, and then ticks by the amount provided.

## Tests
Existing unit tests.

- [ ] `make test` run locally
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

