### PR TITLE
Properly escape multi-segment path parameters

### DIFF
--- a/.codegen/service.py.tmpl
+++ b/.codegen/service.py.tmpl
@@ -9,7 +9,7 @@ import time
 import random
 import logging
 from ..errors import OperationTimeout, OperationFailed
-from ._internal import _enum, _from_dict, _repeated_dict, _repeated_enum, Wait
+from ._internal import _enum, _from_dict, _repeated_dict, _repeated_enum, Wait, _escape_multi_segment_path_parameter
 
 _LOG = logging.getLogger('databricks.sdk')
 
@@ -325,9 +325,7 @@ class {{.PascalName}}API:{{if .Description}}
 
 {{define "method-do" -}}
 self._api.do('{{.Verb}}',
-  {{if .PathParts -}}
-      f'{{range  .PathParts}}{{.Prefix}}{{if .Field}}{{"{"}}{{template "safe-snake-name" .Field}}{{with .Field.Entity.Enum}}.value{{end}}{{"}"}}{{else if .IsAccountId}}{{"{self._api.account_id}"}}{{end}}{{ end }}'
-  {{- else}}'{{.Path}}'{{end}}
+  {{ template "path" . }}
   {{if .Request}}
       {{- if .Request.HasQueryField}}, query=query{{end}}
       {{- if .Request.MapValue}}, body=contents
@@ -340,6 +338,31 @@ self._api.do('{{.Verb}}',
   {{- if and .IsRequestByteStream .RequestBodyField }}, data={{template "safe-snake-name" .RequestBodyField}}{{ end }}
   {{- if .IsResponseByteStream }}, raw=True{{ end }})
 {{- end}}
+
+{{- define "path" -}}
+{{- if .PathParts -}}
+  f'{{range  .PathParts -}}
+    {{- .Prefix -}}
+    {{- if .Field -}}
+      {{- "{" -}}
+      {{- if .Field.IsPathMultiSegment -}}_escape_multi_segment_path_parameter({{ template "path-parameter" . }})
+      {{- else -}}{{ template "path-parameter" . }}
+      {{- end -}}
+      {{- "}" -}}
+    {{- else if .IsAccountId}}
+      {{- "{" -}}
+      self._api.account_id
+      {{- "}" -}}
+    {{- end -}}
+  {{- end }}'
+{{- else -}}
+  '{{.Path}}'
+{{- end -}}
+{{- end -}}
+
+{{- define "path-parameter" -}}
+  {{template "safe-snake-name" .Field}}{{with .Field.Entity.Enum}}.value{{end}}
+{{- end -}}
 
 {{define "method-return-type" -}}
   {{if and .Wait (and (not .IsCrudRead) (not (eq .SnakeName "get_run"))) }} -> Wait[{{.Wait.Poll.Response.PascalName}}]

--- a/databricks/sdk/service/_internal.py
+++ b/databricks/sdk/service/_internal.py
@@ -1,5 +1,6 @@
 import datetime
 from typing import Callable, Dict, Generic, Optional, Type, TypeVar
+import urllib.parse
 
 
 def _from_dict(d: Dict[str, any], field: str, cls: Type) -> any:
@@ -36,6 +37,10 @@ def _repeated_enum(d: Dict[str, any], field: str, cls: Type) -> any:
         if val:
             res.append(val)
     return res
+
+
+def _escape_multi_segment_path_parameter(param: str) -> str:
+    return urllib.parse.quote(param)
 
 
 ReturnType = TypeVar('ReturnType')

--- a/databricks/sdk/service/_internal.py
+++ b/databricks/sdk/service/_internal.py
@@ -1,6 +1,6 @@
 import datetime
-from typing import Callable, Dict, Generic, Optional, Type, TypeVar
 import urllib.parse
+from typing import Callable, Dict, Generic, Optional, Type, TypeVar
 
 
 def _from_dict(d: Dict[str, any], field: str, cls: Type) -> any:

--- a/databricks/sdk/service/files.py
+++ b/databricks/sdk/service/files.py
@@ -6,7 +6,7 @@ import logging
 from dataclasses import dataclass
 from typing import BinaryIO, Dict, Iterator, List, Optional
 
-from ._internal import _repeated_dict
+from ._internal import _escape_multi_segment_path_parameter, _repeated_dict
 
 _LOG = logging.getLogger('databricks.sdk')
 
@@ -789,7 +789,9 @@ class FilesAPI:
 
         headers = {}
 
-        self._api.do('PUT', f'/api/2.0/fs/directories{directory_path}', headers=headers)
+        self._api.do('PUT',
+                     f'/api/2.0/fs/directories{_escape_multi_segment_path_parameter(directory_path)}',
+                     headers=headers)
 
     def delete(self, file_path: str):
         """Delete a file.
@@ -804,7 +806,9 @@ class FilesAPI:
 
         headers = {}
 
-        self._api.do('DELETE', f'/api/2.0/fs/files{file_path}', headers=headers)
+        self._api.do('DELETE',
+                     f'/api/2.0/fs/files{_escape_multi_segment_path_parameter(file_path)}',
+                     headers=headers)
 
     def delete_directory(self, directory_path: str):
         """Delete a directory.
@@ -822,7 +826,9 @@ class FilesAPI:
 
         headers = {}
 
-        self._api.do('DELETE', f'/api/2.0/fs/directories{directory_path}', headers=headers)
+        self._api.do('DELETE',
+                     f'/api/2.0/fs/directories{_escape_multi_segment_path_parameter(directory_path)}',
+                     headers=headers)
 
     def download(self, file_path: str) -> DownloadResponse:
         """Download a file.
@@ -839,7 +845,7 @@ class FilesAPI:
         headers = {'Accept': 'application/octet-stream', }
         response_headers = ['content-length', 'content-type', 'last-modified', ]
         res = self._api.do('GET',
-                           f'/api/2.0/fs/files{file_path}',
+                           f'/api/2.0/fs/files{_escape_multi_segment_path_parameter(file_path)}',
                            headers=headers,
                            response_headers=response_headers,
                            raw=True)
@@ -864,7 +870,9 @@ class FilesAPI:
 
         headers = {}
 
-        self._api.do('HEAD', f'/api/2.0/fs/directories{directory_path}', headers=headers)
+        self._api.do('HEAD',
+                     f'/api/2.0/fs/directories{_escape_multi_segment_path_parameter(directory_path)}',
+                     headers=headers)
 
     def get_metadata(self, file_path: str) -> GetMetadataResponse:
         """Get file metadata.
@@ -880,7 +888,7 @@ class FilesAPI:
         headers = {}
         response_headers = ['content-length', 'content-type', 'last-modified', ]
         res = self._api.do('HEAD',
-                           f'/api/2.0/fs/files{file_path}',
+                           f'/api/2.0/fs/files{_escape_multi_segment_path_parameter(file_path)}',
                            headers=headers,
                            response_headers=response_headers)
         return GetMetadataResponse.from_dict(res)
@@ -924,10 +932,11 @@ class FilesAPI:
         headers = {'Accept': 'application/json', }
 
         while True:
-            json = self._api.do('GET',
-                                f'/api/2.0/fs/directories{directory_path}',
-                                query=query,
-                                headers=headers)
+            json = self._api.do(
+                'GET',
+                f'/api/2.0/fs/directories{_escape_multi_segment_path_parameter(directory_path)}',
+                query=query,
+                headers=headers)
             if 'contents' in json:
                 for v in json['contents']:
                     yield DirectoryEntry.from_dict(v)
@@ -956,4 +965,8 @@ class FilesAPI:
         if overwrite is not None: query['overwrite'] = overwrite
         headers = {'Content-Type': 'application/octet-stream', }
 
-        self._api.do('PUT', f'/api/2.0/fs/files{file_path}', query=query, headers=headers, data=contents)
+        self._api.do('PUT',
+                     f'/api/2.0/fs/files{_escape_multi_segment_path_parameter(file_path)}',
+                     query=query,
+                     headers=headers,
+                     data=contents)

--- a/tests/integration/test_files.py
+++ b/tests/integration/test_files.py
@@ -219,7 +219,7 @@ def test_files_api_upload_download(ucws, random):
     with ResourceWithCleanup.create_schema(w, 'main', schema):
         with ResourceWithCleanup.create_volume(w, 'main', schema, volume):
             f = io.BytesIO(b"some text data")
-            target_file = f'/Volumes/main/{schema}/{volume}/filesit-{random()}.txt'
+            target_file = f'/Volumes/main/{schema}/{volume}/filesit-with-?-and-#-{random()}.txt'
             w.files.upload(target_file, f)
             with w.files.download(target_file).contents as f:
                 assert f.read() == b"some text data"

--- a/tests/test_internal.py
+++ b/tests/test_internal.py
@@ -1,8 +1,9 @@
 from dataclasses import dataclass
 from enum import Enum
 
-from databricks.sdk.service._internal import (_enum, _from_dict,
-                                              _repeated_dict, _repeated_enum, _escape_multi_segment_path_parameter)
+from databricks.sdk.service._internal import (
+    _enum, _escape_multi_segment_path_parameter, _from_dict, _repeated_dict,
+    _repeated_enum)
 
 
 class A(Enum):

--- a/tests/test_internal.py
+++ b/tests/test_internal.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from enum import Enum
 
 from databricks.sdk.service._internal import (_enum, _from_dict,
-                                              _repeated_dict, _repeated_enum)
+                                              _repeated_dict, _repeated_enum, _escape_multi_segment_path_parameter)
 
 
 class A(Enum):
