### PR TITLE
Fixed AccountClient U2M OAuth2 auth when using `external-browser` auth type

### DIFF
--- a/databricks/sdk/credentials_provider.py
+++ b/databricks/sdk/credentials_provider.py
@@ -200,7 +200,8 @@ def external_browser(cfg: 'Config') -> Optional[CredentialsProvider]:
     oauth_client = OAuthClient(host=cfg.host,
                                client_id=client_id,
                                redirect_url='http://localhost:8020',
-                               client_secret=cfg.client_secret)
+                               client_secret=cfg.client_secret,
+                               account_id=cfg.account_id)
 
     # Load cached credentials from disk if they exist.
     # Note that these are local to the Python SDK and not reused by other SDKs.

--- a/databricks/sdk/oauth.py
+++ b/databricks/sdk/oauth.py
@@ -359,7 +359,8 @@ class OAuthClient:
                  redirect_url: str,
                  *,
                  scopes: List[str] = None,
-                 client_secret: str = None):
+                 client_secret: str = None,
+                 account_id: str = None):
         # TODO: is it a circular dependency?..
         from .core import Config
         from .credentials_provider import credentials_strategy
@@ -368,7 +369,7 @@ class OAuthClient:
         def noop_credentials(_: any):
             return lambda: {}
 
-        config = Config(host=host, credentials_strategy=noop_credentials)
+        config = Config(host=host, credentials_strategy=noop_credentials, account_id=account_id)
         if not scopes:
             scopes = ['all-apis']
         oidc = config.oidc_endpoints


### PR DESCRIPTION
OIDC endpoints now contains the information about the Databricks Account ID.

## Changes
<!-- Summary of your changes that are easy to understand -->

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

