### PR TITLE
Use all-apis scope with external-browser

### DIFF
--- a/databricks/sdk/oauth.py
+++ b/databricks/sdk/oauth.py
@@ -366,7 +366,7 @@ class OAuthClient:
 
         config = Config(host=host, credentials_provider=noop_credentials)
         if not scopes:
-            scopes = ['offline_access', 'all-apis']
+            scopes = ['all-apis']
         if config.is_azure:
             # Azure AD only supports full access to Azure Databricks.
             scopes = [f'{config.effective_azure_login_app_id}/user_impersonation', 'offline_access']

--- a/databricks/sdk/oauth.py
+++ b/databricks/sdk/oauth.py
@@ -366,7 +366,7 @@ class OAuthClient:
 
         config = Config(host=host, credentials_provider=noop_credentials)
         if not scopes:
-            scopes = ['offline_access', 'clusters', 'sql']
+            scopes = ['offline_access', 'all-apis']
         if config.is_azure:
             # Azure AD only supports full access to Azure Databricks.
             scopes = [f'{config.effective_azure_login_app_id}/user_impersonation', 'offline_access']


### PR DESCRIPTION
## Changes
For all OAuth flows, we pretty much only support the `all-apis` scope now. This fixes `external-browser` credentials provider to use this scope, as the other scopes there do not work.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

