### PR TITLE
Add `serverless_compute_id` field to the config

### DIFF
--- a/databricks/sdk/config.py
+++ b/databricks/sdk/config.py
@@ -66,6 +66,7 @@ class Config:
     auth_type: str = ConfigAttribute(env='DATABRICKS_AUTH_TYPE')
     cluster_id: str = ConfigAttribute(env='DATABRICKS_CLUSTER_ID')
     warehouse_id: str = ConfigAttribute(env='DATABRICKS_WAREHOUSE_ID')
+    serverless_compute_id: str = ConfigAttribute(env='DATABRICKS_SERVERLESS_COMPUTE_ID')
     skip_verify: bool = ConfigAttribute()
     http_timeout_seconds: float = ConfigAttribute()
     debug_truncate_bytes: int = ConfigAttribute(env='DATABRICKS_DEBUG_TRUNCATE_BYTES')


### PR DESCRIPTION
## Changes
We propose adding a new `serverless_compute_id` attribute in the config that will be used to enable serverless compute in the downstream applications. The default value to enable serverless is `serverless_compute_id = auto`, other values might be used in the future if needed. Config doesn't have to validate the value in `serverless_compute_id`, this will be done in the downstream applications.

## Tests

- [x] `make test` run locally
- [x] `make fmt` applied
- [ ] relevant integration tests applied
