### PR TITLE
fix to set `filter` to `None` when `next_page_token` is returned from previous call 

### DIFF
--- a/databricks/sdk/service/pipelines.py
+++ b/databricks/sdk/service/pipelines.py
@@ -2001,6 +2001,7 @@ class PipelinesAPI:
             if 'next_page_token' not in json or not json['next_page_token']:
                 return
             query['page_token'] = json['next_page_token']
+            query['filter'] = None
 
     def list_pipelines(self,
                        *,
@@ -2049,6 +2050,7 @@ class PipelinesAPI:
             if 'next_page_token' not in json or not json['next_page_token']:
                 return
             query['page_token'] = json['next_page_token']
+            query['filter'] = None
 
     def list_updates(self,
                      pipeline_id: str,


### PR DESCRIPTION
## Changes
clear `query[filter]` when preivous call returns `next_page_token` to avoid error when with `filter` request
```bash
databricks.sdk.errors.platform.InvalidParameterValue: When providing a page token and a filter, the filter must match the filter represented by the page token.
```
similar fix in https://github.com/databricks/databricks-sdk-java/pull/255, https://github.com/databricks/databricks-sdk-go/pull/875
## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] `make fmt` applied
- [x] relevant integration tests applied

