### PR TITLE
[Fix] Decrease runtime of recursive workspace listing test

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -104,6 +104,14 @@ def volume(ucws, schema):
     ucws.volumes.delete(volume.full_name)
 
 
+@pytest.fixture()
+def workspace_dir(w, random):
+    directory = f'/Users/{w.current_user.me().user_name}/dir-{random(12)}'
+    w.workspace.mkdirs(directory)
+    yield directory
+    w.workspace.delete(directory, recursive=True)
+
+
 def _load_debug_env_if_runs_from_ide(key) -> bool:
     if not _is_in_debug():
         return False

--- a/tests/integration/test_workspace.py
+++ b/tests/integration/test_workspace.py
@@ -3,11 +3,21 @@ import io
 from databricks.sdk.service.workspace import ImportFormat, Language
 
 
-def test_workspace_recursive_list(w, random):
+def test_workspace_recursive_list(w, workspace_dir, random):
+    # create a file in the directory
+    file = f'{workspace_dir}/file-{random(12)}.py'
+    w.workspace.upload(file, io.BytesIO(b'print(1)'))
+    # create a subdirectory
+    subdirectory = f'{workspace_dir}/subdir-{random(12)}'
+    w.workspace.mkdirs(subdirectory)
+    # create a file in the subdirectory
+    subfile = f'{subdirectory}/subfile-{random(12)}.py'
+    w.workspace.upload(subfile, io.BytesIO(b'print(2)'))
+    # list the directory recursively
     names = []
-    for i in w.workspace.list(f'/Users/{w.current_user.me().user_name}', recursive=True):
+    for i in w.workspace.list(workspace_dir, recursive=True):
         names.append(i.path)
-    assert len(names) > 0
+    assert len(names) == 2
 
 
 def test_workspace_upload_download_notebooks(w, random):


### PR DESCRIPTION
## Changes
The current integration test for recursive workspace listing is very slow because it lists all resources in a very large directory (the integration test user's home folder). To decrease the time this test takes, we can simply create a directory with a file and a subdirectory with another file. This means the test requires only two API calls to complete.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

