### PR TITLE
Fix integer deserialization for headers

### DIFF
--- a/.codegen/service.py.tmpl
+++ b/.codegen/service.py.tmpl
@@ -58,6 +58,7 @@ class {{.PascalName}}{{if eq "List" .PascalName}}Request{{end}}:{{if .Descriptio
 		{{- else}}d.get('{{.Name}}', None){{- end -}}
 	{{- else if (or .Entity.IsObject .Entity.IsExternal) }}_from_dict(d, '{{.Name}}', {{template "type-nq" .Entity}})
 	{{- else if .Entity.Enum }}_enum(d, '{{.Name}}', {{template "type-nq" .Entity}})
+	{{- else if and .IsHeader (or .Entity.IsInt64 .Entity.IsInt) }} int(d.get('{{.Name}}', None))
 	{{- else}}d.get('{{.Name}}', None){{- end -}}
 {{- end -}}
 {{- define "as_request_type" -}}

--- a/databricks/sdk/service/files.py
+++ b/databricks/sdk/service/files.py
@@ -171,7 +171,7 @@ class DownloadResponse:
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> DownloadResponse:
         """Deserializes the DownloadResponse from a dictionary."""
-        return cls(content_length=d.get('content-length', None),
+        return cls(content_length=int(d.get('content-length', None)),
                    content_type=d.get('content-type', None),
                    contents=d.get('contents', None),
                    last_modified=d.get('last-modified', None))
@@ -228,7 +228,7 @@ class GetMetadataResponse:
     @classmethod
     def from_dict(cls, d: Dict[str, any]) -> GetMetadataResponse:
         """Deserializes the GetMetadataResponse from a dictionary."""
-        return cls(content_length=d.get('content-length', None),
+        return cls(content_length=int(d.get('content-length', None)),
                    content_type=d.get('content-type', None),
                    last_modified=d.get('last-modified', None))
 


### PR DESCRIPTION
## Changes
Fix integer deserialization for headers. Headers are always serialized as strings by Http convention, so we need to cast on deserialization.

## Tests
Used the new tests for files API
https://github.com/databricks/databricks-sdk-py/pull/552/files


