### PR TITLE
Fix type issue with widgets.getArgument

### DIFF
--- a/databricks/sdk/runtime/dbutils_stub.py
+++ b/databricks/sdk/runtime/dbutils_stub.py
@@ -288,7 +288,7 @@ class dbutils:
             ...
 
         @staticmethod
-        def getArgument(name: str, defaultValue: typing.Optional[str] = None) -> str | None:
+        def getArgument(name: str, defaultValue: typing.Optional[str] = None) -> typing.Optional[str]:
             """Returns the current value of a widget with give name.
             :param name: Name of the argument to be accessed
             :param defaultValue: (Deprecated) default value


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
- The `str | None` used previously doesn't work with older version of python, fixing it so that it unblocks integration test and release

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] `make fmt` applied
- [x] relevant integration tests applied

