### PR TITLE
Sort index pages by name in docs

### DIFF
--- a/docs/account/index.rst
+++ b/docs/account/index.rst
@@ -7,9 +7,9 @@ These APIs are available from AccountClient
 .. toctree::
    :maxdepth: 1
 
-   iam/index
-   catalog/index
-   settings/index
-   provisioning/index
    billing/index
+   catalog/index
+   iam/index
    oauth2/index
+   provisioning/index
+   settings/index

--- a/docs/dbdataclasses/index.rst
+++ b/docs/dbdataclasses/index.rst
@@ -5,20 +5,20 @@ Dataclasses
 .. toctree::
    :maxdepth: 1
    
-   workspace
-   compute
-   jobs
-   pipelines
-   files
-   ml
-   serving
-   iam
-   sql
-   catalog
-   sharing
-   settings
-   provisioning
    billing
-   oauth2
-   vectorsearch
+   catalog
+   compute
    dashboards
+   files
+   iam
+   jobs
+   ml
+   oauth2
+   pipelines
+   provisioning
+   serving
+   settings
+   sharing
+   sql
+   vectorsearch
+   workspace

--- a/docs/gen-client-docs.py
+++ b/docs/gen-client-docs.py
@@ -330,7 +330,7 @@ class Generator:
             doc = DataclassesDoc(package=pkg, dataclasses=sorted(all_members))
             with open(f'{__dir__}/dbdataclasses/{pkg.name}.rst', 'w') as f:
                 f.write(doc.as_rst())
-        all = "\n   ".join([f'{p.name}' for p in self.packages])
+        all = "\n   ".join(sorted([p.name for p in self.packages]))
         with open(f'{__dir__}/dbdataclasses/index.rst', 'w') as f:
             f.write(f'''
 Dataclasses
@@ -374,7 +374,7 @@ Dataclasses
         """Writes out the top-level index for the APIs supported by a client."""
         self._make_folder_if_not_exists(f'{__dir__}/{folder}')
         with open(f'{__dir__}/{folder}/index.rst', 'w') as f:
-            all = "\n   ".join([f'{name}/index' for name in packages])
+            all = "\n   ".join([f'{name}/index' for name in sorted(packages)])
             f.write(f'''
 {label}
 {'=' * len(label)}
@@ -390,7 +390,7 @@ Dataclasses
         """Writes out the index for a single package supported by a client."""
         self._make_folder_if_not_exists(f'{__dir__}/{folder}/{pkg.name}')
         with open(f'{__dir__}/{folder}/{pkg.name}/index.rst', 'w') as f:
-            all = "\n   ".join(services)
+            all = "\n   ".join(sorted(services))
             f.write(f'''
 {pkg.label}
 {'=' * len(pkg.label)}

--- a/docs/workspace/index.rst
+++ b/docs/workspace/index.rst
@@ -7,17 +7,17 @@ These APIs are available from WorkspaceClient
 .. toctree::
    :maxdepth: 1
 
-   workspace/index
-   compute/index
-   jobs/index
-   pipelines/index
-   files/index
-   ml/index
-   serving/index
-   iam/index
-   sql/index
    catalog/index
-   sharing/index
-   settings/index
-   vectorsearch/index
+   compute/index
    dashboards/index
+   files/index
+   iam/index
+   jobs/index
+   ml/index
+   pipelines/index
+   serving/index
+   settings/index
+   sharing/index
+   sql/index
+   vectorsearch/index
+   workspace/index


### PR DESCRIPTION
## Changes
The indices under the APIs and Dataclasses pages were not sorted, resulting in them being shown in an unexpected/random order. This fixes this so they are shown alphabetically.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

