### PR TITLE
Increase cluster creation test timeout

### DIFF
--- a/tests/integration/test_clusters.py
+++ b/tests/integration/test_clusters.py
@@ -35,7 +35,7 @@ def test_create_cluster(w, env_or_skip, random):
                              spark_version=w.clusters.select_spark_version(long_term_support=True),
                              instance_pool_id=env_or_skip('TEST_INSTANCE_POOL_ID'),
                              autotermination_minutes=10,
-                             num_workers=1).result(timeout=timedelta(minutes=10))
+                             num_workers=1).result(timeout=timedelta(minutes=20))
     logging.info(f'Created: {info}')
 
 


### PR DESCRIPTION
## Changes
Increase test timeout for cluster creation from 10m to 20m, as the time taken in GCP is close to 10 minutes.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

