### PR TITLE
Resolve issue with AttributeError during update of serving endpoint tags

### DIFF
--- a/databricks/sdk/service/serving.py
+++ b/databricks/sdk/service/serving.py
@@ -3111,7 +3111,7 @@ class ServingEndpointsAPI:
         headers = {'Accept': 'application/json', 'Content-Type': 'application/json', }
 
         res = self._api.do('PATCH', f'/api/2.0/serving-endpoints/{name}/tags', body=body, headers=headers)
-        return [EndpointTag.from_dict(v) for v in res]
+        return [EndpointTag.from_dict(v) for v in res["tags"]]
 
     def put(self, name: str, *, rate_limits: Optional[List[RateLimit]] = None) -> PutResponse:
         """Update rate limits of a serving endpoint.


### PR DESCRIPTION
Hi! I noticed today when you try to update tags in serving endpoint using `patch` method it fails with `AttributeError`. The fix is very straightforward.

## Changes

I just updated the way how response are unpacked and passed into `EndpointTag`

## Tests

Tested on my dev account.

- [x] `make test` run locally
- [x] `make fmt` applied
- [x] relevant integration tests applied

Thanks!

