### PR TITLE
Add `with_library(product, version)` to track usage of each upstream library separately

### DIFF
--- a/databricks/sdk/__init__.py
+++ b/databricks/sdk/__init__.py
@@ -215,6 +215,11 @@ class WorkspaceClient:
         self._workspace_bindings = WorkspaceBindingsAPI(self._api_client)
         self._workspace_conf = WorkspaceConfAPI(self._api_client)
 
+    def with_library(self, product: str, version: str) -> 'WorkspaceClient':
+        config = self._config.with_library(product, version)
+        # TODO: same for AccountClient & codegen
+        return WorkspaceClient(config=config)
+
     @property
     def config(self) -> client.Config:
         return self._config

--- a/databricks/sdk/config.py
+++ b/databricks/sdk/config.py
@@ -251,6 +251,11 @@ class Config:
         self._user_agent_other_info.append(f"{key}/{value}")
         return self
 
+    def with_library(self, product: str, version: str) -> 'Config':
+        config_copy = self.copy()
+        config_copy.with_user_agent_extra(product, version)
+        return config_copy
+
     @property
     def oidc_endpoints(self) -> Optional[OidcEndpoints]:
         self._fix_host_if_needed()


### PR DESCRIPTION
This PR adds `with_library(product, version)` method to clients & config, creating a copy with the user-agent extra propagated only for the relevant calls

