### PR TITLE
Better error message when private link enabled workspaces reject requests

### DIFF
--- a/databricks/sdk/azure.py
+++ b/databricks/sdk/azure.py
@@ -5,32 +5,6 @@ from .oauth import TokenSource
 from .service.provisioning import Workspace
 
 
-@dataclass
-class AzureEnvironment:
-    name: str
-    service_management_endpoint: str
-    resource_manager_endpoint: str
-    active_directory_endpoint: str
-
-
-ARM_DATABRICKS_RESOURCE_ID = "2ff814a6-3304-4ab8-85cb-cd0e6f879c1d"
-
-ENVIRONMENTS = dict(
-    PUBLIC=AzureEnvironment(name="PUBLIC",
-                            service_management_endpoint="https://management.core.windows.net/",
-                            resource_manager_endpoint="https://management.azure.com/",
-                            active_directory_endpoint="https://login.microsoftonline.com/"),
-    USGOVERNMENT=AzureEnvironment(name="USGOVERNMENT",
-                                  service_management_endpoint="https://management.core.usgovcloudapi.net/",
-                                  resource_manager_endpoint="https://management.usgovcloudapi.net/",
-                                  active_directory_endpoint="https://login.microsoftonline.us/"),
-    CHINA=AzureEnvironment(name="CHINA",
-                           service_management_endpoint="https://management.core.chinacloudapi.cn/",
-                           resource_manager_endpoint="https://management.chinacloudapi.cn/",
-                           active_directory_endpoint="https://login.chinacloudapi.cn/"),
-)
-
-
 def add_workspace_id_header(cfg: 'Config', headers: Dict[str, str]):
     if cfg.azure_workspace_resource_id:
         headers["X-Databricks-Azure-Workspace-Resource-Id"] = cfg.azure_workspace_resource_id

--- a/databricks/sdk/azure.py
+++ b/databricks/sdk/azure.py
@@ -1,4 +1,3 @@
-from dataclasses import dataclass
 from typing import Dict
 
 from .oauth import TokenSource

--- a/databricks/sdk/config.py
+++ b/databricks/sdk/config.py
@@ -167,6 +167,8 @@ class Config:
 
     @property
     def is_azure(self) -> bool:
+        if self.azure_workspace_resource_id:
+            return True
         return self.environment.cloud == Cloud.AZURE
 
     @property

--- a/databricks/sdk/config.py
+++ b/databricks/sdk/config.py
@@ -10,11 +10,10 @@ from typing import Dict, Iterable, Optional
 
 import requests
 
-from .azure import AzureEnvironment
 from .clock import Clock, RealClock
 from .credentials_provider import CredentialsProvider, DefaultCredentials
-from .environments import (ALL_ENVS, DEFAULT_ENVIRONMENT, Cloud,
-                           DatabricksEnvironment)
+from .environments import (ALL_ENVS, AzureEnvironment, Cloud,
+                           DatabricksEnvironment, get_environment_for_hostname)
 from .oauth import OidcEndpoints
 from .version import __version__
 
@@ -154,11 +153,7 @@ class Config:
         """Returns the environment based on configuration."""
         if self.databricks_environment:
             return self.databricks_environment
-        if self.host:
-            for environment in ALL_ENVS:
-                if self.host.endswith(environment.dns_zone):
-                    return environment
-        if self.azure_workspace_resource_id:
+        if not self.host and self.azure_workspace_resource_id:
             azure_env = self._get_azure_environment_name()
             for environment in ALL_ENVS:
                 if environment.cloud != Cloud.AZURE:
@@ -168,7 +163,7 @@ class Config:
                 if environment.dns_zone.startswith(".dev") or environment.dns_zone.startswith(".staging"):
                     continue
                 return environment
-        return DEFAULT_ENVIRONMENT
+        return get_environment_for_hostname(self.host)
 
     @property
     def is_azure(self) -> bool:

--- a/databricks/sdk/core.py
+++ b/databricks/sdk/core.py
@@ -238,7 +238,8 @@ class ApiClient:
             if not response.ok: # internally calls response.raise_for_status()
                 # TODO: experiment with traceback pruning for better readability
                 # See https://stackoverflow.com/a/58821552/277035
-                response.json()
+                payload = response.json()
+                raise self._make_nicer_error(response=response, **payload) from None
             # Private link failures happen via a redirect to the login page. From a requests-perspective, the request
             # is successful, but the response is not what we expect. We need to handle this case separately.
             if _is_private_link_redirect(response):

--- a/databricks/sdk/core.py
+++ b/databricks/sdk/core.py
@@ -238,7 +238,7 @@ class ApiClient:
             if not response.ok: # internally calls response.raise_for_status()
                 # TODO: experiment with traceback pruning for better readability
                 # See https://stackoverflow.com/a/58821552/277035
