### PR TITLE
Remove unnecessary `dbfs:` scheme when listing in `w.dbutils.fs.ls()`

### DIFF
--- a/databricks/sdk/mixins/files.py
+++ b/databricks/sdk/mixins/files.py
@@ -439,6 +439,7 @@ class _VolumesPath(_Path):
             for file in self._api.list_directory_contents(next_path.as_string):
                 if recursive and file.is_directory:
                     queue.append(self.child(file.name))
+                    continue
                 yield files.FileInfo(path=file.path,
                                      is_dir=file.is_directory,
                                      file_size=file.file_size,
@@ -496,7 +497,7 @@ class _DbfsPath(_Path):
     def list(self, *, recursive=False) -> Generator[files.FileInfo, None, None]:
         if not self.is_dir:
             meta = self._api.get_status(self.as_string)
-            yield files.FileInfo(path='dbfs:' + self.as_string,
+            yield files.FileInfo(path=self.as_string,
                                  is_dir=False,
                                  file_size=meta.file_size,
                                  modification_time=meta.modification_time,
@@ -508,7 +509,7 @@ class _DbfsPath(_Path):
             for file in self._api.list(next_path.as_string):
                 if recursive and file.is_dir:
                     queue.append(self.child(file.path))
-                file.path = f'dbfs:{file.path}' if not file.path.startswith('dbfs:') else file.path
+                    continue
                 yield file
 
     def delete(self, *, recursive=False):

--- a/tests/integration/test_dbutils.py
+++ b/tests/integration/test_dbutils.py
@@ -13,7 +13,7 @@ from databricks.sdk.service.catalog import VolumeType
 def dbfs_volume(ucws, random):
     schema = ucws.schemas.create('dbfs-' + random(), 'main')
     volume = ucws.volumes.create('main', schema.name, 'dbfs-test', VolumeType.MANAGED)
-    yield 'dbfs:/Volumes/' + volume.full_name.replace(".", "/")
+    yield '/Volumes/' + volume.full_name.replace(".", "/")
     ucws.volumes.delete(volume.full_name)
     ucws.schemas.delete(schema.full_name)
 
@@ -38,7 +38,7 @@ def test_proxy_dbfs_mounts(w, env_or_skip):
 def fs_and_base_path(request, ucws, dbfs_volume):
     if request.param == 'dbfs':
         fs = ucws.dbutils.fs
-        base_path = 'dbfs:/tmp'
+        base_path = '/tmp'
     else:
         fs = ucws.dbutils.fs
         base_path = dbfs_volume
@@ -82,6 +82,27 @@ def test_cp_dir(fs_and_base_path, random):
     assert len(output) == 2
     assert output[0].path == path + "_copy/file1"
     assert output[1].path == path + "_copy/file2"
+
+
+def test_ls_file(fs_and_base_path, random):
+    fs, base_path = fs_and_base_path
+    path = base_path + "/dbc_qa_file-" + random()
+    fs.put(path, "test", True)
+    output = fs.ls(path)
+    assert len(output) == 1
+    assert output[0].path == path
+
+
+def test_ls_dir(fs_and_base_path, random):
+    fs, base_path = fs_and_base_path
+    path = base_path + "/dbc_qa_dir-" + random()
+    fs.mkdirs(path)
+    fs.put(path + "/file1", "test1", True)
+    fs.put(path + "/file2", "test2", True)
+    output = fs.ls(path)
+    assert len(output) == 2
+    assert output[0].path == path + "/file1"
+    assert output[1].path == path + "/file2"
 
 
 def test_mv_file(fs_and_base_path, random):


### PR DESCRIPTION
## Changes
#623 introduced DBUtils support for volumes but also caused a small regression in listing behavior: `dbutils.fs.ls()` should not include the `dbfs:` scheme. This PR makes that fix. Additionally, it fixes a small bug in volumes recursive listing, only including the file paths as is the behavior with DBFS.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

