### PR TITLE
Ignore DataPlane Services during generation

### DIFF
--- a/.codegen/__init__.py.tmpl
+++ b/.codegen/__init__.py.tmpl
@@ -5,8 +5,8 @@ from databricks.sdk.credentials_provider import CredentialsStrategy
 from databricks.sdk.mixins.files import DbfsExt
 from databricks.sdk.mixins.compute import ClustersExt
 from databricks.sdk.mixins.workspace import WorkspaceExt
-{{- range .Services}}
-from databricks.sdk.service.{{.Package.Name}} import {{.PascalName}}API{{end}}
+{{- range .Services}} {{if not .IsDataPlane}}
+from databricks.sdk.service.{{.Package.Name}} import {{.PascalName}}API{{end}}{{end}}
 from databricks.sdk.service.provisioning import Workspace
 from databricks.sdk import azure
 
@@ -61,7 +61,7 @@ class WorkspaceClient:
         self._dbutils = _make_dbutils(self._config)
         self._api_client = client.ApiClient(self._config)
 
-        {{- range .Services}}{{if and (not .IsAccounts) (not .HasParent)}}
+        {{- range .Services}}{{if and (not .IsAccounts) (not .HasParent) (not .IsDataPlane)}}
         self._{{.SnakeName}} = {{template "api" .}}(self._api_client){{end -}}{{end}}
 
     @property
@@ -76,7 +76,7 @@ class WorkspaceClient:
     def dbutils(self) -> dbutils.RemoteDbUtils:
         return self._dbutils
 
-    {{- range .Services}}{{if and (not .IsAccounts) (not .HasParent)}}
+    {{- range .Services}}{{if and (not .IsAccounts) (not .HasParent) (not .IsDataPlane)}}
     @property
     def {{.SnakeName}}(self) -> {{template "api" .}}:
         {{if .Description}}"""{{.Summary}}"""{{end}}
@@ -117,7 +117,7 @@ class AccountClient:
         self._config = config.copy()
         self._api_client = client.ApiClient(self._config)
 
-        {{- range .Services}}{{if and .IsAccounts (not .HasParent)}}
+        {{- range .Services}}{{if and .IsAccounts (not .HasParent) (not .IsDataPlane)}}
         self._{{(.TrimPrefix "account").SnakeName}} = {{template "api" .}}(self._api_client){{end -}}{{end}}
 
     @property
@@ -128,7 +128,7 @@ class AccountClient:
     def api_client(self) -> client.ApiClient:
         return self._api_client
 
-    {{- range .Services}}{{if and .IsAccounts (not .HasParent)}}
+    {{- range .Services}}{{if and .IsAccounts (not .HasParent) (not .IsDataPlane)}}
     @property
     def {{(.TrimPrefix "account").SnakeName}}(self) -> {{template "api" .}}:{{if .Description}}
         """{{.Summary}}"""{{end}}

--- a/.codegen/service.py.tmpl
+++ b/.codegen/service.py.tmpl
@@ -100,7 +100,7 @@ class {{.PascalName}}{{if eq "List" .PascalName}}Request{{end}}:{{if .Descriptio
 	{{- end -}}
 {{- end -}}
 
-{{range .Services}}
+{{range .Services}} {{if not .IsDataPlane}}
 class {{.PascalName}}API:{{if .Description}}
     """{{.Comment "    " 110}}"""
     {{end}}
@@ -195,6 +195,7 @@ class {{.PascalName}}API:{{if .Description}}
         return self.{{template "safe-snake-name" .}}({{range $i, $x := .Request.Fields}}{{if $i}}, {{end}}{{template "safe-snake-name" .}}={{template "safe-snake-name" .}}{{end}}).result(timeout=timeout)
     {{end}}
     {{end -}}
+{{end}}
 {{- end}}
 
 {{define "method-parameters" -}}


### PR DESCRIPTION
## Changes
Ignore DataPlane Services during generation until proper support is implemented


## Tests
Generated SDK using local universe (which contains DataPlane services)

- [X] `make test` passing
- [X] `make fmt` applied
- [ ] relevant integration tests applied

