### PR TITLE
[Internal] Fix get_workspace_client test to match Go SDK behavior

### DIFF
--- a/tests/integration/test_client.py
+++ b/tests/integration/test_client.py
@@ -1,4 +1,3 @@
-import pytest
 
 
 def test_get_workspace_client(ucacct, env_or_skip):

--- a/tests/integration/test_client.py
+++ b/tests/integration/test_client.py
@@ -1,5 +1,3 @@
-
-
 def test_get_workspace_client(ucacct, env_or_skip):
     # Need to switch to ucacct
     workspace_id = env_or_skip("TEST_WORKSPACE_ID")

--- a/tests/integration/test_client.py
+++ b/tests/integration/test_client.py
@@ -14,10 +14,9 @@ def test_get_workspace_id(ucws, env_or_skip):
     assert ucws.get_workspace_id() == ws_id
 
 
-def test_creating_ws_client_from_ac_client_does_not_override_config(a):
-    wss = list(a.workspaces.list())
-    if len(wss) == 0:
-        pytest.skip("no workspaces")
-    w = a.get_workspace_client(wss[0])
+def test_creating_ws_client_from_ac_client_does_not_override_config(ucacct, env_or_skip):
+    ws_id = env_or_skip('TEST_WORKSPACE_ID')
+    ws = ucacct.workspaces.get(ws_id)
+    w = ucacct.get_workspace_client(ws)
     me = w.current_user.me()
     assert me.user_name is not None


### PR DESCRIPTION
## Changes
The current get_workspace_client test fails because the SP used by the test does not have access to the first workspace listed. In the [Go](https://github.com/databricks/databricks-sdk-go/blob/main/internal/account_client_test.go#L12) & [Java](https://github.com/databricks/databricks-sdk-java/blob/1b90e2318f8221ac0a6e4b56c9b0e4c286e38c9f/databricks-sdk-java/src/test/java/com/databricks/sdk/integration/AccountClientIT.java#L17) SDKs, the corresponding test respects the `TEST_WORKSPACE_ID` environment variable to know which workspace to attempt to login to. This PR changes the test to use that environment variable as well.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

