### PR TITLE
Add proper URL encoding for upload and download

### DIFF
--- a/tests/integration/test_files.py
+++ b/tests/integration/test_files.py
@@ -225,6 +225,19 @@ def test_files_api_upload_download(ucws, random):
                 assert f.read() == b"some text data"
 
 
+def test_files_api_upload_download_url_encode(ucws, random):
+    w = ucws
+    schema = 'filesit-' + random()
+    volume = 'filesit-' + random()
+    with ResourceWithCleanup.create_schema(w, 'main', schema):
+        with ResourceWithCleanup.create_volume(w, 'main', schema, volume):
+            f = io.BytesIO(b"some text data")
+            target_file = f'/Volumes/main/{schema}/{volume}/filesit?#-{random()}.txt'
+            w.files.upload(target_file, f)
+            with w.files.download(target_file).contents as f:
+                assert f.read() == b"some text data"
+
+
 def test_files_api_read_twice_from_one_download(ucws, random):
     w = ucws
     schema = 'filesit-' + random()


### PR DESCRIPTION
## Changes
URL encode the file path before making the API request. This prevents issues with file paths that include characters like `?` and `#`.

I only added to `upload` and `download` because those are the APIs I am using and could easily test, but happy to add to other places if the change seems ok and you'd like it in other places too.

## Tests
 I manually tested upload/download with a file named `file with #? hi.txt`.
 
 I also added integration tests, although I'm not entirely sure how to run them. Hoping they run in CI?

- [ ] `make test` run locally
- [x] `make fmt` applied
- [ ] relevant integration tests applied

