### PR TITLE
Fix typos in doc string for select_spark_version

### DIFF
--- a/databricks/sdk/mixins/compute.py
+++ b/databricks/sdk/mixins/compute.py
@@ -87,8 +87,8 @@ class ClustersExt(compute.ClustersAPI):
         :param latest: bool
         :param ml: bool
         :param gpu: bool
-        :param scala: bool
-        :param spark_version: bool
+        :param scala: str
+        :param spark_version: str
         :param photon: bool
         :param graviton: bool
 


### PR DESCRIPTION
## Changes
Fix typos for argument types for the `select_spark_version` method. e.g. `spark_version` should be a string.

## Tests
Docs only

- [ ] `make test` run locally
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

