### PR TITLE
[Fix] Properly include message when handing SCIM errors

### DIFF
--- a/databricks/sdk/errors/parser.py
+++ b/databricks/sdk/errors/parser.py
@@ -60,8 +60,9 @@ class _StandardErrorParser(_ErrorParser):
         if detail:
             # Handle SCIM error message details
             # @see https://tools.ietf.org/html/rfc7644#section-3.7.3
-            error_args[
-                'message'] = f"{scim_type} {error_args.get('message', 'SCIM API Internal Error')}".strip(" ")
+            if detail == "null":
+                detail = "SCIM API Internal Error"
+            error_args['message'] = f"{scim_type} {detail}".strip(" ")
             error_args['error_code'] = f"SCIM_{status}"
         return error_args
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -109,7 +109,14 @@ subclass_test_cases = [(fake_valid_response('GET', x[0], x[1], 'nope'), x[2], 'n
        'Please report this issue with the following debugging information to the SDK issue tracker at '
        'https://github.com/databricks/databricks-sdk-go/issues. Request log:```GET /api/2.0/service\n'
        '< 400 Bad Request\n'
-       '< this is not a real response```')), ])
+       '< this is not a real response```')),
+     [fake_response('GET', 404, json.dumps({
+         'detail': 'Group with id 1234 is not found',
+         'status': '404',
+         'schemas': [
+             'urn:ietf:params:scim:api:messages:2.0:Error'
+         ]
+     })), errors.NotFound, 'None Group with id 1234 is not found']])
 def test_get_api_error(response, expected_error, expected_message):
     with pytest.raises(errors.DatabricksError) as e:
         raise errors.get_api_error(response)

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -110,13 +110,15 @@ subclass_test_cases = [(fake_valid_response('GET', x[0], x[1], 'nope'), x[2], 'n
        'https://github.com/databricks/databricks-sdk-go/issues. Request log:```GET /api/2.0/service\n'
        '< 400 Bad Request\n'
        '< this is not a real response```')),
-     [fake_response('GET', 404, json.dumps({
-         'detail': 'Group with id 1234 is not found',
-         'status': '404',
-         'schemas': [
-             'urn:ietf:params:scim:api:messages:2.0:Error'
-         ]
-     })), errors.NotFound, 'None Group with id 1234 is not found']])
+     [
+         fake_response(
+             'GET', 404,
+             json.dumps({
+                 'detail': 'Group with id 1234 is not found',
+                 'status': '404',
+                 'schemas': ['urn:ietf:params:scim:api:messages:2.0:Error']
+             })), errors.NotFound, 'None Group with id 1234 is not found'
+     ]])
 def test_get_api_error(response, expected_error, expected_message):
     with pytest.raises(errors.DatabricksError) as e:
         raise errors.get_api_error(response)


### PR DESCRIPTION
## Changes
#741 introduced a regression in retrieving error details from SCIM APIs. This PR addresses this and adds a regression test for this case. The implementation should now match the Go SDK's here: https://github.com/databricks/databricks-sdk-go/blob/main/apierr/errors.go#L220-L224.

Fixes #749.

## Tests
Added a unit test based on the supplied response in the ticket.

- [ ] `make test` run locally
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

