### PR TITLE
Fix scopes in OAuthClient with using model serving on Azure

### DIFF
--- a/databricks/sdk/oauth.py
+++ b/databricks/sdk/oauth.py
@@ -369,7 +369,8 @@ class OAuthClient:
             scopes = ['all-apis']
         if config.is_azure:
             # Azure AD only supports full access to Azure Databricks.
-            scopes = [f'{config.effective_azure_login_app_id}/user_impersonation', 'offline_access']
+            # Append necessary additional scopes if not already present.
+            scopes = list(set(scopes + [f'{config.effective_azure_login_app_id}/user_impersonation', 'offline_access']))
         oidc = config.oidc_endpoints
         if not oidc:
             raise ValueError(f'{host} does not support OAuth')


### PR DESCRIPTION
## Changes
If the application instantiating an instance of OAuthClient is using Azure, full access to Azure Databricks is required. So the scope list must include '{effective_azure_login_app_id}/user_impersonation' and 'offline_access'. However, the scopes were set to these instead of appending to any existing scopes that may be been in the list. In the case of calling a model serving endpoint, scope 'all-apis' is also needed.

Changed the line to **append** the additional Azure-required scopes if not already present in the list rather than **set**.

## Tests
Tested using https://github.com/sdonohoo-db/model-serving-oauth/blob/main/U2M/flask_app_with_oauth.py sample client adapted from https://github.com/databricks/databricks-sdk-py/blob/main/examples/flask_app_with_oauth.py to demonstrate using U2M OAuth with model serving.

- [ ] `make test` run locally
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

