### PR TITLE
Fix test_local_io for windows

### DIFF
--- a/tests/integration/test_dbutils.py
+++ b/tests/integration/test_dbutils.py
@@ -56,7 +56,7 @@ def test_put_local_path(fs_and_base_path, random):
     to_write = random(1024 * 1024 * 2)
     base_path = base_path / "tmp_file"
     fs.put(base_path, to_write, True)
-    assert fs.head(base_path, 1024*1024*2) == to_write
+    assert fs.head(base_path, 1024 * 1024 * 2) == to_write
 
 
 def test_cp_file(fs_and_base_path, random):

--- a/tests/integration/test_dbutils.py
+++ b/tests/integration/test_dbutils.py
@@ -55,7 +55,7 @@ def test_put_local_path(w, random, tmp_path):
     to_write = random(1024 * 1024 * 2)
     tmp_path = tmp_path / "tmp_file"
     w.dbutils.fs.put(f'file:{tmp_path}', to_write, True)
-    assert w.dbutils.fs.head(f'file:{tmp_path}', 1024*1024*2) == to_write
+    assert w.dbutils.fs.head(f'file:{tmp_path}', 1024 * 1024 * 2) == to_write
 
 
 def test_cp_file(fs_and_base_path, random):

--- a/tests/integration/test_dbutils.py
+++ b/tests/integration/test_dbutils.py
@@ -51,6 +51,14 @@ def test_large_put(fs_and_base_path):
     assert output == ("test" * 20000)[:65536]
 
 
+def test_put_local_path(fs_and_base_path, random):
+    fs, base_path = fs_and_base_path
+    to_write = random(1024 * 1024 * 2)
+    base_path = base_path / "tmp_file"
+    fs.put(f'file:{base_path}', to_write, True)
+    assert fs.head(f'file:{base_path}', 1024*1024*2) == to_write
+
+
 def test_cp_file(fs_and_base_path, random):
     fs, base_path = fs_and_base_path
     path = base_path + "/dbc_qa_file-" + random()

--- a/tests/integration/test_dbutils.py
+++ b/tests/integration/test_dbutils.py
@@ -55,8 +55,8 @@ def test_put_local_path(fs_and_base_path, random):
     fs, base_path = fs_and_base_path
     to_write = random(1024 * 1024 * 2)
     base_path = base_path / "tmp_file"
-    fs.put(f'file:{base_path}', to_write, True)
-    assert fs.head(f'file:{base_path}', 1024*1024*2) == to_write
+    fs.put(base_path, to_write, True)
+    assert fs.head(base_path, 1024*1024*2) == to_write
 
 
 def test_cp_file(fs_and_base_path, random):

--- a/tests/integration/test_dbutils.py
+++ b/tests/integration/test_dbutils.py
@@ -51,12 +51,11 @@ def test_large_put(fs_and_base_path):
     assert output == ("test" * 20000)[:65536]
 
 
-def test_put_local_path(fs_and_base_path, random):
-    fs, base_path = fs_and_base_path
+def test_put_local_path(w, random, tmp_path):
     to_write = random(1024 * 1024 * 2)
-    base_path = base_path / "tmp_file"
-    fs.put(base_path, to_write, True)
-    assert fs.head(base_path, 1024 * 1024 * 2) == to_write
+    tmp_path = tmp_path / "tmp_file"
+    w.dbutils.fs.put(f'file:{tmp_path}', to_write, True)
+    assert w.dbutils.fs.head(f'file:{tmp_path}', 1024*1024*2) == to_write
 
 
 def test_cp_file(fs_and_base_path, random):

--- a/tests/integration/test_files.py
+++ b/tests/integration/test_files.py
@@ -3,7 +3,7 @@ import logging
 import pathlib
 import time
 from typing import Callable, List, Tuple, Union
-
+import platform
 import pytest
 
 from databricks.sdk.core import DatabricksError
@@ -11,7 +11,10 @@ from databricks.sdk.service.catalog import VolumeType
 
 
 def test_local_io(random):
-    dummy_file = f'/tmp/{random()}'
+    if platform.system() == 'Windows':
+        dummy_file = f'C:\\Windows\\Temp\\{random()}'
+    else:
+        dummy_file = f'/tmp/{random()}'
     to_write = random(1024 * 1024 * 2.5).encode()
     with open(dummy_file, 'wb') as f:
         written = f.write(to_write)

--- a/tests/integration/test_files.py
+++ b/tests/integration/test_files.py
@@ -1,9 +1,10 @@
 import io
 import logging
 import pathlib
+import platform
 import time
 from typing import Callable, List, Tuple, Union
-import platform
+
 import pytest
 
 from databricks.sdk.core import DatabricksError


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
Fix `tests/integration/test_files.py::test_local_io` for windows. This PR is part of fixing the test for windows
## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

