### PR TITLE
Gracefully handle null JSON responses from API

### DIFF
--- a/databricks/sdk/core.py
+++ b/databricks/sdk/core.py
@@ -146,6 +146,8 @@ class ApiClient:
             return resp
 
         json = response.json()
+        if json is None:
+            return resp
         if isinstance(json, list):
             return json
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -335,6 +335,20 @@ def test_shares(config, requests_mock):
     assert requests_mock.last_request.json() == {'changes': [{'principal': 'principal'}]}
 
 
+def test_deletes(config, requests_mock):
+    requests_mock.delete("http://localhost/api/2.0/preview/sql/alerts/alertid",
+                         request_headers={"User-Agent": config.user_agent},
+                         )
+
+    w = WorkspaceClient(config=config)
+    res = w.alerts.delete(alert_id="alertId")
+
+    assert requests_mock.call_count == 1
+    assert requests_mock.called
+
+    assert res is None
+
+
 def test_error(config, requests_mock):
     errorJson = {
         "message":

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -344,6 +344,7 @@ def test_shares(config, requests_mock):
 def test_deletes(config, requests_mock):
     requests_mock.delete("http://localhost/api/2.0/preview/sql/alerts/alertid",
                          request_headers={"User-Agent": config.user_agent},
+                         text="null",
                          )
 
     w = WorkspaceClient(config=config)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -31,12 +31,12 @@ from .conftest import noop_credentials
 
 
 def test_parse_dsn():
-    cfg = Config.parse_dsn('databricks://user:pass@foo.databricks.com?retry_timeout_seconds=600')
+    cfg = Config.parse_dsn("databricks://user:pass@foo.databricks.com?retry_timeout_seconds=600")
 
     headers = cfg.authenticate()
 
-    assert headers['Authorization'] == 'Basic dXNlcjpwYXNz'
-    assert 'basic' == cfg.auth_type
+    assert headers["Authorization"] == "Basic dXNlcjpwYXNz"
+    assert "basic" == cfg.auth_type
 
 
 def test_databricks_cli_token_source_relative_path(config):
@@ -52,7 +52,7 @@ def test_databricks_cli_token_source_absolute_path(config):
 
 
 def test_databricks_cli_token_source_not_installed(config, monkeypatch):
-    monkeypatch.setenv('PATH', 'whatever')
+    monkeypatch.setenv("PATH", "whatever")
     with pytest.raises(FileNotFoundError, match="not installed"):
         DatabricksCliTokenSource(config)
 
@@ -60,13 +60,14 @@ def test_databricks_cli_token_source_not_installed(config, monkeypatch):
 @pytest.mark.parametrize("date_string,expected",
                          [("2023-12-01T15:19:48.007742617Z", datetime(2023, 12, 1, 15, 19, 48)),
                           ("2023-12-05T15:59:01.40081+11:00", datetime(2023, 12, 5, 15, 59, 1)),
-                          ("2023-12-06 10:06:05", datetime(2023, 12, 6, 10, 6, 5))])
+                          ("2023-12-06 10:06:05", datetime(2023, 12, 6, 10, 6, 5)), ],
+                         )
 def test_databricks_cli_token_parse_expiry(date_string, expected):
     assert CliTokenSource._parse_expiry(date_string) == expected
 
 
 def write_small_dummy_executable(path: pathlib.Path):
-    cli = path.joinpath('databricks')
+    cli = path.joinpath("databricks")
     cli.write_text('#!/bin/sh\necho "hello world"\n')
     cli.chmod(0o755)
     assert cli.stat().st_size < 1024
@@ -100,10 +101,10 @@ def test_streaming_response_read_closes(config):
 
 
 def write_large_dummy_executable(path: pathlib.Path):
-    cli = path.joinpath('databricks')
+    cli = path.joinpath("databricks")
 
     # Generate a long random string to inflate the file size.
