### PR TITLE
Fix QueryHistoryAPI.list()

### DIFF
--- a/databricks/sdk/service/sql.py
+++ b/databricks/sdk/service/sql.py
@@ -4702,7 +4702,7 @@ class QueryHistoryAPI:
             if 'res' in json:
                 for v in json['res']:
                     yield QueryInfo.from_dict(v)
-            if 'next_page_token' not in json or not json['next_page_token']:
+            if 'next_page_token' not in json or not json['next_page_token'] or json['next_page_token'] == query.get('page_token'):
                 return
             query['page_token'] = json['next_page_token']
 


### PR DESCRIPTION
## Changes
Adds additional check for same `page_token` because that seems to have been an issue causing it to hang in our environment.

## Tests
I didn't, except for running it on our environment and I'm too lazy to add proper tests.

- [ ] `make test` run locally
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

