### PR TITLE
DBUtils implementation for Volumes

### DIFF
--- a/databricks/sdk/_property.py
+++ b/databricks/sdk/_property.py
@@ -1,12 +1,11 @@
 # Copied from functools.py
 # Remove when Python 3.8 is the minimum supported version.
 
-from types import GenericAlias
-
 _NOT_FOUND = object()
 
 
 class _cached_property:
+
     def __init__(self, func):
         self.func = func
         self.attrname = None
@@ -17,24 +16,19 @@ class _cached_property:
         if self.attrname is None:
             self.attrname = name
         elif name != self.attrname:
-            raise TypeError(
-                "Cannot assign the same cached_property to two different names "
-                f"({self.attrname!r} and {name!r})."
-            )
+            raise TypeError("Cannot assign the same cached_property to two different names "
+                            f"({self.attrname!r} and {name!r}).")
 
     def __get__(self, instance, owner=None):
         if instance is None:
             return self
         if self.attrname is None:
-            raise TypeError(
-                "Cannot use cached_property instance without calling __set_name__ on it.")
+            raise TypeError("Cannot use cached_property instance without calling __set_name__ on it.")
         try:
             cache = instance.__dict__
-        except AttributeError:  # not all objects have __dict__ (e.g. class defines slots)
-            msg = (
-                f"No '__dict__' attribute on {type(instance).__name__!r} "
-                f"instance to cache {self.attrname!r} property."
-            )
+        except AttributeError: # not all objects have __dict__ (e.g. class defines slots)
+            msg = (f"No '__dict__' attribute on {type(instance).__name__!r} "
+                   f"instance to cache {self.attrname!r} property.")
             raise TypeError(msg) from None
         val = cache.get(self.attrname, _NOT_FOUND)
         if val is _NOT_FOUND:
@@ -42,11 +36,7 @@ class _cached_property:
             try:
                 cache[self.attrname] = val
             except TypeError:
-                msg = (
-                    f"The '__dict__' attribute on {type(instance).__name__!r} instance "
-                    f"does not support item assignment for caching {self.attrname!r} property."
-                )
+                msg = (f"The '__dict__' attribute on {type(instance).__name__!r} instance "
+                       f"does not support item assignment for caching {self.attrname!r} property.")
                 raise TypeError(msg) from None
         return val
-
-    __class_getitem__ = classmethod(GenericAlias)

--- a/databricks/sdk/_property.py
+++ b/databricks/sdk/_property.py
@@ -1,0 +1,52 @@
+# Copied from functools.py
+# Remove when Python 3.8 is the minimum supported version.
+
+from types import GenericAlias
+
+_NOT_FOUND = object()
+
+
+class _cached_property:
+    def __init__(self, func):
+        self.func = func
+        self.attrname = None
+        self.__doc__ = func.__doc__
+        self.__module__ = func.__module__
+
+    def __set_name__(self, owner, name):
+        if self.attrname is None:
+            self.attrname = name
+        elif name != self.attrname:
+            raise TypeError(
+                "Cannot assign the same cached_property to two different names "
+                f"({self.attrname!r} and {name!r})."
+            )
+
+    def __get__(self, instance, owner=None):
+        if instance is None:
+            return self
+        if self.attrname is None:
+            raise TypeError(
+                "Cannot use cached_property instance without calling __set_name__ on it.")
+        try:
+            cache = instance.__dict__
+        except AttributeError:  # not all objects have __dict__ (e.g. class defines slots)
+            msg = (
+                f"No '__dict__' attribute on {type(instance).__name__!r} "
+                f"instance to cache {self.attrname!r} property."
+            )
+            raise TypeError(msg) from None
+        val = cache.get(self.attrname, _NOT_FOUND)
+        if val is _NOT_FOUND:
+            val = self.func(instance)
+            try:
+                cache[self.attrname] = val
+            except TypeError:
+                msg = (
+                    f"The '__dict__' attribute on {type(instance).__name__!r} instance "
+                    f"does not support item assignment for caching {self.attrname!r} property."
+                )
+                raise TypeError(msg) from None
+        return val
+
+    __class_getitem__ = classmethod(GenericAlias)

--- a/databricks/sdk/dbutils.py
+++ b/databricks/sdk/dbutils.py
@@ -45,17 +45,12 @@ class _FsUtil:
 
     def head(self, file: str, maxBytes: int = 65536) -> str:
         """Returns up to the first 'maxBytes' bytes of the given file as a String encoded in UTF-8 """
-        res = self._dbfs.read(file, length=maxBytes, offset=0)
-        raw = base64.b64decode(res.data)
-        return raw.decode('utf8')
+        with self._dbfs.download(file) as f:
+            return f.read(maxBytes).decode('utf8')
 
     def ls(self, dir: str) -> typing.List[FileInfo]:
         """Lists the contents of a directory """
-        result = []
-        for f in self._dbfs.list(dir):
-            name = f.path.split('/')[-1]
-            result.append(FileInfo(f'dbfs:{f.path}', name, f.file_size, f.modification_time))
-        return result
+        return list(self._dbfs.list(dir))
 
     def mkdirs(self, dir: str) -> bool:
         """Creates the given directory if it does not exist, also creating any necessary parent directories """

--- a/databricks/sdk/dbutils.py
+++ b/databricks/sdk/dbutils.py
@@ -3,8 +3,8 @@ import json
 import logging
 import os.path
 import threading
-from typing import Callable, List, Dict
 from collections import namedtuple
+from typing import Callable, Dict, List
 
 from .core import ApiClient, Config, DatabricksError
 from .mixins import compute as compute_ext
@@ -51,7 +51,10 @@ class _FsUtil:
 
     def ls(self, dir: str) -> List[FileInfo]:
         """Lists the contents of a directory """
-        return [FileInfo(f.path, os.path.basename(f.path), f.file_size, f.modification_time) for f in self._dbfs.list(dir)]
+        return [
+            FileInfo(f.path, os.path.basename(f.path), f.file_size, f.modification_time)
+            for f in self._dbfs.list(dir)
+        ]
 
     def mkdirs(self, dir: str) -> bool:
         """Creates the given directory if it does not exist, also creating any necessary parent directories """
@@ -241,8 +244,7 @@ class _ProxyUtil:
     """Enables temporary workaround to call remote in-REPL dbutils without having to re-implement them"""
 
     def __init__(self, *, command_execution: compute.CommandExecutionAPI,
-                 context_factory: Callable[[],
-                                                  compute.ContextStatusResponse], cluster_id: str, name: str):
+                 context_factory: Callable[[], compute.ContextStatusResponse], cluster_id: str, name: str):
         self._commands = command_execution
         self._cluster_id = cluster_id
         self._context_factory = context_factory