@@ -41,3 +41,10 @@ def test_from_dict():
 
 def test_repeated_dict():
     assert _repeated_dict({'x': [{'field': 'a'}, {'field': 'c'}]}, 'x', B) == [B('a'), B('c')]
+
+
+def test_escape_multi_segment_path_parameter():
+    assert _escape_multi_segment_path_parameter('a b') == 'a%20b'
+    assert _escape_multi_segment_path_parameter('a/b') == 'a/b'
+    assert _escape_multi_segment_path_parameter('a?b') == 'a%3Fb'
+    assert _escape_multi_segment_path_parameter('a#b') == 'a%23b'


### PR DESCRIPTION
## Changes
Ports https://github.com/databricks/databricks-sdk-go/pull/869 to Python SDK. Subsumes #592.

Currently, path parameters are directly interpolated into the request URL without escaping. This means that characters like /, ? and # will not be percent-encoded and will affect the semantics of the URL, starting a new path segment, query parameters, or fragment, respectively. This means that it is impossible for users of the Files API to upload/download objects that contain ? or # in their name. / is allowed in the path of the Files API, so it does not need to be escaped.

The Files API is currently marked with x-databricks-multi-segment, indicating that it should be permitted to have / characters but other characters need to be percent-encoded. This PR implements this.

## Tests

- [x] Unit test for multi-segment path escaping behavior.
- [x] Updated integration test to use # and ? symbols in the file name. This failed on main but succeeded on this PR.
