### PR TITLE
Update catalog.py

### DIFF
--- a/databricks/sdk/service/catalog.py
+++ b/databricks/sdk/service/catalog.py
@@ -5160,7 +5160,7 @@ class UpdatePermissions:
         body = {}
         if self.changes: body['changes'] = [v.as_dict() for v in self.changes]
         if self.full_name is not None: body['full_name'] = self.full_name
-        if self.securable_type is not None: body['securable_type'] = self.securable_type.value
+        if self.securable_type is not None: body['securable_type'] = self.securable_type
         return body
 
     @classmethod


### PR DESCRIPTION
Fix for the following error

File /databricks/python/lib/python3.10/site-packages/databricks/sdk/service/catalog.py:2117, in UpdatePermissions.as_dict(self)
   2116 if self.full_name: body['full_name'] = self.full_name
-> 2117 if self.securable_type: body['securable_type'] = self.securable_type.value
   2118 return body

AttributeError: 'str' object has no attribute 'value'

## Changes
<!-- Summary of your changes that are easy to understand -->

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