-    random_string = ''.join(random.choice(string.ascii_letters) for i in range(1024 * 1024))
+    random_string = "".join(random.choice(string.ascii_letters) for i in range(1024 * 1024))
     cli.write_text("""#!/bin/sh
 cat <<EOF
 {
@@ -121,33 +122,33 @@ exit 0
 
 def test_databricks_cli_token_source_installed_legacy(config, monkeypatch, tmp_path):
     write_small_dummy_executable(tmp_path)
-    monkeypatch.setenv('PATH', tmp_path.as_posix())
+    monkeypatch.setenv("PATH", tmp_path.as_posix())
     with pytest.raises(FileNotFoundError, match="version <0.100.0 detected"):
         DatabricksCliTokenSource(config)
 
 
 def test_databricks_cli_token_source_installed_legacy_with_symlink(config, monkeypatch, tmp_path):
-    dir1 = tmp_path.joinpath('dir1')
-    dir2 = tmp_path.joinpath('dir2')
+    dir1 = tmp_path.joinpath("dir1")
+    dir2 = tmp_path.joinpath("dir2")
     dir1.mkdir()
     dir2.mkdir()
 
     (dir1 / "databricks").symlink_to(write_small_dummy_executable(dir2))
 
-    monkeypatch.setenv('PATH', dir1.as_posix())
+    monkeypatch.setenv("PATH", dir1.as_posix())
     with pytest.raises(FileNotFoundError, match="version <0.100.0 detected"):
         DatabricksCliTokenSource(config)
 
 
 def test_databricks_cli_token_source_installed_new(config, monkeypatch, tmp_path):
     write_large_dummy_executable(tmp_path)
-    monkeypatch.setenv('PATH', tmp_path.as_posix())
+    monkeypatch.setenv("PATH", tmp_path.as_posix())
     DatabricksCliTokenSource(config)
 
 
 def test_databricks_cli_token_source_installed_both(config, monkeypatch, tmp_path):
-    dir1 = tmp_path.joinpath('dir1')
-    dir2 = tmp_path.joinpath('dir2')
+    dir1 = tmp_path.joinpath("dir1")
+    dir2 = tmp_path.joinpath("dir2")
     dir1.mkdir()
     dir2.mkdir()
 
@@ -155,28 +156,28 @@ def test_databricks_cli_token_source_installed_both(config, monkeypatch, tmp_pat
     write_large_dummy_executable(dir2)
 
     # Resolve small before large.
-    monkeypatch.setenv('PATH', str(os.pathsep).join([dir1.as_posix(), dir2.as_posix()]))
+    monkeypatch.setenv("PATH", str(os.pathsep).join([dir1.as_posix(), dir2.as_posix()]))
     DatabricksCliTokenSource(config)
 
     # Resolve large before small.
-    monkeypatch.setenv('PATH', str(os.pathsep).join([dir2.as_posix(), dir1.as_posix()]))
+    monkeypatch.setenv("PATH", str(os.pathsep).join([dir2.as_posix(), dir1.as_posix()]))
     DatabricksCliTokenSource(config)
 
 
 def test_databricks_cli_credential_provider_not_installed(config, monkeypatch):
-    monkeypatch.setenv('PATH', 'whatever')
+    monkeypatch.setenv("PATH", "whatever")
     assert databricks_cli(config) == None
 
 
 def test_databricks_cli_credential_provider_installed_legacy(config, monkeypatch, tmp_path):
     write_small_dummy_executable(tmp_path)
-    monkeypatch.setenv('PATH', tmp_path.as_posix())
+    monkeypatch.setenv("PATH", tmp_path.as_posix())
     assert databricks_cli(config) == None
 
 
 def test_databricks_cli_credential_provider_installed_new(config, monkeypatch, tmp_path):
     write_large_dummy_executable(tmp_path)
-    monkeypatch.setenv('PATH', str(os.pathsep).join([tmp_path.as_posix(), os.environ['PATH']]))
+    monkeypatch.setenv("PATH", str(os.pathsep).join([tmp_path.as_posix(), os.environ["PATH"]]))
     assert databricks_cli(config) is not None
 
 
@@ -186,18 +187,20 @@ def test_extra_and_upstream_user_agent(monkeypatch):
 
         @property
         def system(self):
-            return 'TestOS'
+            return "TestOS"
 
-    monkeypatch.setattr(platform, 'python_version', lambda: '3.0.0')
-    monkeypatch.setattr(platform, 'uname', MockUname)
-    monkeypatch.setenv('DATABRICKS_SDK_UPSTREAM', "upstream-product")
-    monkeypatch.setenv('DATABRICKS_SDK_UPSTREAM_VERSION', "0.0.1")
-    monkeypatch.setenv('DATABRICKS_RUNTIME_VERSION', "13.1 anything/else")
+    monkeypatch.setattr(platform, "python_version", lambda: "3.0.0")
+    monkeypatch.setattr(platform, "uname", MockUname)
+    monkeypatch.setenv("DATABRICKS_SDK_UPSTREAM", "upstream-product")
+    monkeypatch.setenv("DATABRICKS_SDK_UPSTREAM_VERSION", "0.0.1")
+    monkeypatch.setenv("DATABRICKS_RUNTIME_VERSION", "13.1 anything/else")
 
-    config = Config(host='http://localhost', username="something", password="something", product='test',
-                    product_version='0.0.0') \
-        .with_user_agent_extra('test-extra-1', '1') \
-        .with_user_agent_extra('test-extra-2', '2')
+    config = (Config(host="http://localhost",
+                     username="something",
+                     password="something",
+                     product="test",
+                     product_version="0.0.0",
+                     ).with_user_agent_extra("test-extra-1", "1").with_user_agent_extra("test-extra-2", "2"))
 
     assert config.user_agent == (
         f"test/0.0.0 databricks-sdk-py/{__version__} python/3.0.0 os/testos auth/basic"
@@ -216,7 +219,7 @@ def test_config_copy_shallow_copies_credential_provider():
         def auth_type(self) -> str:
             return "test"
 
-        def __call__(self, cfg: 'Config') -> HeaderFactory:
+        def __call__(self, cfg: "Config") -> HeaderFactory:
             return lambda: {"token": self._token}
 
         def refresh(self):
@@ -276,8 +279,8 @@ def test_config_can_be_subclassed(fake_fs):
 
 
 def test_config_parsing_non_string_env_vars(monkeypatch):
-    monkeypatch.setenv('DATABRICKS_DEBUG_TRUNCATE_BYTES', '100')
-    c = Config(host='http://localhost', credentials_provider=noop_credentials)
+    monkeypatch.setenv("DATABRICKS_DEBUG_TRUNCATE_BYTES", "100")
+    c = Config(host="http://localhost", credentials_provider=noop_credentials)
     assert c.debug_truncate_bytes == 100
 
 
@@ -306,33 +309,36 @@ def test_api_client_do_custom_headers(config, requests_mock):
                       request_headers={
                           "test": "test",
                           "User-Agent": config.user_agent
-                      })
+                      },
+                      )
     res = client.do("GET", "/test", headers={"test": "test"})
     assert res == {"well": "done"}
 
 
 def test_access_control_list(config, requests_mock):
     requests_mock.post("http://localhost/api/2.1/jobs/create",
-                       request_headers={"User-Agent": config.user_agent})
+                       request_headers={"User-Agent": config.user_agent},
+                       )
 
     w = WorkspaceClient(config=config)
     res = w.jobs.create(access_control_list=[AccessControlRequest(group_name="group")])
 
     assert requests_mock.call_count == 1
     assert requests_mock.called
-    assert requests_mock.last_request.json() == {'access_control_list': [{'group_name': 'group'}]}
+    assert requests_mock.last_request.json() == {"access_control_list": [{"group_name": "group"}]}
 
 
 def test_shares(config, requests_mock):
     requests_mock.patch("http://localhost/api/2.1/unity-catalog/shares/jobId/permissions",
-                        request_headers={"User-Agent": config.user_agent})
+                        request_headers={"User-Agent": config.user_agent},
+                        )
 
     w = WorkspaceClient(config=config)
     res = w.shares.update_permissions(name="jobId", changes=[PermissionsChange(principal="principal")])
 
     assert requests_mock.call_count == 1
     assert requests_mock.called
-    assert requests_mock.last_request.json() == {'changes': [{'principal': 'principal'}]}
+    assert requests_mock.last_request.json() == {"changes": [{"principal": "principal"}]}
 
 
 def test_deletes(config, requests_mock):
@@ -366,8 +372,8 @@ def test_error(config, requests_mock):
             "domain": "wrong domain",
             "metadata": {
                 "etag": "wrong etag"
-            }
-        }],
+            },
+        }, ],
     }
 
     client = ApiClient(config)
@@ -402,23 +408,24 @@ def http_fixture_server(handler: typing.Callable[[BaseHTTPRequestHandler], None]
             super().__init__(*args)
 
         def __getattr__(self, item):
-            if 'do_' != item[0:3]:
-                raise AttributeError(f'method {item} not found')
+            if "do_" != item[0:3]:
+                raise AttributeError(f"method {item} not found")
             return functools.partial(self._handler, self)
 
     handler_factory = functools.partial(_handler, handler)
-    srv = HTTPServer(('localhost', 0), handler_factory)
+    srv = HTTPServer(("localhost", 0), handler_factory)
     t = Thread(target=srv.serve_forever)
     try:
         t.daemon = True
         t.start()
-        yield 'http://{0}:{1}'.format(*srv.server_address)
+        yield "http://{0}:{1}".format(*srv.server_address)
     finally:
         srv.shutdown()
 
 
-@pytest.mark.parametrize('status_code,include_retry_after',
-                         ((429, False), (429, True), (503, False), (503, True)))
+@pytest.mark.parametrize("status_code,include_retry_after",
+                         ((429, False), (429, True), (503, False), (503, True)),
+                         )
 def test_http_retry_after(status_code, include_retry_after):
     requests = []
 
@@ -426,20 +433,20 @@ def test_http_retry_after(status_code, include_retry_after):
         if len(requests) == 0:
             h.send_response(status_code)
             if include_retry_after:
-                h.send_header('Retry-After', '1')
-            h.send_header('Content-Type', 'application/json')
+                h.send_header("Retry-After", "1")
+            h.send_header("Content-Type", "application/json")
             h.end_headers()
         else:
             h.send_response(200)
-            h.send_header('Content-Type', 'application/json')
+            h.send_header("Content-Type", "application/json")
             h.end_headers()
             h.wfile.write(b'{"foo": 1}')
         requests.append(h.requestline)
 
     with http_fixture_server(inner) as host:
-        api_client = ApiClient(Config(host=host, token='_', clock=FakeClock()))
-        res = api_client.do('GET', '/foo')
-        assert 'foo' in res
+        api_client = ApiClient(Config(host=host, token="_", clock=FakeClock()))
+        res = api_client.do("GET", "/foo")
+        assert "foo" in res
 
     assert len(requests) == 2
 
@@ -450,19 +457,19 @@ def test_http_retry_after_wrong_format():
     def inner(h: BaseHTTPRequestHandler):
         if len(requests) == 0:
             h.send_response(429)
-            h.send_header('Retry-After', '1.58')
+            h.send_header("Retry-After", "1.58")
             h.end_headers()
         else:
             h.send_response(200)
-            h.send_header('Content-Type', 'application/json')
+            h.send_header("Content-Type", "application/json")
             h.end_headers()
             h.wfile.write(b'{"foo": 1}')
         requests.append(h.requestline)
 
     with http_fixture_server(inner) as host:
-        api_client = ApiClient(Config(host=host, token='_', clock=FakeClock()))
-        res = api_client.do('GET', '/foo')
-        assert 'foo' in res
+        api_client = ApiClient(Config(host=host, token="_", clock=FakeClock()))
+        res = api_client.do("GET", "/foo")
+        assert "foo" in res
 
     assert len(requests) == 2
 
@@ -472,14 +479,14 @@ def test_http_retried_exceed_limit():
 
     def inner(h: BaseHTTPRequestHandler):
         h.send_response(429)
-        h.send_header('Retry-After', '1')
+        h.send_header("Retry-After", "1")
         h.end_headers()
         requests.append(h.requestline)
 
     with http_fixture_server(inner) as host:
-        api_client = ApiClient(Config(host=host, token='_', retry_timeout_seconds=1, clock=FakeClock()))
+        api_client = ApiClient(Config(host=host, token="_", retry_timeout_seconds=1, clock=FakeClock()))
         with pytest.raises(TimeoutError):
-            api_client.do('GET', '/foo')
+            api_client.do("GET", "/foo")
 
     assert len(requests) == 1
 
@@ -499,9 +506,9 @@ def test_http_retried_on_match():
         requests.append(h.requestline)
 
     with http_fixture_server(inner) as host:
-        api_client = ApiClient(Config(host=host, token='_', clock=FakeClock()))
-        res = api_client.do('GET', '/foo')
-        assert 'foo' in res
+        api_client = ApiClient(Config(host=host, token="_", clock=FakeClock()))
+        res = api_client.do("GET", "/foo")
+        assert "foo" in res
 
     assert len(requests) == 2
 
@@ -517,9 +524,9 @@ def test_http_not_retried_on_normal_errors():
         requests.append(h.requestline)
 
     with http_fixture_server(inner) as host:
-        api_client = ApiClient(Config(host=host, token='_', clock=FakeClock()))
+        api_client = ApiClient(Config(host=host, token="_", clock=FakeClock()))
         with pytest.raises(DatabricksError):
-            api_client.do('GET', '/foo')
+            api_client.do("GET", "/foo")
 
     assert len(requests) == 1
 
@@ -535,9 +542,9 @@ def test_http_retried_on_connection_error():
         requests.append(h.requestline)
 
     with http_fixture_server(inner) as host:
-        api_client = ApiClient(Config(host=host, token='_', clock=FakeClock()))
-        res = api_client.do('GET', '/foo')
-        assert 'foo' in res
+        api_client = ApiClient(Config(host=host, token="_", clock=FakeClock()))
+        res = api_client.do("GET", "/foo")
+        assert "foo" in res
 
     assert len(requests) == 2
 
@@ -545,53 +552,57 @@ def test_http_retried_on_connection_error():
 def test_github_oidc_flow_works_with_azure(monkeypatch):
 
     def inner(h: BaseHTTPRequestHandler):
-        if 'audience=api://AzureADTokenExchange' in h.path:
-            auth = h.headers['Authorization']
-            assert 'Bearer gh-actions-token' == auth
+        if "audience=api://AzureADTokenExchange" in h.path:
+            auth = h.headers["Authorization"]
+            assert "Bearer gh-actions-token" == auth
             h.send_response(200)
             h.end_headers()
             h.wfile.write(b'{"value": "this_is_jwt_token"}')
             return
-        if '/oidc/oauth2/v2.0/authorize' == h.path:
+        if "/oidc/oauth2/v2.0/authorize" == h.path:
             h.send_response(301)
-            h.send_header('Location', f'http://{h.headers["Host"]}/mocked-tenant-id/irrelevant/part')
+            h.send_header("Location", f'http://{h.headers["Host"]}/mocked-tenant-id/irrelevant/part', )
             h.end_headers()
             return
-        if '/mocked-tenant-id/oauth2/token' == h.path:
+        if "/mocked-tenant-id/oauth2/token" == h.path:
             h.send_response(200)
             h.end_headers()
             h.wfile.write(b'{"expires_in": 100, "access_token": "this-is-it", "token_type": "Taker"}')
 
     with http_fixture_server(inner) as host:
-        monkeypatch.setenv('ACTIONS_ID_TOKEN_REQUEST_URL', f'{host}/oidc')
-        monkeypatch.setenv('ACTIONS_ID_TOKEN_REQUEST_TOKEN', 'gh-actions-token')
+        monkeypatch.setenv("ACTIONS_ID_TOKEN_REQUEST_URL", f"{host}/oidc")
+        monkeypatch.setenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", "gh-actions-token")
         azure_environment = AzureEnvironment(name=host,
-                                             service_management_endpoint=host + '/',
-                                             resource_manager_endpoint=host + '/',
-                                             active_directory_endpoint=host + '/')
+                                             service_management_endpoint=host + "/",
+                                             resource_manager_endpoint=host + "/",
+                                             active_directory_endpoint=host + "/",
+                                             )
         databricks_environment = DatabricksEnvironment(Cloud.AZURE,
-                                                       '...',
+                                                       "...",
                                                        azure_environment=azure_environment)
         cfg = Config(host=host,
                      azure_workspace_resource_id=...,
-                     azure_client_id='test',
+                     azure_client_id="test",
                      azure_environment=host,
-                     databricks_environment=databricks_environment)
+                     databricks_environment=databricks_environment,
+                     )
         headers = cfg.authenticate()
 
-        assert {'Authorization': 'Taker this-is-it'} == headers
+        assert {"Authorization": "Taker this-is-it"} == headers
 
 
-@pytest.mark.parametrize(['azure_environment', 'expected'],
-                         [('PUBLIC', ENVIRONMENTS['PUBLIC']), ('USGOVERNMENT', ENVIRONMENTS['USGOVERNMENT']),
-                          ('CHINA', ENVIRONMENTS['CHINA']), ('public', ENVIRONMENTS['PUBLIC']),
-                          ('usgovernment', ENVIRONMENTS['USGOVERNMENT']), ('china', ENVIRONMENTS['CHINA']),
+@pytest.mark.parametrize(["azure_environment", "expected"],
+                         [("PUBLIC", ENVIRONMENTS["PUBLIC"]), ("USGOVERNMENT", ENVIRONMENTS["USGOVERNMENT"]),
+                          ("CHINA", ENVIRONMENTS["CHINA"]), ("public", ENVIRONMENTS["PUBLIC"]),
+                          ("usgovernment", ENVIRONMENTS["USGOVERNMENT"]), ("china", ENVIRONMENTS["CHINA"]),
                           # Kept for historical compatibility
-                          ('AzurePublicCloud', ENVIRONMENTS['PUBLIC']),
-                          ('AzureUSGovernment', ENVIRONMENTS['USGOVERNMENT']),
-                          ('AzureChinaCloud', ENVIRONMENTS['CHINA']), ])
+                          ("AzurePublicCloud", ENVIRONMENTS["PUBLIC"]),
+                          ("AzureUSGovernment", ENVIRONMENTS["USGOVERNMENT"]),
+                          ("AzureChinaCloud", ENVIRONMENTS["CHINA"]), ],
+                         )
 def test_azure_environment(azure_environment, expected):
     c = Config(credentials_provider=noop_credentials,
-               azure_workspace_resource_id='...',
-               azure_environment=azure_environment)
+               azure_workspace_resource_id="...",
+               azure_environment=azure_environment,
+               )
     assert c.arm_environment == expected


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
For some DELETE requests, notably when deleting an Alert, the API returns a JSON response containing only `null`. This is not seen as an empty response, because the content length is greater than zero.

When calling `WorkspaceClient.alerts.delete(alertId)`, this results in the alert being deleted as expected. However, a `TypeError` is raised when trying to unpack the response at `databricks/sdk/core.py:170`.

To fix this, we will null-check the decoded JSON before attempting to unpack it. If it is `None`, we will simply return the response dict like we do for empty responses.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [X] `make test` run locally
- [X] `make fmt` applied
  - This seems to have modified far more lines than expected.
  - Actual code changes are [here](https://github.com/databricks/databricks-sdk-py/pull/641/files#diff-62999ba950664150f7db28196ce10b0ef471f324264425a682a169b109ce5c03R153)
  - New test is [here](https://github.com/databricks/databricks-sdk-py/pull/641/files#diff-938de46e643ab091cff6a7c23e4e752e8907e2266f47889d988923352f7a1058R344)
- [X] relevant integration tests applied
  - Added a test which shows the `null` response received when calling `DELETE /api/2.0/preview/sql/alerts/alertid`. This test fails before applying my fix, and passes with the fix in place.

