### PR TITLE
[Internal] Add apps package in docgen

### DIFF
--- a/docs/gen-client-docs.py
+++ b/docs/gen-client-docs.py
@@ -247,6 +247,7 @@ class Generator:
         Package("vectorsearch", "Vector Search", "Create and query Vector Search indexes"),
         Package("dashboards", "Dashboards", "Manage Lakeview dashboards"),
         Package("marketplace", "Marketplace", "Manage AI and analytics assets such as ML models, notebooks, applications in an open marketplace"),
+        Package("apps", "Apps", "Build custom applications on Databricks"),
     ]
 
     def __init__(self):


### PR DESCRIPTION
## Changes
To enable the release of the Apps package, we need to manually add it to our doc generation.

Going forward, this should be added to the internal API specification.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] Codegen tool runs successfully on commit 88571b688969bc4509fb520d86d161eb20c3d662 of the API specification from this PR.

