### PR TITLE
[Internal] Fix test_iam::test_scim_error_unmarshall integration test

### DIFF
--- a/tests/integration/test_iam.py
+++ b/tests/integration/test_iam.py
@@ -1,5 +1,6 @@
 import pytest
 
+from databricks.sdk import errors
 from databricks.sdk.core import DatabricksError
 
 
@@ -13,7 +14,7 @@ def test_scim_error_unmarshall(w, random):
     with pytest.raises(DatabricksError) as exc_info:
         groups = w.groups.list(filter=random(12))
         next(groups)
-    assert 'Given filter operator is not supported' in str(exc_info.value)
+    assert isinstance(exc_info.value, errors.BadRequest)
 
 
 def test_scim_get_user_as_dict(w):


### PR DESCRIPTION
## Changes
The error message returned by the SCIM API when using an invalid filter changed, breaking our integration test. This PR updates the test to check for the type of error returned, which should be robust to error message changes. The new error message, `InvalidFilter request failed`, is worse in my opinion, so I will raise this with the identity team.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