-                payload = response.json()
+                response.json()
             # Private link failures happen via a redirect to the login page. From a requests-perspective, the request
             # is successful, but the response is not what we expect. We need to handle this case separately.
             if _is_private_link_redirect(response):

--- a/databricks/sdk/core.py
+++ b/databricks/sdk/core.py
@@ -12,6 +12,7 @@ from .config import *
 # To preserve backwards compatibility (as these definitions were previously in this module)
 from .credentials_provider import *
 from .errors import DatabricksError, error_mapper
+from .errors.private_link import _is_private_link_redirect
 from .retries import retried
 
 __all__ = ['Config', 'DatabricksError']
@@ -238,7 +239,10 @@ class ApiClient:
                 # TODO: experiment with traceback pruning for better readability
                 # See https://stackoverflow.com/a/58821552/277035
                 payload = response.json()
-                raise self._make_nicer_error(response=response, **payload) from None
+            # Private link failures happen via a redirect to the login page. From a requests-perspective, the request
+            # is successful, but the response is not what we expect. We need to handle this case separately.
+            if _is_private_link_redirect(response):
+                raise self._make_nicer_error(response=response) from None
             return response
         except requests.exceptions.JSONDecodeError:
             message = self._make_sense_from_html(response.text)

--- a/databricks/sdk/environments.py
+++ b/databricks/sdk/environments.py
@@ -97,6 +97,8 @@ ALL_ENVS = [
 
 
 def get_environment_for_hostname(hostname: str) -> DatabricksEnvironment:
+    if not hostname:
+        return DEFAULT_ENVIRONMENT
     for env in ALL_ENVS:
         if hostname.endswith(env.dns_zone):
             return env

--- a/databricks/sdk/environments.py
+++ b/databricks/sdk/environments.py
@@ -2,7 +2,31 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Optional
 
-from .azure import ARM_DATABRICKS_RESOURCE_ID, ENVIRONMENTS, AzureEnvironment
+
+@dataclass
+class AzureEnvironment:
+    name: str
+    service_management_endpoint: str
+    resource_manager_endpoint: str
+    active_directory_endpoint: str
+
+
+ARM_DATABRICKS_RESOURCE_ID = "2ff814a6-3304-4ab8-85cb-cd0e6f879c1d"
+
+ENVIRONMENTS = dict(
+    PUBLIC=AzureEnvironment(name="PUBLIC",
+                            service_management_endpoint="https://management.core.windows.net/",
+                            resource_manager_endpoint="https://management.azure.com/",
+                            active_directory_endpoint="https://login.microsoftonline.com/"),
+    USGOVERNMENT=AzureEnvironment(name="USGOVERNMENT",
+                                  service_management_endpoint="https://management.core.usgovcloudapi.net/",
+                                  resource_manager_endpoint="https://management.usgovcloudapi.net/",
+                                  active_directory_endpoint="https://login.microsoftonline.us/"),
+    CHINA=AzureEnvironment(name="CHINA",
+                           service_management_endpoint="https://management.core.chinacloudapi.cn/",
+                           resource_manager_endpoint="https://management.chinacloudapi.cn/",
+                           active_directory_endpoint="https://login.chinacloudapi.cn/"),
+)
 
 
 class Cloud(Enum):
@@ -70,3 +94,10 @@ ALL_ENVS = [
     DatabricksEnvironment(Cloud.GCP, ".staging.gcp.databricks.com"),
     DatabricksEnvironment(Cloud.GCP, ".gcp.databricks.com")
 ]
+
+
+def get_environment_for_hostname(hostname: str) -> DatabricksEnvironment:
+    for env in ALL_ENVS:
+        if hostname.endswith(env.dns_zone):
+            return env
+    return DEFAULT_ENVIRONMENT

--- a/databricks/sdk/errors/__init__.py
+++ b/databricks/sdk/errors/__init__.py
@@ -1,5 +1,5 @@
 from .base import DatabricksError, ErrorDetail
 from .mapper import error_mapper
 from .platform import *
-from .sdk import *
 from .private_link import PrivateLinkValidationError
+from .sdk import *

--- a/databricks/sdk/errors/__init__.py
+++ b/databricks/sdk/errors/__init__.py
@@ -2,3 +2,4 @@ from .base import DatabricksError, ErrorDetail
 from .mapper import error_mapper
 from .platform import *
 from .sdk import *
+from .private_link import PrivateLinkValidationError

--- a/databricks/sdk/errors/mapper.py
+++ b/databricks/sdk/errors/mapper.py
@@ -4,6 +4,7 @@ from databricks.sdk.errors import platform
 from databricks.sdk.errors.base import DatabricksError
 
 from .overrides import _ALL_OVERRIDES
+from .private_link import _is_private_link_redirect, _get_private_link_validation_error
 
 
 def error_mapper(response: requests.Response, raw: dict) -> DatabricksError:
@@ -21,7 +22,11 @@ def error_mapper(response: requests.Response, raw: dict) -> DatabricksError:
         # where there's a default exception class per HTTP status code, and we do
         # rely on Databricks platform exception mapper to do the right thing.
         return platform.STATUS_CODE_MAPPING[status_code](**raw)
+    if _is_private_link_redirect(response):
+        return _get_private_link_validation_error(response.url)
 
     # backwards-compatible error creation for cases like using older versions of
     # the SDK on way never releases of the platform.
     return DatabricksError(**raw)
+
+

--- a/databricks/sdk/errors/mapper.py
+++ b/databricks/sdk/errors/mapper.py
@@ -4,7 +4,8 @@ from databricks.sdk.errors import platform
 from databricks.sdk.errors.base import DatabricksError
 
 from .overrides import _ALL_OVERRIDES
-from .private_link import _is_private_link_redirect, _get_private_link_validation_error
+from .private_link import (_get_private_link_validation_error,
+                           _is_private_link_redirect)
 
 
 def error_mapper(response: requests.Response, raw: dict) -> DatabricksError:
@@ -28,5 +29,3 @@ def error_mapper(response: requests.Response, raw: dict) -> DatabricksError:
     # backwards-compatible error creation for cases like using older versions of
     # the SDK on way never releases of the platform.
     return DatabricksError(**raw)
-
-

--- a/databricks/sdk/errors/private_link.py
+++ b/databricks/sdk/errors/private_link.py
@@ -1,10 +1,11 @@
-from urllib import parse
 from dataclasses import dataclass
+from urllib import parse
 
 import requests
 
-from .platform import PermissionDenied
 from ..environments import Cloud, get_environment_for_hostname
+from .platform import PermissionDenied
+
 
 @dataclass
 class _PrivateLinkInfo:
@@ -16,21 +17,23 @@ class _PrivateLinkInfo:
         return (
             f'The requested workspace has {self.serviceName} enabled and is not accessible from the current network. '
             f'Ensure that {self.serviceName} is properly configured and that your device has access to the '
-            f'{self.endpointName}. For more information, see {self.referencePage}.'
-        )
+            f'{self.endpointName}. For more information, see {self.referencePage}.')
+
 
 _private_link_info_map = {
-    Cloud.AWS: _PrivateLinkInfo(
-        serviceName='AWS PrivateLink',
-        endpointName='AWS VPC endpoint',
-        referencePage='https://docs.databricks.com/en/security/network/classic/privatelink.html',
-    ),
-    Cloud.AZURE: _PrivateLinkInfo(
+    Cloud.AWS:
+    _PrivateLinkInfo(serviceName='AWS PrivateLink',
+                     endpointName='AWS VPC endpoint',
+                     referencePage='https://docs.databricks.com/en/security/network/classic/privatelink.html',
+                     ),
+    Cloud.AZURE:
+    _PrivateLinkInfo(
         serviceName='Azure Private Link',
         endpointName='Azure Private Link endpoint',
         referencePage='https://learn.microsoft.com/en-us/azure/databricks/security/network/classic/private-link-standard#authentication-troubleshooting',
     ),
-    Cloud.GCP: _PrivateLinkInfo(
+    Cloud.GCP:
+    _PrivateLinkInfo(
         serviceName='Private Service Connect',
         endpointName='GCP VPC endpoint',
         referencePage='https://docs.gcp.databricks.com/en/security/network/classic/private-service-connect.html',
@@ -51,8 +54,7 @@ def _is_private_link_redirect(resp: requests.Response) -> bool:
 def _get_private_link_validation_error(url: str) -> _PrivateLinkInfo:
     parsed = parse.urlparse(url)
     env = get_environment_for_hostname(parsed.hostname)
-    return PrivateLinkValidationError(
-        message=_private_link_info_map[env.cloud].error_message(),
-        error_code='PRIVATE_LINK_VALIDATION_ERROR',
-        status_code=403,
-    )
+    return PrivateLinkValidationError(message=_private_link_info_map[env.cloud].error_message(),
+                                      error_code='PRIVATE_LINK_VALIDATION_ERROR',
+                                      status_code=403,
+                                      )

--- a/databricks/sdk/errors/private_link.py
+++ b/databricks/sdk/errors/private_link.py
@@ -1,0 +1,58 @@
+from urllib import parse
+from dataclasses import dataclass
+
+import requests
+
+from .platform import PermissionDenied
+from ..environments import Cloud, get_environment_for_hostname
+
+@dataclass
+class _PrivateLinkInfo:
+    serviceName: str
+    endpointName: str
+    referencePage: str
+
+    def error_message(self):
+        return (
+            f'The requested workspace has {self.serviceName} enabled and is not accessible from the current network. '
+            f'Ensure that {self.serviceName} is properly configured and that your device has access to the '
+            f'{self.endpointName}. For more information, see {self.referencePage}.'
+        )
+
+_private_link_info_map = {
+    Cloud.AWS: _PrivateLinkInfo(
+        serviceName='AWS PrivateLink',
+        endpointName='AWS VPC endpoint',
+        referencePage='https://docs.databricks.com/en/security/network/classic/privatelink.html',
+    ),
+    Cloud.AZURE: _PrivateLinkInfo(
+        serviceName='Azure Private Link',
+        endpointName='Azure Private Link endpoint',
+        referencePage='https://learn.microsoft.com/en-us/azure/databricks/security/network/classic/private-link-standard#authentication-troubleshooting',
+    ),
+    Cloud.GCP: _PrivateLinkInfo(
+        serviceName='Private Service Connect',
+        endpointName='GCP VPC endpoint',
+        referencePage='https://docs.gcp.databricks.com/en/security/network/classic/private-service-connect.html',
+    )
+}
+
+
+class PrivateLinkValidationError(PermissionDenied):
+    """Raised when a user tries to access a Private Link-enabled workspace, but the user's network does not have access
+    to the workspace."""
+
+
+def _is_private_link_redirect(resp: requests.Response) -> bool:
+    parsed = parse.urlparse(resp.url)
+    return parsed.path == '/login.html' and 'error=private-link-validation-error' in parsed.query
+
+
+def _get_private_link_validation_error(url: str) -> _PrivateLinkInfo:
+    parsed = parse.urlparse(url)
+    env = get_environment_for_hostname(parsed.hostname)
+    return PrivateLinkValidationError(
+        message=_private_link_info_map[env.cloud].error_message(),
+        error_code='PRIVATE_LINK_VALIDATION_ERROR',
+        status_code=403,
+    )

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -196,10 +196,10 @@ def test_config_azure_pat():
 def test_config_azure_cli_host(monkeypatch):
     monkeypatch.setenv('HOME', __tests__ + '/testdata/azure')
     monkeypatch.setenv('PATH', __tests__ + '/testdata:/bin')
-    cfg = Config(host='x', azure_workspace_resource_id='/sub/rg/ws')
+    cfg = Config(host='https://adb-123.4.azuredatabricks.net', azure_workspace_resource_id='/sub/rg/ws')
 
     assert cfg.auth_type == 'azure-cli'
-    assert cfg.host == 'https://x'
+    assert cfg.host == 'https://adb-123.4.azuredatabricks.net'
     assert cfg.is_azure
 
 
@@ -232,10 +232,10 @@ def test_config_azure_cli_host_pat_conflict_with_config_file_present_without_def
 def test_config_azure_cli_host_and_resource_id(monkeypatch):
     monkeypatch.setenv('HOME', __tests__ + '/testdata')
     monkeypatch.setenv('PATH', __tests__ + '/testdata:/bin')
-    cfg = Config(host='x', azure_workspace_resource_id='/sub/rg/ws')
+    cfg = Config(host='https://adb-123.4.azuredatabricks.net', azure_workspace_resource_id='/sub/rg/ws')
 
     assert cfg.auth_type == 'azure-cli'
-    assert cfg.host == 'https://x'
+    assert cfg.host == 'https://adb-123.4.azuredatabricks.net'
     assert cfg.is_azure
 
 
@@ -243,21 +243,21 @@ def test_config_azure_cli_host_and_resource_i_d_configuration_precedence(monkeyp
     monkeypatch.setenv('DATABRICKS_CONFIG_PROFILE', 'justhost')
     monkeypatch.setenv('HOME', __tests__ + '/testdata/azure')
     monkeypatch.setenv('PATH', __tests__ + '/testdata:/bin')
-    cfg = Config(host='x', azure_workspace_resource_id='/sub/rg/ws')
+    cfg = Config(host='https://adb-123.4.azuredatabricks.net', azure_workspace_resource_id='/sub/rg/ws')
 
     assert cfg.auth_type == 'azure-cli'
-    assert cfg.host == 'https://x'
+    assert cfg.host == 'https://adb-123.4.azuredatabricks.net'
     assert cfg.is_azure
 
 
 @raises(
-    "validate: more than one authorization method configured: azure and basic. Config: host=https://x, username=x, azure_workspace_resource_id=/sub/rg/ws. Env: DATABRICKS_USERNAME"
+    "validate: more than one authorization method configured: azure and basic. Config: host=https://adb-123.4.azuredatabricks.net, username=x, azure_workspace_resource_id=/sub/rg/ws. Env: DATABRICKS_USERNAME"
 )
 def test_config_azure_and_password_conflict(monkeypatch):
     monkeypatch.setenv('DATABRICKS_USERNAME', 'x')
     monkeypatch.setenv('HOME', __tests__ + '/testdata/azure')
     monkeypatch.setenv('PATH', __tests__ + '/testdata:/bin')
-    cfg = Config(host='x', azure_workspace_resource_id='/sub/rg/ws')
+    cfg = Config(host='https://adb-123.4.azuredatabricks.net', azure_workspace_resource_id='/sub/rg/ws')
 
 
 @raises(

--- a/tests/test_auth_manual_tests.py
+++ b/tests/test_auth_manual_tests.py
@@ -7,7 +7,7 @@ def test_azure_cli_workspace_header_present(monkeypatch):
     monkeypatch.setenv('HOME', __tests__ + '/testdata/azure')
     monkeypatch.setenv('PATH', __tests__ + '/testdata:/bin')
     resource_id = '/subscriptions/123/resourceGroups/abc/providers/Microsoft.Databricks/workspaces/abc123'
-    cfg = Config(auth_type='azure-cli', host='x', azure_workspace_resource_id=resource_id)
+    cfg = Config(auth_type='azure-cli', host='https://adb-123.4.azuredatabricks.net', azure_workspace_resource_id=resource_id)
     assert 'X-Databricks-Azure-Workspace-Resource-Id' in cfg.authenticate()
     assert cfg.authenticate()['X-Databricks-Azure-Workspace-Resource-Id'] == resource_id
 
@@ -16,7 +16,7 @@ def test_azure_cli_user_with_management_access(monkeypatch):
     monkeypatch.setenv('HOME', __tests__ + '/testdata/azure')
     monkeypatch.setenv('PATH', __tests__ + '/testdata:/bin')
     resource_id = '/subscriptions/123/resourceGroups/abc/providers/Microsoft.Databricks/workspaces/abc123'
-    cfg = Config(auth_type='azure-cli', host='x', azure_workspace_resource_id=resource_id)
+    cfg = Config(auth_type='azure-cli', host='https://adb-123.4.azuredatabricks.net', azure_workspace_resource_id=resource_id)
     assert 'X-Databricks-Azure-SP-Management-Token' in cfg.authenticate()
 
 
@@ -25,7 +25,7 @@ def test_azure_cli_user_no_management_access(monkeypatch):
     monkeypatch.setenv('PATH', __tests__ + '/testdata:/bin')
     monkeypatch.setenv('FAIL_IF', 'https://management.core.windows.net/')
     resource_id = '/subscriptions/123/resourceGroups/abc/providers/Microsoft.Databricks/workspaces/abc123'
-    cfg = Config(auth_type='azure-cli', host='x', azure_workspace_resource_id=resource_id)
+    cfg = Config(auth_type='azure-cli', host='https://adb-123.4.azuredatabricks.net', azure_workspace_resource_id=resource_id)
     assert 'X-Databricks-Azure-SP-Management-Token' not in cfg.authenticate()
 
 
@@ -34,7 +34,7 @@ def test_azure_cli_fallback(monkeypatch):
     monkeypatch.setenv('PATH', __tests__ + '/testdata:/bin')
     monkeypatch.setenv('FAIL_IF', 'subscription')
     resource_id = '/subscriptions/123/resourceGroups/abc/providers/Microsoft.Databricks/workspaces/abc123'
-    cfg = Config(auth_type='azure-cli', host='x', azure_workspace_resource_id=resource_id)
+    cfg = Config(auth_type='azure-cli', host='https://adb-123.4.azuredatabricks.net', azure_workspace_resource_id=resource_id)
     assert 'X-Databricks-Azure-SP-Management-Token' in cfg.authenticate()
 
 
@@ -43,5 +43,5 @@ def test_azure_cli_with_warning_on_stderr(monkeypatch):
     monkeypatch.setenv('PATH', __tests__ + '/testdata:/bin')
     monkeypatch.setenv('WARN', 'this is a warning')
     resource_id = '/subscriptions/123/resourceGroups/abc/providers/Microsoft.Databricks/workspaces/abc123'
-    cfg = Config(auth_type='azure-cli', host='x', azure_workspace_resource_id=resource_id)
+    cfg = Config(auth_type='azure-cli', host='https://adb-123.4.azuredatabricks.net', azure_workspace_resource_id=resource_id)
     assert 'X-Databricks-Azure-SP-Management-Token' in cfg.authenticate()

--- a/tests/test_auth_manual_tests.py
+++ b/tests/test_auth_manual_tests.py
@@ -7,7 +7,9 @@ def test_azure_cli_workspace_header_present(monkeypatch):
     monkeypatch.setenv('HOME', __tests__ + '/testdata/azure')
     monkeypatch.setenv('PATH', __tests__ + '/testdata:/bin')
     resource_id = '/subscriptions/123/resourceGroups/abc/providers/Microsoft.Databricks/workspaces/abc123'
-    cfg = Config(auth_type='azure-cli', host='https://adb-123.4.azuredatabricks.net', azure_workspace_resource_id=resource_id)
+    cfg = Config(auth_type='azure-cli',
+                 host='https://adb-123.4.azuredatabricks.net',
+                 azure_workspace_resource_id=resource_id)
     assert 'X-Databricks-Azure-Workspace-Resource-Id' in cfg.authenticate()
     assert cfg.authenticate()['X-Databricks-Azure-Workspace-Resource-Id'] == resource_id
 
@@ -16,7 +18,9 @@ def test_azure_cli_user_with_management_access(monkeypatch):
     monkeypatch.setenv('HOME', __tests__ + '/testdata/azure')
     monkeypatch.setenv('PATH', __tests__ + '/testdata:/bin')
     resource_id = '/subscriptions/123/resourceGroups/abc/providers/Microsoft.Databricks/workspaces/abc123'
-    cfg = Config(auth_type='azure-cli', host='https://adb-123.4.azuredatabricks.net', azure_workspace_resource_id=resource_id)
+    cfg = Config(auth_type='azure-cli',
+                 host='https://adb-123.4.azuredatabricks.net',
+                 azure_workspace_resource_id=resource_id)
     assert 'X-Databricks-Azure-SP-Management-Token' in cfg.authenticate()
 
 
@@ -25,7 +29,9 @@ def test_azure_cli_user_no_management_access(monkeypatch):
     monkeypatch.setenv('PATH', __tests__ + '/testdata:/bin')
     monkeypatch.setenv('FAIL_IF', 'https://management.core.windows.net/')
     resource_id = '/subscriptions/123/resourceGroups/abc/providers/Microsoft.Databricks/workspaces/abc123'
-    cfg = Config(auth_type='azure-cli', host='https://adb-123.4.azuredatabricks.net', azure_workspace_resource_id=resource_id)
+    cfg = Config(auth_type='azure-cli',
+                 host='https://adb-123.4.azuredatabricks.net',
+                 azure_workspace_resource_id=resource_id)
     assert 'X-Databricks-Azure-SP-Management-Token' not in cfg.authenticate()
 
 
@@ -34,7 +40,9 @@ def test_azure_cli_fallback(monkeypatch):
     monkeypatch.setenv('PATH', __tests__ + '/testdata:/bin')
     monkeypatch.setenv('FAIL_IF', 'subscription')
     resource_id = '/subscriptions/123/resourceGroups/abc/providers/Microsoft.Databricks/workspaces/abc123'
-    cfg = Config(auth_type='azure-cli', host='https://adb-123.4.azuredatabricks.net', azure_workspace_resource_id=resource_id)
+    cfg = Config(auth_type='azure-cli',
+                 host='https://adb-123.4.azuredatabricks.net',
+                 azure_workspace_resource_id=resource_id)
     assert 'X-Databricks-Azure-SP-Management-Token' in cfg.authenticate()
 
 
@@ -43,5 +51,7 @@ def test_azure_cli_with_warning_on_stderr(monkeypatch):
     monkeypatch.setenv('PATH', __tests__ + '/testdata:/bin')
     monkeypatch.setenv('WARN', 'this is a warning')
     resource_id = '/subscriptions/123/resourceGroups/abc/providers/Microsoft.Databricks/workspaces/abc123'
-    cfg = Config(auth_type='azure-cli', host='https://adb-123.4.azuredatabricks.net', azure_workspace_resource_id=resource_id)
+    cfg = Config(auth_type='azure-cli',
+                 host='https://adb-123.4.azuredatabricks.net',
+                 azure_workspace_resource_id=resource_id)
     assert 'X-Databricks-Azure-SP-Management-Token' in cfg.authenticate()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -14,14 +14,13 @@ import pytest
 import requests
 
 from databricks.sdk import WorkspaceClient
-from databricks.sdk.azure import ENVIRONMENTS, AzureEnvironment
 from databricks.sdk.core import (ApiClient, Config, DatabricksError,
                                  StreamingResponse)
 from databricks.sdk.credentials_provider import (CliTokenSource,
                                                  CredentialsProvider,
                                                  DatabricksCliTokenSource,
                                                  HeaderFactory, databricks_cli)
-from databricks.sdk.environments import Cloud, DatabricksEnvironment
+from databricks.sdk.environments import Cloud, DatabricksEnvironment, ENVIRONMENTS, AzureEnvironment
 from databricks.sdk.service.catalog import PermissionsChange
 from databricks.sdk.service.iam import AccessControlRequest
 from databricks.sdk.version import __version__

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -20,7 +20,8 @@ from databricks.sdk.credentials_provider import (CliTokenSource,
                                                  CredentialsProvider,
                                                  DatabricksCliTokenSource,
                                                  HeaderFactory, databricks_cli)
-from databricks.sdk.environments import Cloud, DatabricksEnvironment, ENVIRONMENTS, AzureEnvironment
+from databricks.sdk.environments import (ENVIRONMENTS, AzureEnvironment, Cloud,
+                                         DatabricksEnvironment)
 from databricks.sdk.service.catalog import PermissionsChange
 from databricks.sdk.service.iam import AccessControlRequest
 from databricks.sdk.version import __version__

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -34,6 +34,14 @@ def test_missing_error_code():
     assert errors.DatabricksError == type(err)
 
 
+def test_private_link_error():
+    resp = requests.Response()
+    resp.url = 'https://databricks.com/login.html?error=private-link-validation-error'
+    resp.request = requests.Request('GET', 'https://databricks.com/api/2.0/service').prepare()
+    err = errors.error_mapper(resp, {})
+    assert errors.PrivateLinkValidationError == type(err)
+
+
 @pytest.mark.parametrize('status_code, error_code, klass',
                          [(400, ..., errors.BadRequest), (400, 'INVALID_PARAMETER_VALUE', errors.BadRequest),
                           (400, 'INVALID_PARAMETER_VALUE', errors.InvalidParameterValue),


### PR DESCRIPTION
## Changes
This PR ports https://github.com/databricks/databricks-sdk-go/pull/924 to the Python SDK.

When a user tries to access a Private Link-enabled workspace configured with no public internet access from a different network than the VPC endpoint belongs to, the Private Link backend redirects the user to the login page, rather than outright rejecting the request. The login page, however, is not a JSON document and cannot be parsed by the SDK, resulting in this error message:

```
$ databricks current-user me
Error: unexpected error handling request: invalid character '<' looking for beginning of value. This is likely a bug in the Databricks SDK for Go or the underlying REST API. Please report this issue with the following debugging information to the SDK issue tracker at https://github.com/databricks/databricks-sdk-go/issues. Request log:
GET /login.html?error=private-link-validation-error:<WSID>
> * Host: 
> * Accept: application/json
> * Authorization: REDACTED
> * Referer: https://adb-<WSID>.azuredatabricks.net/api/2.0/preview/scim/v2/Me
> * User-Agent: cli/0.0.0-dev+5ed10bb8ccc1 databricks-sdk-go/0.39.0 go/1.22.2 os/darwin cmd/current-user_me auth/pat
< HTTP/2.0 200 OK
< * Cache-Control: no-cache, no-store, must-revalidate
< * Content-Security-Policy: default-src *; font-src * data:; frame-src * blob:; img-src * blob: data:; media-src * data:; object-src 'none'; style-src * 'unsafe-inline'; worker-src * blob:; script-src 'self' 'unsafe-eval' 'unsafe-hashes' 'report-sample' https://*.databricks.com https://databricks.github.io/debug-bookmarklet/ https://widget.intercom.io https://js.intercomcdn.com https://ajax.googleapis.com/ajax/libs/jquery/2.2.0/jquery.min.js https://databricks-ui-assets.azureedge.net https://ui-serving-cdn-testing.azureedge.net https://uiserviceprodwestus-cdn-endpoint.azureedge.net https://databricks-ui-infra.s3.us-west-2.amazonaws.com 'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=' 'sha256-YOlue469P2BtTMZYUFLupA2aOUsgc6B/TDewH7/Qz7s=' 'sha256-Lh4yp7cr3YOJ3MOn6erNz3E3WI0JA20mWV+0RuuviFM=' 'sha256-0jMhpY6PB/BTRDLWtfcjdwiHOpE+6rFk3ohvY6fbuHU='; report-uri /ui-csp-reports; frame-ancestors *.vocareum.com *.docebosaas.com *.edx.org *.deloitte.com *.cloudlabs.ai *.databricks.com *.myteksi.net
< * Content-Type: text/html; charset=utf-8
< * Date: Fri, 17 May 2024 07:47:38 GMT
< * Server: databricks
< * Set-Cookie: enable-armeria-workspace-server-for-ui-flags=false; Max-Age=1800; Expires=Fri, 17 May 2024 08:17:38 GMT; Secure; HTTPOnly; SameSite=Strict
< * Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
< * X-Content-Type-Options: nosniff
< * X-Ui-Svc: true
< * X-Xss-Protection: 1; mode=block
< <!doctype html>
< <html>
<  <head>
<   <meta charset="utf-8">
<   <meta http-equiv="Content-Language" content="en">
<   <title>Databricks - Sign In</title>
<   <meta name="viewport" content="width=960">
<   <link rel="icon" type="image/png" href="https://databricks-ui-assets.azureedge.net/favicon.ico">
<   <meta http-equiv="content-type" content="text/html; charset=UTF8">
<   <script id="__databricks_react_script"></script>
<   <script>window.__DATABRICKS_SAFE_FLAGS__={"databricks.infra.showErrorModalOnFetchError":true,"databricks.fe.infra.useReact18":true,"databricks.fe.infra.useReact18NewAPI":false,"databricks.fe.infra.fixConfigPrefetch":true},window.__DATABRICKS_CONFIG__={"publicPath":{"mlflow":"https://databricks-ui-assets.azureedge.net/","dbsql":"https://databricks-ui-assets.azureedge.net/","feature-store":"https://databricks-ui-assets.azureedge.net/","monolith":"https://databricks-ui-assets.azureedge.net/","jaws":"https://databricks-ui-assets.azureedge.net/"}}</script>
<   <link rel="icon" href="https://databricks-ui-assets.azureedge.net/favicon.ico">
<   <script>
<   function setNoCdnAndReload() {
<       document.cookie = `x-databricks-cdn-inaccessible=true; path=/; max-age=86400`;
<       const metric = 'cdnFallbackOccurred';
<       const browserUserAgent = navigator.userAgent;
<       const browserTabId = window.browserTabId;
<       const performanceEntry = performance.getEntriesByType('resource').filter(e => e.initiatorType === 'script').slice(-1)[0]
<       sessionStorage.setItem('databricks-cdn-fallback-telemetry-key', JSON.stringify({ tags: { browserUserAgent, browserTabId }, performanceEntry}));
<       window.location.reload();
<   }
< </script>
<   <script>
<   // Set a manual timeout for dropped packets to CDN
<   function loadScriptWithTimeout(src, timeout) {
<      return new Promise((resolve, reject) => {
<         const script = document.createElement('script');
<           script.defer = true;
<           script.src = src;
<           script.onload = resolve;
<           script.onerror = reject;
<           document.head.appendChild(script);
<           setTimeout(() => {
<               reject(new Error('Script load timeout'));
<           }, timeout);
<       });
<   }
<   loadScriptWithTimeout('https://databricks-ui-assets.azureedge.net/static/js/login/login.8a983ca2.js', 10000).catch(setNoCdnAndReload);
< </script>
<  </head>
<  <body class="light-mode">
<   <uses-legacy-bootstrap>
<    <div id="login-page"></div>
<   </uses-legacy-bootstrap>
<  </body>
< </html>
```

To address this, I add one additional check in the error mapper logic to inspect whether the user was redirected to the login page with the private link validation error response code. If so, we return a custom error, `PrivateLinkValidationError`, with error code `PRIVATE_LINK_VALIDATION_ERROR` that inherits from PermissionDenied and has a mock 403 status code.

After this change, users will see an error message like this:
```
databricks.sdk.errors.private_link.PrivateLinkValidationError: The requested workspace has Azure Private Link enabled and is not accessible from the current network. Ensure that Azure Private Link is properly configured and that your device has access to the Azure Private Link endpoint. For more information, see https://learn.microsoft.com/en-us/azure/databricks/security/network/classic/private-link-standard#authentication-troubleshooting.
```

The error message is tuned to the specific cloud so that we can redirect users to the appropriate documentation, the cloud being inferred from the request URI.

## Tests
Unit tests cover the private link error message mapping.
To manually test this, I created a private link workspace in Azure, created an access token, restricted access to the workspace, then ran the `last_job_runs.py` example using the host & token:
```
/Users/miles/databricks-cli/.venv/bin/python /Users/miles/databricks-sdk-py/examples/last_job_runs.py 
2024-05-17 11:43:32,529 [databricks.sdk][INFO] loading DEFAULT profile from ~/.databrickscfg: host, token
Traceback (most recent call last):
  File "/Users/miles/databricks-sdk-py/examples/last_job_runs.py", line 20, in <module>
    for job in w.jobs.list():
  File "/Users/miles/databricks-sdk-py/databricks/sdk/service/jobs.py", line 5453, in list
    json = self._api.do('GET', '/api/2.1/jobs/list', query=query, headers=headers)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/miles/databricks-sdk-py/databricks/sdk/core.py", line 131, in do
    response = retryable(self._perform)(method,
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/miles/databricks-sdk-py/databricks/sdk/retries.py", line 54, in wrapper
    raise err
  File "/Users/miles/databricks-sdk-py/databricks/sdk/retries.py", line 33, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/miles/databricks-sdk-py/databricks/sdk/core.py", line 245, in _perform
    raise self._make_nicer_error(response=response) from None
databricks.sdk.errors.private_link.PrivateLinkValidationError: The requested workspace has Azure Private Link enabled and is not accessible from the current network. Ensure that Azure Private Link is properly configured and that your device has access to the Azure Private Link endpoint. For more information, see https://learn.microsoft.com/en-us/azure/databricks/security/network/classic/private-link-standard#authentication-troubleshooting.
```

- [ ] `make test` run locally
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

