### PR TITLE
[Internal] Escape single quotes in regex matchers

### DIFF
--- a/.codegen/error_overrides.py.tmpl
+++ b/.codegen/error_overrides.py.tmpl
@@ -11,9 +11,9 @@ _ALL_OVERRIDES = [
         debug_name="{{.Name}}",
         path_regex=re.compile(r'{{.PathRegex}}'),
         verb="{{.Verb}}",
-        status_code_matcher=re.compile(r'{{.StatusCodeMatcher}}'),
-        error_code_matcher=re.compile(r'{{.ErrorCodeMatcher}}'),
-        message_matcher=re.compile(r'{{.MessageMatcher}}'),
+        status_code_matcher=re.compile(r'{{replaceAll "'" "\\'" .StatusCodeMatcher}}'),
+        error_code_matcher=re.compile(r'{{replaceAll "'" "\\'" .ErrorCodeMatcher}}'),
+        message_matcher=re.compile(r'{{replaceAll "'" "\\'" .MessageMatcher}}'),
         custom_error={{.OverrideErrorCode.PascalName}},
     ),
 {{- end }}


### PR DESCRIPTION
## Changes

This PR makes sure that single quotes are properly escaped when passing regex pattern to match errors. 

## Tests

Verified that SDK can properly be generated when the pattern contains single quotes.

Note that `downstreams / compatibility (ucx, databrickslabs)` was already failing and that this PR should not affect downstream consumers. 

- [x] `make test` run locally
- [x] `make fmt` applied
- [x] relevant integration tests applied

