### PR TITLE
Remove bad generation

### DIFF
--- a/examples/r/wait_catalog_workspace_bindings.py
+++ b/examples/r/wait_catalog_workspace_bindings.py
@@ -1,5 +1,0 @@
-from databricks.sdk import WorkspaceClient
-
-w = WorkspaceClient()
-
-w.r.wait(update_function)


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
`w.r.wait(update_function)` is wrong and shouldn't be part of generated code. Not sure why it was generated, using the latest SDK (v0.31.0) deco tool is failing generation.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

