### PR TITLE
[Feature] Support Models in `dbutils.fs` operations

### DIFF
--- a/tests/test_dbfs_mixins.py
+++ b/tests/test_dbfs_mixins.py
@@ -1,8 +1,8 @@
 import pytest
 
 from databricks.sdk.errors import NotFound
-from databricks.sdk.mixins.files import (DbfsExt, _DbfsPath, _LocalPath,
-                                         _VolumesPath)
+from databricks.sdk.mixins.files import (DbfsExt, _DbfsPath, _FilesPath,
+                                         _LocalPath)
 
 
 def test_moving_dbfs_file_to_local_dir(config, tmp_path, mocker):
@@ -55,11 +55,14 @@ def test_moving_local_dir_to_dbfs(config, tmp_path, mocker):
 
 
 @pytest.mark.parametrize('path,expected_type', [('/path/to/file', _DbfsPath),
-                                                ('/Volumes/path/to/file', _VolumesPath),
+                                                ('/Volumes/path/to/file', _FilesPath),
+                                                ('/Models/path/to/file', _FilesPath),
                                                 ('dbfs:/path/to/file', _DbfsPath),
-                                                ('dbfs:/Volumes/path/to/file', _VolumesPath),
+                                                ('dbfs:/Volumes/path/to/file', _FilesPath),
+                                                ('dbfs:/Models/path/to/file', _FilesPath),
                                                 ('file:/path/to/file', _LocalPath),
-                                                ('file:/Volumes/path/to/file', _LocalPath), ])
+                                                ('file:/Volumes/path/to/file', _LocalPath),
+                                                ('file:/Models/path/to/file', _LocalPath), ])
 def test_fs_path(config, path, expected_type):
     dbfs_ext = DbfsExt(config)
     assert isinstance(dbfs_ext._path(path), expected_type)


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
- Support files operations in WorkspaceClient.Files for Databricks UC Model artifacts so that user can use databricks sdk to download UC model artifacts.
- This PR is part of the work to migrate mlflow client towards using databricks sdk for model artifacts download/upload operations for better security.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->
- Existing tests in test_dbfs_mixins.py, similar to how _VolumesPath is tested
- The following code works
```
from databricks.sdk import WorkspaceClient
w = WorkspaceClient()
resp = w.files.download("/Models/system/ai/dbrx_instruct/3/MLmodel")
```

- [x] `make test` run locally
- [x] `make fmt` applied
- [x] relevant integration tests applied