@@ -263,8 +265,8 @@ import re
 class _ProxyCall:
 
     def __init__(self, *, command_execution: compute.CommandExecutionAPI,
-                 context_factory: Callable[[], compute.ContextStatusResponse], cluster_id: str,
-                 util: str, method: str):
+                 context_factory: Callable[[], compute.ContextStatusResponse], cluster_id: str, util: str,
+                 method: str):
         self._commands = command_execution
         self._cluster_id = cluster_id
         self._context_factory = context_factory

--- a/databricks/sdk/mixins/files.py
+++ b/databricks/sdk/mixins/files.py
@@ -6,6 +6,7 @@ import pathlib
 import shutil
 import sys
 from abc import ABC, abstractmethod
+from collections import deque
 from io import BytesIO
 from types import TracebackType
 from typing import (TYPE_CHECKING, AnyStr, BinaryIO, Generator, Iterable,
@@ -357,9 +358,9 @@ class _LocalPath(_Path):
                                  modification_time=int(st.st_mtime_ns / 1e6),
                                  )
             return
-        queue = [self._path]
+        queue = deque([self._path])
         while queue:
-            path, queue = queue[0], queue[1:]
+            path = queue.popleft()
             for leaf in path.iterdir():
                 if leaf.is_dir():
                     if recursive:
@@ -432,9 +433,9 @@ class _VolumesPath(_Path):
                                  modification_time=meta.last_modified,
                                  )
             return
-        queue = [self]
+        queue = deque([self])
         while queue:
-            next_path, queue = queue[0], queue[1:]
+            next_path = queue.popleft()
             for file in self._api.list_directory_contents(next_path.as_string):
                 if recursive and file.is_directory:
                     queue.append(self.child(file.name))

