### PR TITLE
Fix row_filter name returned from API

### DIFF
--- a/databricks/sdk/service/catalog.py
+++ b/databricks/sdk/service/catalog.py
@@ -4583,8 +4583,8 @@ class TableInfo:
 
 @dataclass
 class TableRowFilter:
-    name: str
-    """The full name of the row filter SQL UDF."""
+    function_name: str
+    """The full function name of the row filter SQL UDF."""
 
     input_column_names: List[str]
     """The list of table columns to be passed as input to the row filter function. The column types
@@ -4594,7 +4594,7 @@ class TableRowFilter:
         """Serializes the TableRowFilter into a dictionary suitable for use as a JSON request body."""
         body = {}
         if self.input_column_names: body['input_column_names'] = [v for v in self.input_column_names]
-        if self.name is not None: body['name'] = self.name
+        if self.function_name is not None: body['function_name'] = self.function_name
         return body
 
     @classmethod


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

Databricks `/api/2.1/unity-catalog/tables/{full_name}` API actually returns `function_name` for `row_filters` and not name as described in the docs.

![image](https://github.com/databricks/databricks-sdk-py/assets/74460035/3db8b868-548b-4d31-b96a-c4be535461a9)

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [x] `make fmt` applied
- [ ] relevant integration tests applied

