### PR TITLE
Create a deepcopy of config when creating workspace client from account client

### DIFF
--- a/databricks/sdk/__init__.py
+++ b/databricks/sdk/__init__.py
@@ -809,7 +809,7 @@ class AccountClient:
         :param workspace: The workspace to construct a client for.
         :return: A ``WorkspaceClient`` for the given workspace.
         """
-        config = self._config.copy()
+        config = self._config.deep_copy()
         config.host = config.environment.deployment_url(workspace.deployment_name)
         config.azure_workspace_resource_id = azure.get_azure_resource_id(workspace)
         config.account_id = None

--- a/databricks/sdk/config.py
+++ b/databricks/sdk/config.py
@@ -462,4 +462,3 @@ class Config:
         """Creates a deep copy of the config object.
         """
         return copy.deepcopy(self)
-        

--- a/databricks/sdk/config.py
+++ b/databricks/sdk/config.py
@@ -457,3 +457,9 @@ class Config:
         cpy: Config = copy.copy(self)
         cpy._user_agent_other_info = copy.deepcopy(self._user_agent_other_info)
         return cpy
+
+    def deep_copy(self):
+        """Creates a deep copy of the config object.
+        """
+        return copy.deepcopy(self)
+        

--- a/databricks/sdk/core.py
+++ b/databricks/sdk/core.py
@@ -142,7 +142,12 @@ class ApiClient:
             resp[header] = response.headers.get(Casing.to_header_case(header))
         if not len(response.content):
             return resp
-        return {**resp, **response.json()}
+
+        json = response.json()
+        if isinstance(json, list):
+            return json
+
+        return {**resp, **json}
 
     @staticmethod
     def _is_retryable(err: BaseException) -> Optional[str]:

--- a/tests/integration/test_client.py
+++ b/tests/integration/test_client.py
@@ -17,8 +17,6 @@ def test_get_workspace_id(ucws, env_or_skip):
 
 
 def test_creating_ws_client_from_ac_client_does_not_override_config(a):
-    if a.config.is_azure or a.config.is_gcp:
-        pytest.skip('Not available on Azure and GCP currently')
     wss = list(a.workspaces.list())
     if len(wss) == 0:
         pytest.skip("no workspaces")

--- a/tests/integration/test_client.py
+++ b/tests/integration/test_client.py
@@ -14,3 +14,15 @@ def test_get_workspace_client(a):
 def test_get_workspace_id(ucws, env_or_skip):
     ws_id = int(env_or_skip('THIS_WORKSPACE_ID'))
     assert ucws.get_workspace_id() == ws_id
+
+
+def test_creating_ws_client_from_ac_client_does_not_override_config(a):
+    if a.config.is_azure or a.config.is_gcp:
+        pytest.skip('Not available on Azure and GCP currently')
+    wss = list(a.workspaces.list())
+    if len(wss) == 0:
+        pytest.skip("no workspaces")
+    a.get_workspace_client(wss[0])
+
+    # assert doesn't throw
+    wss = list(a.workspaces.list())


### PR DESCRIPTION
## Changes
* We are creating a shallow copy of the config object when creating a ws client from acc client. This leads to the config of acc client being overridden by changes made for the workspace client. This PR makes it so that we are making a deepcopy instead. 
* Also, correctly handle list response jsons in the API client. 

## Tests
* added integration test

- [ ] `make test` run locally
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