--- a/databricks/sdk/mixins/files.py
+++ b/databricks/sdk/mixins/files.py
@@ -13,6 +13,7 @@ from typing import (TYPE_CHECKING, AnyStr, BinaryIO, Generator, Iterable,
 
 from ..errors import NotFound
 from ..service import files
+from .._property import _cached_property
 
 if TYPE_CHECKING:
     from _typeshed import Self
@@ -286,7 +287,7 @@ class _Path(ABC):
     def child(self, path: str) -> str:
         ...
 
-    @functools.cached_property
+    @_cached_property
     def is_dir(self) -> bool:
         return self._is_dir()
 

--- a/databricks/sdk/mixins/files.py
+++ b/databricks/sdk/mixins/files.py
@@ -350,7 +350,7 @@ class _LocalPath(_Path):
     def list(self, recursive=False) -> Generator[files.FileInfo, None, None]:
         if not self.is_dir:
             st = self._path.stat()
-            yield files.FileInfo(path=str(self._path.absolute()),
+            yield files.FileInfo(path='file:' + str(self._path.absolute()),
                                  is_dir=False,
                                  file_size=st.st_size,
                                  modification_time=int(st.st_mtime_ns / 1e6),
@@ -365,7 +365,7 @@ class _LocalPath(_Path):
                         queue.append(leaf)
                     continue
                 info = leaf.stat()
-                yield files.FileInfo(path=str(leaf.absolute()),
+                yield files.FileInfo(path='file:' + str(leaf.absolute()),
                                      is_dir=False,
                                      file_size=info.st_size,
                                      modification_time=int(info.st_mtime_ns / 1e6),
@@ -491,7 +491,7 @@ class _DbfsPath(_Path):
     def list(self, *, recursive=False) -> Generator[files.FileInfo, None, None]:
         if not self.is_dir:
             meta = self._api.get_status(self.as_string)
-            yield files.FileInfo(path=self.as_string,
+            yield files.FileInfo(path='dbfs:' + self.as_string,
                                  is_dir=False,
                                  file_size=meta.file_size,
                                  modification_time=meta.modification_time,

--- a/databricks/sdk/mixins/files.py
+++ b/databricks/sdk/mixins/files.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import base64
-import functools
 import os
 import pathlib
 import shutil
@@ -11,9 +10,9 @@ from types import TracebackType
 from typing import (TYPE_CHECKING, AnyStr, BinaryIO, Generator, Iterable,
                     Iterator, Type, Union)
 
+from .._property import _cached_property
 from ..errors import NotFound
 from ..service import files
-from .._property import _cached_property
 
 if TYPE_CHECKING:
     from _typeshed import Self

--- a/databricks/sdk/mixins/files.py
+++ b/databricks/sdk/mixins/files.py
@@ -571,6 +571,8 @@ class DbfsExt(files.DbfsAPI):
     def _path(self, src):
         if str(src).startswith('file:'):
             return _LocalPath(src)
+        if src.startswith('dbfs:'):
+            src = src[len('dbfs:'):]
         if str(src).startswith('/Volumes'):
             return _VolumesPath(self._files_api, src)
         return _DbfsPath(self._dbfs_api, src)

--- a/databricks/sdk/mixins/files.py
+++ b/databricks/sdk/mixins/files.py
@@ -4,6 +4,7 @@ import base64
 import os
 import pathlib
 import shutil
+import sys
 from abc import ABC, abstractmethod
 from io import BytesIO
 from types import TracebackType
@@ -378,7 +379,10 @@ class _LocalPath(_Path):
                     _LocalPath(leaf.path).delete()
             self._path.rmdir()
         else:
-            self._path.unlink(missing_ok=True)
+            kw = {}
+            if sys.version_info[:2] > (3, 7):
+                kw['missing_ok'] = True
+            self._path.unlink(**kw)
 
     def __repr__(self) -> str:
         return f'<_LocalPath {self._path}>'

--- a/databricks/sdk/mixins/files.py
+++ b/databricks/sdk/mixins/files.py
@@ -502,9 +502,9 @@ class _DbfsPath(_Path):
                                  modification_time=meta.modification_time,
                                  )
             return
-        queue = [self]
+        queue = deque([self])
         while queue:
-            next_path, queue = queue[0], queue[1:]
+            next_path = queue.popleft()
             for file in self._api.list(next_path.as_string):
                 if recursive and file.is_dir:
                     queue.append(self.child(file.path))

--- a/databricks/sdk/mixins/files.py
+++ b/databricks/sdk/mixins/files.py
@@ -7,7 +7,7 @@ import shutil
 from abc import ABC, abstractmethod
 from io import BytesIO
 from types import TracebackType
-from typing import TYPE_CHECKING, AnyStr, BinaryIO, Iterable, Iterator, Type, Union
+from typing import TYPE_CHECKING, AnyStr, BinaryIO, Iterable, Iterator, Type, Union, Generator
 import os
 
 from databricks.sdk.core import DatabricksError
@@ -302,7 +302,7 @@ class _Path(ABC):
     def open(self, *, read=False, write=False, overwrite=False):
         ...
 
-    def list(self, *, recursive=False) -> Iterable[files.FileInfo]:
+    def list(self, *, recursive=False) -> Generator[files.FileInfo, None, None]:
         ...
 
     @abstractmethod
@@ -346,7 +346,7 @@ class _LocalPath(_Path):
         self._path.parent.mkdir(mode=0o755, parents=True, exist_ok=True)
         return self._path.open(mode='wb' if overwrite else 'rb' if read else 'xb')
 
-    def list(self, recursive=False) -> Iterable[files.FileInfo]:
+    def list(self, recursive=False) -> Generator[files.FileInfo, None, None]:
         if not self.is_dir:
             st = self._path.stat()
             yield files.FileInfo(
@@ -419,7 +419,7 @@ class _VolumesPath(_Path):
     def open(self, *, read=False, write=False, overwrite=False) -> BinaryIO:
         return _VolumesIO(self._api, self.as_string, read=read, write=write, overwrite=overwrite)
 
-    def list(self, *, recursive=False) -> Iterable[files.FileInfo]:
+    def list(self, *, recursive=False) -> Generator[files.FileInfo, None, None]:
         if not self.is_dir:
             meta = self._api.get_metadata(self.as_string)
             yield files.FileInfo(
@@ -489,7 +489,7 @@ class _DbfsPath(_Path):
     def open(self, *, read=False, write=False, overwrite=False) -> BinaryIO:
         return _DbfsIO(self._api, self.as_string, read=read, write=write, overwrite=overwrite)
 
-    def list(self, *, recursive=False) -> Iterable[files.FileInfo]:
+    def list(self, *, recursive=False) -> Generator[files.FileInfo, None, None]:
         if not self.is_dir:
             meta = self._api.get_status(self.as_string)
             yield files.FileInfo(

--- a/databricks/sdk/mixins/files.py
+++ b/databricks/sdk/mixins/files.py
@@ -1,14 +1,17 @@
 from __future__ import annotations
 
 import base64
+import functools
 import pathlib
 import shutil
-import sys
 from abc import ABC, abstractmethod
+from io import BytesIO
 from types import TracebackType
-from typing import TYPE_CHECKING, AnyStr, BinaryIO, Iterable, Iterator, Type
+from typing import TYPE_CHECKING, AnyStr, BinaryIO, Iterable, Iterator, Type, Union
+import os
 
 from databricks.sdk.core import DatabricksError
+from ..errors import NotFound
 
 from ..service import files
 
@@ -161,19 +164,134 @@ class _DbfsIO(BinaryIO):
         return f"<_DbfsIO {self._path} {'read' if self.readable() else 'write'}=True>"
 
 
+class _VolumesIO(BinaryIO):
+    def __init__(self, api: files.FilesAPI, path: str, *, read: bool, write: bool, overwrite: bool):
+        self._buffer = []
+        self._api = api
+        self._path = path
+        self._read = read
+        self._write = write
+        self._overwrite = overwrite
+        self._closed = False
+        self._read_handle = None
+        self._offset = 0
+
+    def __enter__(self):
+        if self._read:
+            self.__open_read()
+        return self
+
+    def close(self):
+        if self._closed:
+            return
+        if self._write:
+            to_write = b''.join(self._buffer)
+            self._api.upload(self._path, contents=BytesIO(to_write), overwrite=self._overwrite)
+        elif self._read:
+            self._read_handle.close()
+        self._closed = True
+
+    def fileno(self) -> int:
+        return 0
+
+    def flush(self):
+        raise NotImplementedError()
+
+    def isatty(self) -> bool:
+        return False
+
+    def __check_closed(self):
+        if self._closed:
+            raise ValueError('I/O operation on closed file')
+
+    def __open_read(self):
+        if self._read_handle is None:
+            self._read_handle = self._api.download(self._path).contents
+
+    def read(self, __n=...):
+        self.__check_closed()
+        self.__open_read()
+        return self._read_handle.read(__n)
+
+    def readable(self):
+        return self._read
+
+    def readline(self, __limit=...):
+        raise NotImplementedError()
+
+    def readlines(self, __hint=...):
+        raise NotImplementedError()
+
+    def seek(self, __offset, __whence=...):
+        raise NotImplementedError()
+
+    def seekable(self):
+        return False
+
+    def tell(self):
+        if self._read_handle is not None:
+            return self._read_handle.tell()
+        return self._offset
+
+    def truncate(self, __size=...):
+        raise NotImplementedError()
+
+    def writable(self):
+        return self._write
+
+    def write(self, __s):
+        self.__check_closed()
+        self._buffer.append(__s)
+
+    def writelines(self, __lines):
+        raise NotImplementedError()
+
+    def __next__(self):
+        self.__check_closed()
+        return self._read_handle.__next__()
+
+    def __iter__(self):
+        self.__check_closed()
+        return self._read_handle.__iter__()
+
+    def __exit__(self, __t, __value, __traceback):
+        self.close()
+
+    def __repr__(self) -> str:
+        return f"<_VolumesIO {self._path} {'read' if self.readable() else 'write'}=True>"
+
+
 class _Path(ABC):
 
+    def __init__(self, path: str):
+        self._path = pathlib.Path(str(path).replace('dbfs:', '').replace('file:', ''))
+
     @property
-    @abstractmethod
     def is_local(self) -> bool:
+        return self._is_local()
+
+    @abstractmethod
+    def _is_local(self) -> bool:
+        ...
+
+    @property
+    def is_dbfs(self) -> bool:
+        return self._is_dbfs()
+
+    @abstractmethod
+    def _is_dbfs(self) -> bool:
         ...
 
     @abstractmethod
     def child(self, path: str) -> str:
         ...
 
-    @abstractmethod
+    @functools.cached_property
     def is_dir(self) -> bool:
+        return self._is_dir()
+
+    @abstractmethod
+    def _is_dir(self) -> bool:
         ...
 
     @abstractmethod
@@ -184,18 +302,16 @@ class _Path(ABC):
     def open(self, *, read=False, write=False, overwrite=False):
         ...
 
+    def list(self, *, recursive=False) -> Iterable[files.FileInfo]:
+        ...
+
     @abstractmethod
-    def list_opened_handles(self, *, recursive=False) -> Iterator[(str, BinaryIO)]:
+    def mkdir(self):
         ...
 
     @abstractmethod
     def delete(self, *, recursive=False):
         ...
-
-    def _with_path(self, src: str):
-        # create sanitized path representation, so that
-        # we can have clean child paths in list_opened_handles()
-        self._path = pathlib.Path(str(src).replace('dbfs:', '').replace('file:', ''))
 
     @property
     def name(self) -> str:
@@ -207,19 +323,20 @@ class _Path(ABC):
 
 
 class _LocalPath(_Path):
-
-    def __init__(self, src: str):
-        self._with_path(src)
-
-    @property
-    def is_local(self) -> bool:
+    def _is_local(self) -> bool:
         return True
+
+    def _is_dbfs(self) -> bool:
+        return False
 
     def child(self, path: str) -> Self:
         return _LocalPath(str(self._path / path))
 
-    def is_dir(self) -> bool:
+    def _is_dir(self) -> bool:
         return self._path.is_dir()
+
+    def mkdir(self):
+        self._path.mkdir(mode=0o755, parents=True, exist_ok=True)
 
     def exists(self) -> bool:
         return self._path.exists()
@@ -229,7 +346,16 @@ class _LocalPath(_Path):
         self._path.parent.mkdir(mode=0o755, parents=True, exist_ok=True)
         return self._path.open(mode='wb' if overwrite else 'rb' if read else 'xb')
 
-    def _list_local(self, recursive=False):
+    def list(self, recursive=False) -> Iterable[files.FileInfo]:
+        if not self.is_dir:
+            st = self._path.stat()
+            yield files.FileInfo(
+                path=str(self._path.absolute()),
+                is_dir=False,
+                file_size=st.st_size,
+                modification_time=int(st.st_mtime_ns/1e6),
+            )
+            return
         queue = [self._path]
         while queue:
             path, queue = queue[0], queue[1:]
@@ -238,69 +364,149 @@ class _LocalPath(_Path):
                     if recursive:
                         queue.append(leaf)
                     continue
-                yield leaf
-
-    def list_opened_handles(self, *, recursive=False) -> Iterator[(str, BinaryIO)]:
-        for leaf in self._list_local(recursive):
-            if not recursive and leaf.is_dir:
-                continue
-            with leaf.open('rb') as handle:
-                child = str(leaf).replace(str(self._path) + '/', '')
-                yield child, handle
+                info = leaf.stat()
+                yield files.FileInfo(
+                    path=str(leaf.absolute()),
+                    is_dir=False,
+                    file_size=info.st_size,
+                    modification_time=int(info.st_mtime_ns/1e6),
+                )
 
     def delete(self, *, recursive=False):
-        if self.is_dir():
+        if self.is_dir:
             if recursive:
-                for leaf in self._list_local(True):
-                    kw = {}
-                    if sys.version_info[:2] > (3, 7):
-                        # Python3.7 does not support `missing_ok` keyword
-                        kw['missing_ok'] = True
-                    leaf.unlink(**kw)
+                for leaf in self.list(recursive=True):
+                    _LocalPath(leaf.path).delete()
             self._path.rmdir()
-            return
-        self._path.unlink()
+        else:
+            self._path.unlink(missing_ok=True)
 
     def __repr__(self) -> str:
         return f'<_LocalPath {self._path}>'
 
 
-class _DbfsPath(_Path):
-
-    def __init__(self, api: 'DbfsExt', src: str):
-        self._with_path(src)
+class _VolumesPath(_Path):
+    def __init__(self, api: files.FilesAPI, src: Union[str, pathlib.Path]):
+        super().__init__(src)
         self._api = api
 
-    @property
-    def is_local(self) -> bool:
+    def _is_local(self) -> bool:
         return False
+
+    def _is_dbfs(self) -> bool:
+        return False
+
+    def child(self, path: str) -> Self:
+        return _VolumesPath(self._api, str(self._path / path))
+
+    def _is_dir(self) -> bool:
+        try:
+            self._api.get_directory_metadata(self.as_string)
+            return True
+        except NotFound:
+            return False
+
+    def mkdir(self):
+        self._api.create_directory(self.as_string)
+
+    def exists(self) -> bool:
+        try:
+            self._api.get_metadata(self.as_string)
+            return True
+        except NotFound:
+            return self.is_dir
+
+    def open(self, *, read=False, write=False, overwrite=False) -> BinaryIO:
+        return _VolumesIO(self._api, self.as_string, read=read, write=write, overwrite=overwrite)
+
+    def list(self, *, recursive=False) -> Iterable[files.FileInfo]:
+        if not self.is_dir:
+            meta = self._api.get_metadata(self.as_string)
+            yield files.FileInfo(
+                path=self.as_string,
+                is_dir=False,
+                file_size=meta.content_length,
+                modification_time=meta.last_modified,
+            )
+            return
+        queue = [self]
+        while queue:
+            next_path, queue = queue[0], queue[1:]
+            for file in self._api.list_directory_contents(next_path.as_string):
+                if recursive and file.is_directory:
+                    queue.append(self.child(file.name))
+                yield files.FileInfo(
+                    path=file.path,
+                    is_dir=file.is_directory,
+                    file_size=file.file_size,
+                    modification_time=file.last_modified,
+                )
+
+    def delete(self, *, recursive=False):
+        if self.is_dir:
+            for entry in self.list(recursive=False):
+                _VolumesPath(self._api, entry.path).delete(recursive=True)
+            self._api.delete_directory(self.as_string)
+        else:
+            self._api.delete(self.as_string)
+
+    def __repr__(self) -> str:
+        return f'<_VolumesPath {self._path}>'
+
+
+class _DbfsPath(_Path):
+    def __init__(self, api: files.DbfsAPI, src: str):
+        super().__init__(src)
+        self._api = api
+
+    def _is_local(self) -> bool:
+        return False
+
+    def _is_dbfs(self) -> bool:
+        return True
 
     def child(self, path: str) -> Self:
         child = self._path / path
         return _DbfsPath(self._api, str(child))
 
-    def is_dir(self) -> bool:
+    def _is_dir(self) -> bool:
         try:
             remote = self._api.get_status(self.as_string)
             return remote.is_dir
-        except DatabricksError as e:
-            if e.error_code == 'RESOURCE_DOES_NOT_EXIST':
-                return False
-            raise e
+        except NotFound:
+            return False
+
+    def mkdir(self):
+        self._api.mkdirs(self.as_string)
 
     def exists(self) -> bool:
-        return self._api.exists(self.as_string)
+        try:
+            self._api.get_status(self.as_string)
+            return True
+        except NotFound:
+            return False
 
     def open(self, *, read=False, write=False, overwrite=False) -> BinaryIO:
-        return self._api.open(self.as_string, read=read, write=write, overwrite=overwrite)
+        return _DbfsIO(self._api, self.as_string, read=read, write=write, overwrite=overwrite)
 
-    def list_opened_handles(self, *, recursive=False) -> Iterator[(str, BinaryIO)]:
-        for file in self._api.list(self.as_string, recursive=recursive):
-            if not recursive and file.is_dir:
-                continue
-            with self._api.open(file.path, read=True) as handle:
-                child = file.path.replace(str(self._path) + '/', '').replace('dbfs:', '')
-                yield child, handle
+    def list(self, *, recursive=False) -> Iterable[files.FileInfo]:
+        if not self.is_dir:
+            meta = self._api.get_status(self.as_string)
+            yield files.FileInfo(
+                path=self.as_string,
+                is_dir=False,
+                file_size=meta.file_size,
+                modification_time=meta.modification_time,
+            )
+            return
+        queue = [self]
+        while queue:
+            next_path, queue = queue[0], queue[1:]
+            for file in self._api.list(next_path.as_string):
+                if recursive and file.is_dir:
+                    queue.append(self.child(file.path))
+                file.path = f'dbfs:{file.path}' if not file.path.startswith('dbfs:') else file.path
+                yield file
 
     def delete(self, *, recursive=False):
         self._api.delete(self.as_string, recursive=recursive)
@@ -312,8 +518,13 @@ class _DbfsPath(_Path):
 class DbfsExt(files.DbfsAPI):
     __doc__ = files.DbfsAPI.__doc__
 
-    def open(self, path: str, *, read: bool = False, write: bool = False, overwrite: bool = False) -> _DbfsIO:
-        return _DbfsIO(self, path, read=read, write=write, overwrite=overwrite)
+    def __init__(self, api_client):
+        super().__init__(api_client)
+        self._files_api = files.FilesAPI(api_client)
+        self._dbfs_api = files.DbfsAPI(api_client)
+
+    def open(self, path: str, *, read: bool = False, write: bool = False, overwrite: bool = False) -> BinaryIO:
+        return self._path(path).open(read=read, write=write, overwrite=overwrite)
 
     def upload(self, path: str, src: BinaryIO, *, overwrite: bool = False):
         """Upload file to DBFS"""
@@ -333,34 +544,29 @@ class DbfsExt(files.DbfsAPI):
         When calling list on a large directory, the list operation will time out after approximately 60
         seconds.
 
+        :param path: the DBFS or UC Volume path to list
         :param recursive: traverse deep into directory tree
         :returns iterator of metadata for every file
         """
-        queue = [path]
-        while queue:
-            path, queue = queue[0], queue[1:]
-            for file_info in super().list(path):
-                if recursive and file_info.is_dir:
-                    queue.append(file_info.path)
-                    continue
-                yield file_info
+        p = self._path(path)
+        yield from p.list(recursive=recursive)
+
+    def mkdirs(self, path: str):
+        """Create directory on DBFS"""
+        p = self._path(path)
+        p.mkdir()
 
     def exists(self, path: str) -> bool:
         """If file exists on DBFS"""
-        # TODO: check if we want to put it to errors module to prevent circular import
-        from databricks.sdk.core import DatabricksError
-        try:
-            self.get_status(path)
-            return True
-        except DatabricksError as e:
-            if e.error_code == 'RESOURCE_DOES_NOT_EXIST':
-                return False
-            raise e
+        p = self._path(path)
+        return p.exists()
 
     def _path(self, src):
         if str(src).startswith('file:'):
             return _LocalPath(src)
-        return _DbfsPath(self, src)
+        if str(src).startswith('/Volumes'):
+            return _VolumesPath(self._files_api, src)
+        return _DbfsPath(self._dbfs_api, src)
 
     def copy(self, src: str, dst: str, *, recursive=False, overwrite=False):
         """Copy files between DBFS and local filesystems"""
@@ -368,32 +574,38 @@ class DbfsExt(files.DbfsAPI):
         dst = self._path(dst)
         if src.is_local and dst.is_local:
             raise IOError('both destinations are on local FS')
-        if dst.exists() and dst.is_dir():
+        if dst.exists() and dst.is_dir:
             # if target is a folder, make file with the same name there
             dst = dst.child(src.name)
-        if not src.is_dir():
-            # copy single file
-            with src.open(read=True) as reader:
-                with dst.open(write=True, overwrite=overwrite) as writer:
+        if src.is_dir:
+            queue = [self._path(x.path) for x in src.list(recursive=recursive)]
+        else:
+            queue = [src]
+        for child in queue:
+            child_dst = dst.child(os.path.relpath(child.as_string, src.as_string))
+            with child.open(read=True) as reader:
+                with child_dst.open(write=True, overwrite=overwrite) as writer:
                     shutil.copyfileobj(reader, writer, length=_DbfsIO.MAX_CHUNK_SIZE)
-            return
-        # iterate through files
-        for child, reader in src.list_opened_handles(recursive=recursive):
-            with dst.child(child).open(write=True, overwrite=overwrite) as writer:
-                shutil.copyfileobj(reader, writer, length=_DbfsIO.MAX_CHUNK_SIZE)
 
     def move_(self, src: str, dst: str, *, recursive=False, overwrite=False):
         """Move files between local and DBFS systems"""
         source = self._path(src)
         target = self._path(dst)
-        if not source.is_local and not target.is_local:
+        if source.is_dbfs and target.is_dbfs:
             # Moves a file from one location to another location within DBFS.
             # this operation is recursive by default.
             return self.move(source.as_string, target.as_string)
         if source.is_local and target.is_local:
             raise IOError('both destinations are on local FS')
-        if source.is_dir() and not recursive:
+        if source.is_dir and not recursive:
             raise IOError('moving directories across filesystems requires recursive flag')
         # do cross-fs moving
         self.copy(src, dst, recursive=recursive, overwrite=overwrite)
-        source.delete(recursive=recursive)
+        self.delete(src, recursive=recursive)
+
+    def delete(self, path: str, *, recursive=False):
+        """Delete file or directory on DBFS"""
+        p = self._path(path)
+        if p.is_dir and not recursive:
+            raise IOError('deleting directories requires recursive flag')
+        p.delete(recursive=recursive)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -37,7 +37,7 @@ def pytest_collection_modifyitems(items):
                 item.add_marker('integration')
 
 
-@pytest.fixture
+@pytest.fixture(scope='session')
 def random():
     import random
 

--- a/tests/integration/test_dbutils.py
+++ b/tests/integration/test_dbutils.py
@@ -4,6 +4,17 @@ import logging
 import pytest
 
 from databricks.sdk.core import DatabricksError
+from databricks.sdk.errors import NotFound
+from databricks.sdk.service.catalog import VolumeType
+
+
+@pytest.fixture(scope='session')
+def dbfs_volume(ucws, random):
+    schema = ucws.schemas.create('dbfs-' + random(), 'main')
+    volume = ucws.volumes.create('main', schema.name, 'dbfs-test', VolumeType.MANAGED)
+    yield '/Volumes/' + volume.full_name.replace(".", "/")
+    ucws.volumes.delete(volume.full_name)
+    ucws.schemas.delete(schema.full_name)
 
 
 def test_rest_dbfs_ls(w, env_or_skip):
@@ -22,14 +33,163 @@ def test_proxy_dbfs_mounts(w, env_or_skip):
     assert len(x) > 1
 
 
-def test_dbutils_put(w):
+def test_dbutils_dbfs_put_head_small(w):
     fs = w.dbutils.fs
+    _test_put(fs, 'dbfs:/tmp')
 
-    path = "/tmp/dbc_qa_file"
+
+def test_dbutils_volumes_put_head_small(ucws, dbfs_volume):
+    fs = ucws.dbutils.fs
+    _test_put(fs, dbfs_volume)
+
+
+def _test_put(fs, base_path):
+    path = base_path + "/dbc_qa_file"
     fs.put(path, "test", True)
     output = fs.head(path)
+    assert output == "test"
 
-    assert output == 'test'
+
+def test_dbutils_dbfs_put_head_large(w):
+    fs = w.dbutils.fs
+    _test_large_put(fs, 'dbfs:/tmp')
+
+
+def test_dbutils_volumes_put_head_large(ucws, dbfs_volume):
+    fs = ucws.dbutils.fs
+    _test_large_put(fs, dbfs_volume)
+
+
+def _test_large_put(fs, base_path):
+    path = base_path + "/dbc_qa_large_file"
+    fs.put(path, "test" * 20000, True)
+    output = fs.head(path)
+    assert output == ("test" * 20000)[:65536]
+
+
+def test_dbutils_dbfs_cp_file(w, random):
+    fs = w.dbutils.fs
+    _test_cp_file(fs, 'dbfs:/tmp', random)
+
+
+def test_dbutils_volumes_cp_file(ucws, dbfs_volume, random):
+    fs = ucws.dbutils.fs
+    _test_cp_file(fs, dbfs_volume, random)
+
+
+def _test_cp_file(fs, base_path, random):
+    path = base_path + "/dbc_qa_file-" + random()
+    fs.put(path, "test", True)
+    fs.cp(path, path + "_copy")
+    output = fs.head(path + "_copy")
+    assert output == "test"
+    assert len(fs.ls(path)) == 1
+
+
+def test_dbutils_dbfs_cp_dir(w, random):
+    fs = w.dbutils.fs
+    _test_cp_dir(fs, 'dbfs:/tmp', random)
+
+
+def test_dbutils_volumes_cp_dir(ucws, dbfs_volume, random):
+    fs = ucws.dbutils.fs
+    _test_cp_dir(fs, dbfs_volume, random)
+
+
+def _test_cp_dir(fs, base_path, random):
+    path = base_path + "/dbc_qa_dir-" + random()
+    fs.mkdirs(path)
+    fs.put(path + "/file1", "test1", True)
+    fs.put(path + "/file2", "test2", True)
+    fs.cp(path, path + "_copy")
+    output = fs.ls(path + "_copy")
+    assert len(output) == 2
+    assert output[0].path == path + "_copy/file1"
+    assert output[1].path == path + "_copy/file2"
+
+
+def test_dbutils_dbfs_mv_file(w, random):
+    fs = w.dbutils.fs
+    _test_mv_file(fs, 'dbfs:/tmp', random)
+
+
+def test_dbutils_volumes_mv_file(ucws, dbfs_volume, random):
+    fs = ucws.dbutils.fs
+    _test_mv_file(fs, dbfs_volume, random)
+
+
+def _test_mv_file(fs, base_path, random):
+    path = base_path + "/dbc_qa_file-" + random()
+    fs.put(path, "test", True)
+    fs.mv(path, path + "_moved")
+    output = fs.head(path + "_moved")
+    assert output == "test"
+    with pytest.raises(NotFound):
+        fs.ls(path)
+
+
+def test_dbutils_dbfs_mv_dir(w, random):
+    fs = w.dbutils.fs
+    _test_mv_dir(fs, 'dbfs:/tmp', random)
+
+
+def test_dbutils_volumes_mv_dir(ucws, dbfs_volume, random):
+    fs = ucws.dbutils.fs
+    _test_mv_dir(fs, dbfs_volume, random)
+
+
+def _test_mv_dir(fs, base_path, random):
+    path = base_path + "/dbc_qa_dir-" + random()
+    fs.mkdirs(path)
+    fs.put(path + "/file1", "test1", True)
+    fs.put(path + "/file2", "test2", True)
+    fs.mv(path, path + "_moved")
+    output = fs.ls(path + "_moved")
+    assert len(output) == 2
+    assert output[0].path == path + "_moved/file1"
+    assert output[1].path == path + "_moved/file2"
+    with pytest.raises(NotFound):
+        fs.ls(path)
+
+
+def test_dbutils_dbfs_rm_file(w, random):
+    fs = w.dbutils.fs
+    _test_rm_file(fs, 'dbfs:/tmp', random)
+
+
+def test_dbutils_volumes_rm_file(ucws, dbfs_volume, random):
+    fs = ucws.dbutils.fs
+    _test_rm_file(fs, dbfs_volume, random)
+
+
+def _test_rm_file(fs, base_path, random):
+    path = base_path + "/dbc_qa_file-" + random()
+    fs.put(path, "test", True)
+    fs.rm(path)
+    with pytest.raises(NotFound):
+        fs.ls(path)
+
+
+def test_dbutils_dbfs_rm_dir(w, random):
+    fs = w.dbutils.fs
+    _test_rm_dir(fs, 'dbfs:/tmp', random)
+
+
+def test_dbutils_volumes_rm_dir(ucws, dbfs_volume, random):
+    fs = ucws.dbutils.fs
+    _test_rm_dir(fs, dbfs_volume, random)
+
+
+def _test_rm_dir(fs, base_path, random):
+    path = base_path + "/dbc_qa_dir-" + random()
+    fs.mkdirs(path)
+    fs.put(path + "/file1", "test1", True)
+    fs.put(path + "/file2", "test2", True)
+    with pytest.raises(IOError):
+        fs.rm(path)
+    fs.rm(path, recurse=True)
+    with pytest.raises(NotFound):
+        fs.ls(path)
 
 
 def test_secrets(w, random):

--- a/tests/integration/test_dbutils.py
+++ b/tests/integration/test_dbutils.py
@@ -1,5 +1,6 @@
 import base64
 import logging
+import os
 
 import pytest
 
@@ -150,6 +151,26 @@ def _test_mv_dir(fs, base_path, random):
     assert output[1].path == path + "_moved/file2"
     with pytest.raises(NotFound):
         fs.ls(path)
+
+
+def test_dbutils_dbfs_mv_local_to_remote(w, random, tmp_path):
+    fs = w.dbutils.fs
+    _test_mv_local_to_remote(fs, 'dbfs:/tmp', random, tmp_path)
+
+
+def test_dbutils_volumes_mv_local_to_remote(ucws, dbfs_volume, random, tmp_path):
+    fs = ucws.dbutils.fs
+    _test_mv_local_to_remote(fs, dbfs_volume, random, tmp_path)
+
+
+def _test_mv_local_to_remote(fs, base_path, random, tmp_path):
+    path = base_path + "/dbc_qa_file-" + random()
+    with open(tmp_path / "test", "w") as f:
+        f.write("test")
+    fs.mv('file:' + str(tmp_path / "test"), path)
+    output = fs.head(path)
+    assert output == "test"
+    assert os.listdir(tmp_path) == []
 
 
 def test_dbutils_dbfs_rm_file(w, random):

--- a/tests/integration/test_dbutils.py
+++ b/tests/integration/test_dbutils.py
@@ -13,7 +13,7 @@ from databricks.sdk.service.catalog import VolumeType
 def dbfs_volume(ucws, random):
     schema = ucws.schemas.create('dbfs-' + random(), 'main')
     volume = ucws.volumes.create('main', schema.name, 'dbfs-test', VolumeType.MANAGED)
-    yield '/Volumes/' + volume.full_name.replace(".", "/")
+    yield 'dbfs:/Volumes/' + volume.full_name.replace(".", "/")
     ucws.volumes.delete(volume.full_name)
     ucws.schemas.delete(schema.full_name)
 
@@ -133,7 +133,7 @@ def test_mv_remote_to_local(fs_and_base_path, random, tmp_path):
         fs.ls(path)
 
 
-def _test_rm_file(fs_and_base_path, random):
+def test_rm_file(fs_and_base_path, random):
     fs, base_path = fs_and_base_path
     path = base_path + "/dbc_qa_file-" + random()
     fs.put(path, "test", True)
@@ -142,7 +142,7 @@ def _test_rm_file(fs_and_base_path, random):
         fs.ls(path)
 
 
-def _test_rm_dir(fs_and_base_path, random):
+def test_rm_dir(fs_and_base_path, random):
     fs, base_path = fs_and_base_path
     path = base_path + "/dbc_qa_dir-" + random()
     fs.mkdirs(path)

--- a/tests/test_dbfs_mixins.py
+++ b/tests/test_dbfs_mixins.py
@@ -30,7 +30,6 @@ def test_moving_dbfs_file_to_local_dir(config, tmp_path, mocker):
 
 def test_moving_local_dir_to_dbfs(config, tmp_path, mocker):
     from databricks.sdk import WorkspaceClient
-    from databricks.sdk.core import DatabricksError
     from databricks.sdk.service.files import CreateResponse
 
     with (tmp_path / 'a').open('wb') as f:

--- a/tests/test_dbfs_mixins.py
+++ b/tests/test_dbfs_mixins.py
@@ -1,7 +1,8 @@
 import pytest
 
 from databricks.sdk.errors import NotFound
-from databricks.sdk.mixins.files import _DbfsPath, _VolumesPath, _LocalPath, DbfsExt
+from databricks.sdk.mixins.files import (DbfsExt, _DbfsPath, _LocalPath,
+                                         _VolumesPath)
 
 
 def test_moving_dbfs_file_to_local_dir(config, tmp_path, mocker):
@@ -53,14 +54,12 @@ def test_moving_local_dir_to_dbfs(config, tmp_path, mocker):
     assert not (tmp_path / 'a').exists()
 
 
-@pytest.mark.parametrize('path,expected_type', [
-    ('/path/to/file', _DbfsPath),
-    ('/Volumes/path/to/file', _VolumesPath),
-    ('dbfs:/path/to/file', _DbfsPath),
-    ('dbfs:/Volumes/path/to/file', _VolumesPath),
-    ('file:/path/to/file', _LocalPath),
-    ('file:/Volumes/path/to/file', _LocalPath),
-])
+@pytest.mark.parametrize('path,expected_type', [('/path/to/file', _DbfsPath),
+                                                ('/Volumes/path/to/file', _VolumesPath),
+                                                ('dbfs:/path/to/file', _DbfsPath),
+                                                ('dbfs:/Volumes/path/to/file', _VolumesPath),
+                                                ('file:/path/to/file', _LocalPath),
+                                                ('file:/Volumes/path/to/file', _LocalPath), ])
 def test_fs_path(config, path, expected_type):
     dbfs_ext = DbfsExt(config)
     assert isinstance(dbfs_ext._path(path), expected_type)

--- a/tests/test_dbfs_mixins.py
+++ b/tests/test_dbfs_mixins.py
@@ -1,4 +1,7 @@
+import pytest
+
 from databricks.sdk.errors import NotFound
+from databricks.sdk.mixins.files import _DbfsPath, _VolumesPath, _LocalPath, DbfsExt
 
 
 def test_moving_dbfs_file_to_local_dir(config, tmp_path, mocker):
@@ -48,3 +51,16 @@ def test_moving_local_dir_to_dbfs(config, tmp_path, mocker):
     close.assert_called_with(123)
     add_block.assert_called_with(123, 'aGVsbG8=')
     assert not (tmp_path / 'a').exists()
+
+
+@pytest.mark.parametrize('path,expected_type', [
+    ('/path/to/file', _DbfsPath),
+    ('/Volumes/path/to/file', _VolumesPath),
+    ('dbfs:/path/to/file', _DbfsPath),
+    ('dbfs:/Volumes/path/to/file', _VolumesPath),
+    ('file:/path/to/file', _LocalPath),
+    ('file:/Volumes/path/to/file', _LocalPath),
+])
+def test_fs_path(config, path, expected_type):
+    dbfs_ext = DbfsExt(config)
+    assert isinstance(dbfs_ext._path(path), expected_type)

--- a/tests/test_dbutils.py
+++ b/tests/test_dbutils.py
@@ -1,6 +1,7 @@
 import pytest as pytest
 
 from databricks.sdk.dbutils import FileInfo as DBUtilsFileInfo
+from databricks.sdk.mixins.files import _DbfsPath, _VolumesPath, _LocalPath
 from databricks.sdk.service.files import FileInfo, ReadResponse
 
 from .conftest import raises

--- a/tests/test_dbutils.py
+++ b/tests/test_dbutils.py
@@ -1,7 +1,6 @@
 import pytest as pytest
 
 from databricks.sdk.dbutils import FileInfo as DBUtilsFileInfo
-from databricks.sdk.mixins.files import _DbfsPath, _VolumesPath, _LocalPath
 from databricks.sdk.service.files import FileInfo, ReadResponse
 
 from .conftest import raises

--- a/tests/test_dbutils.py
+++ b/tests/test_dbutils.py
@@ -1,9 +1,9 @@
 import pytest as pytest
 
-from .conftest import raises
-
 from databricks.sdk.dbutils import FileInfo as DBUtilsFileInfo
-from databricks.sdk.service.files import ReadResponse, FileInfo
+from databricks.sdk.service.files import FileInfo, ReadResponse
+
+from .conftest import raises
 
 
 @pytest.fixture

--- a/tests/test_dbutils.py
+++ b/tests/test_dbutils.py
@@ -2,6 +2,9 @@ import pytest as pytest
 
 from .conftest import raises
 
+from databricks.sdk.dbutils import FileInfo as DBUtilsFileInfo
+from databricks.sdk.service.files import ReadResponse, FileInfo
+
 
 @pytest.fixture
 def dbutils(config):
@@ -18,30 +21,37 @@ def test_fs_cp(dbutils, mocker):
 
 
 def test_fs_head(dbutils, mocker):
-    from databricks.sdk.service.files import ReadResponse
     inner = mocker.patch('databricks.sdk.service.files.DbfsAPI.read',
-                         return_value=ReadResponse(data='aGVsbG8='))
+                         return_value=ReadResponse(data='aGVsbG8=', bytes_read=5))
+    inner2 = mocker.patch('databricks.sdk.service.files.DbfsAPI.get_status',
+                          return_value=FileInfo(path='a', is_dir=False, file_size=5))
 
     result = dbutils.fs.head('a')
 
     inner.assert_called_with('a', length=65536, offset=0)
+    inner2.assert_called_with('a')
     assert result == 'hello'
 
 
 def test_fs_ls(dbutils, mocker):
-    from databricks.sdk.service.files import FileInfo
-    inner = mocker.patch('databricks.sdk.mixins.files.DbfsExt.list',
+    inner = mocker.patch('databricks.sdk.service.files.DbfsAPI.list',
                          return_value=[
-                             FileInfo(path='b', file_size=10, modification_time=20),
-                             FileInfo(path='c', file_size=30, modification_time=40),
+                             FileInfo(path='a/b', file_size=10, modification_time=20),
+                             FileInfo(path='a/c', file_size=30, modification_time=40),
                          ])
+    inner2 = mocker.patch('databricks.sdk.service.files.DbfsAPI.get_status',
+                          side_effect=[
+                              FileInfo(path='a', is_dir=True, file_size=5),
+                              FileInfo(path='a/b', is_dir=False, file_size=5),
+                              FileInfo(path='a/c', is_dir=False, file_size=5),
+                          ])
 
     result = dbutils.fs.ls('a')
 
-    from databricks.sdk.dbutils import FileInfo
     inner.assert_called_with('a')
     assert len(result) == 2
-    assert result[0] == FileInfo('dbfs:b', 'b', 10, 20)
+    assert result[0] == DBUtilsFileInfo('dbfs:a/b', 'b', 10, 20)
+    assert result[1] == DBUtilsFileInfo('dbfs:a/c', 'c', 30, 40)
 
 
 def test_fs_mkdirs(dbutils, mocker):
@@ -85,6 +95,8 @@ def test_fs_put(dbutils, mocker):
 
 def test_fs_rm(dbutils, mocker):
     inner = mocker.patch('databricks.sdk.service.files.DbfsAPI.delete')
+    inner2 = mocker.patch('databricks.sdk.service.files.DbfsAPI.get_status',
+                          return_value=FileInfo(path='a', is_dir=False, file_size=5))
 
     dbutils.fs.rm('a')
 


### PR DESCRIPTION
## Changes
UC Volumes has been released for some time, but users are unable to use UC Volumes with `dbutils.fs` from the SDK. This PR implements support for `/Volumes` paths in DBUtils in the SDK.

I've done this primarily by extending `DbfsExt` to work with UC Volumes paths. A new class `_VolumePath` is supported, implementing the set of base operations defined on the `_Path` parent abstract class for volume paths. An accompanying `_VolumesIO` is also implemented to provide a consistent interface for reading from and writing to UC Volumes files, especially for writing: the `download` API already returns a `BinaryIO`, but the `upload` API _accepts_ a `BinaryIO`, so this adapter allows for a user to "open" a Volumes path for writing.

In order to properly implement `ls`, I changed the existing implementation of `list` in `_Path` subclasses to return a generator of `FileInfo`s. This allows for better reuse of this common functionality between `ls`, `cp` and `mv`.

Open questions:
* Should we do anything to distinguish between a path named `/Volumes` on disk and UC Volumes? E.g. via a different scheme?

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

