### PR TITLE
Add get_workspace_id to docgen blocklist

### DIFF
--- a/docs/gen-client-docs.py
+++ b/docs/gen-client-docs.py
@@ -278,7 +278,7 @@ class Generator:
 
     def service_docs(self, client_inst) -> list[ServiceDoc]:
         client_prefix = 'w' if isinstance(client_inst, WorkspaceClient) else 'a'
-        ignore_client_fields = ('config', 'dbutils', 'api_client', 'files', 'get_workspace_client')
+        ignore_client_fields = ('config', 'dbutils', 'api_client', 'files', 'get_workspace_client', 'get_workspace_id')
         all = []
         for service_name, service_inst in inspect.getmembers(client_inst):
             if service_name.startswith('_'):


### PR DESCRIPTION
## Changes
Doc generation is done automatically for all services in the `WorkspaceClient` and `AccountClient` classes. However, `get_workspace_id()` does not need to go through the same process, as its docs will appear on the `WorkspaceClient` doc page anyways: https://databricks-sdk-py--549.org.readthedocs.build/en/549/clients/workspace.html#databricks.sdk.WorkspaceClient.get_workspace_id.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

