### PR TITLE
[Fix] Fix deserialization of 401/403 errors

### DIFF
--- a/databricks/sdk/core.py
+++ b/databricks/sdk/core.py
@@ -261,10 +261,8 @@ class _AddDebugErrorCustomizer(_ErrorCustomizer):
         self._cfg = cfg
 
     def customize_error(self, response: requests.Response, kwargs: dict):
-        status_code = response.status_code
-        is_http_unauthorized_or_forbidden = status_code in (401, 403)
-        message = kwargs.get('message', 'request failed')
-        if is_http_unauthorized_or_forbidden:
+        if response.status_code in (401, 403):
+            message = kwargs.get('message', 'request failed')
             kwargs['message'] = self._cfg.wrap_debug_info(message)
 
 

--- a/databricks/sdk/core.py
+++ b/databricks/sdk/core.py
@@ -10,7 +10,7 @@ from .casing import Casing
 from .config import *
 # To preserve backwards compatibility (as these definitions were previously in this module)
 from .credentials_provider import *
-from .errors import DatabricksError, _Parser, _ErrorCustomizer
+from .errors import DatabricksError, _ErrorCustomizer, _Parser
 from .logger import RoundTrip
 from .oauth import retrieve_token
 from .retries import retried
@@ -254,6 +254,7 @@ class ApiClient:
 
 
 class _AddDebugErrorCustomizer(_ErrorCustomizer):
+
     def __init__(self, cfg: Config):
         self._cfg = cfg
 

--- a/databricks/sdk/core.py
+++ b/databricks/sdk/core.py
@@ -254,6 +254,8 @@ class ApiClient:
 
 
 class _AddDebugErrorCustomizer(_ErrorCustomizer):
+    """An error customizer that adds debug information about the configuration to unauthenticated and
+    unauthorized errors."""
 
     def __init__(self, cfg: Config):
         self._cfg = cfg

--- a/databricks/sdk/errors/__init__.py
+++ b/databricks/sdk/errors/__init__.py
@@ -1,6 +1,6 @@
 from .base import DatabricksError, ErrorDetail
-from .parser import _Parser
 from .customizer import _ErrorCustomizer
+from .parser import _Parser
 from .platform import *
 from .private_link import PrivateLinkValidationError
 from .sdk import *

--- a/databricks/sdk/errors/__init__.py
+++ b/databricks/sdk/errors/__init__.py
@@ -1,6 +1,6 @@
 from .base import DatabricksError, ErrorDetail
 from .mapper import _error_mapper
-from .parser import get_api_error
+from .parser import _Parser, _ErrorCustomizer
 from .platform import *
 from .private_link import PrivateLinkValidationError
 from .sdk import *

--- a/databricks/sdk/errors/__init__.py
+++ b/databricks/sdk/errors/__init__.py
@@ -1,6 +1,7 @@
 from .base import DatabricksError, ErrorDetail
 from .mapper import _error_mapper
-from .parser import _Parser, _ErrorCustomizer
+from .parser import _Parser
+from .customizer import _ErrorCustomizer
 from .platform import *
 from .private_link import PrivateLinkValidationError
 from .sdk import *

--- a/databricks/sdk/errors/__init__.py
+++ b/databricks/sdk/errors/__init__.py
@@ -1,5 +1,4 @@
 from .base import DatabricksError, ErrorDetail
-from .mapper import _error_mapper
 from .parser import _Parser
 from .customizer import _ErrorCustomizer
 from .platform import *

--- a/databricks/sdk/errors/base.py
+++ b/databricks/sdk/errors/base.py
@@ -85,7 +85,6 @@ class DatabricksError(IOError):
             message = f"{scimType} {message}".strip(" ")
             error_code = f"SCIM_{status}"
         super().__init__(message if message else error)
-        self.message = message
         self.error_code = error_code
         self.retry_after_secs = retry_after_secs
         self.details = [ErrorDetail.from_dict(detail) for detail in details] if details else []

--- a/databricks/sdk/errors/base.py
+++ b/databricks/sdk/errors/base.py
@@ -85,6 +85,7 @@ class DatabricksError(IOError):
             message = f"{scimType} {message}".strip(" ")
             error_code = f"SCIM_{status}"
         super().__init__(message if message else error)
+        self.message = message
         self.error_code = error_code
         self.retry_after_secs = retry_after_secs
         self.details = [ErrorDetail.from_dict(detail) for detail in details] if details else []

--- a/databricks/sdk/errors/customizer.py
+++ b/databricks/sdk/errors/customizer.py
@@ -14,6 +14,8 @@ class _ErrorCustomizer(abc.ABC):
 
 
 class _RetryAfterCustomizer(_ErrorCustomizer):
+    """An error customizer that sets the retry_after_secs parameter based on the Retry-After header."""
+
     _RETRY_AFTER_DEFAULT = 1
 
     @classmethod

--- a/databricks/sdk/errors/customizer.py
+++ b/databricks/sdk/errors/customizer.py
@@ -1,6 +1,5 @@
 import abc
 import logging
-from typing import Optional
 
 import requests
 
@@ -16,18 +15,20 @@ class _ErrorCustomizer(abc.ABC):
 class _RetryAfterCustomizer(_ErrorCustomizer):
     """An error customizer that sets the retry_after_secs parameter based on the Retry-After header."""
 
-    _RETRY_AFTER_DEFAULT = 1
+    _DEFALT_RETRY_AFTER_SECONDS = 1
+    """The default number of seconds to wait before retrying a request if the Retry-After header is missing or is not
+    a valid integer."""
 
     @classmethod
-    def _parse_retry_after(cls, response: requests.Response) -> Optional[int]:
+    def _parse_retry_after(cls, response: requests.Response) -> int:
         retry_after = response.headers.get("Retry-After")
         if retry_after is None:
             logging.debug(
-                f'No Retry-After header received in response with status code 429 or 503. Defaulting to {cls._RETRY_AFTER_DEFAULT}'
+                f'No Retry-After header received in response with status code 429 or 503. Defaulting to {cls._DEFALT_RETRY_AFTER_SECONDS}'
             )
             # 429 requests should include a `Retry-After` header, but if it's missing,
             # we default to 1 second.
-            return cls._RETRY_AFTER_DEFAULT
+            return cls._DEFALT_RETRY_AFTER_SECONDS
         # If the request is throttled, try parse the `Retry-After` header and sleep
         # for the specified number of seconds. Note that this header can contain either
         # an integer or a RFC1123 datetime string.
@@ -39,13 +40,11 @@ class _RetryAfterCustomizer(_ErrorCustomizer):
             return int(retry_after)
         except ValueError:
             logging.debug(
-                f'Invalid Retry-After header received: {retry_after}. Defaulting to {cls._RETRY_AFTER_DEFAULT}'
+                f'Invalid Retry-After header received: {retry_after}. Defaulting to {cls._DEFALT_RETRY_AFTER_SECONDS}'
             )
             # defaulting to 1 sleep second to make self._is_retryable() simpler
-            return cls._RETRY_AFTER_DEFAULT
+            return cls._DEFALT_RETRY_AFTER_SECONDS
 
     def customize_error(self, response: requests.Response, kwargs: dict):
-        status_code = response.status_code
-        is_too_many_requests_or_unavailable = status_code in (429, 503)
-        if is_too_many_requests_or_unavailable:
+        if response.status_code in (429, 503):
             kwargs['retry_after_secs'] = self._parse_retry_after(response)

--- a/databricks/sdk/errors/customizer.py
+++ b/databricks/sdk/errors/customizer.py
@@ -1,0 +1,47 @@
+import abc
+import logging
+from typing import Optional
+
+import requests
+
+
+class _ErrorCustomizer(abc.ABC):
+    """A customizer for errors from the Databricks REST API."""
+
+    @abc.abstractmethod
+    def customize_error(self, response: requests.Response, kwargs: dict):
+        """Customize the error constructor parameters."""
+
+
+class _RetryAfterCustomizer(_ErrorCustomizer):
+    _RETRY_AFTER_DEFAULT = 1
+
+    @classmethod
+    def _parse_retry_after(cls, response: requests.Response) -> Optional[int]:
+        retry_after = response.headers.get("Retry-After")
+        if retry_after is None:
+            logging.debug(f'No Retry-After header received in response with status code 429 or 503. Defaulting to {cls._RETRY_AFTER_DEFAULT}')
+            # 429 requests should include a `Retry-After` header, but if it's missing,
+            # we default to 1 second.
+            return cls._RETRY_AFTER_DEFAULT
+        # If the request is throttled, try parse the `Retry-After` header and sleep
+        # for the specified number of seconds. Note that this header can contain either
+        # an integer or a RFC1123 datetime string.
+        # See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After
+        #
+        # For simplicity, we only try to parse it as an integer, as this is what Databricks
+        # platform returns. Otherwise, we fall back and don't sleep.
+        try:
+            return int(retry_after)
+        except ValueError:
+            logging.debug(f'Invalid Retry-After header received: {retry_after}. Defaulting to {cls._RETRY_AFTER_DEFAULT}')
+            # defaulting to 1 sleep second to make self._is_retryable() simpler
+            return cls._RETRY_AFTER_DEFAULT
+
+    def customize_error(self, response: requests.Response, kwargs: dict):
+        status_code = response.status_code
+        is_too_many_requests_or_unavailable = status_code in (429, 503)
+        if is_too_many_requests_or_unavailable:
+            kwargs['retry_after_secs'] = self._parse_retry_after(response)
+
+

--- a/databricks/sdk/errors/customizer.py
+++ b/databricks/sdk/errors/customizer.py
@@ -20,7 +20,9 @@ class _RetryAfterCustomizer(_ErrorCustomizer):
     def _parse_retry_after(cls, response: requests.Response) -> Optional[int]:
         retry_after = response.headers.get("Retry-After")
         if retry_after is None:
-            logging.debug(f'No Retry-After header received in response with status code 429 or 503. Defaulting to {cls._RETRY_AFTER_DEFAULT}')
+            logging.debug(
+                f'No Retry-After header received in response with status code 429 or 503. Defaulting to {cls._RETRY_AFTER_DEFAULT}'
+            )
             # 429 requests should include a `Retry-After` header, but if it's missing,
             # we default to 1 second.
             return cls._RETRY_AFTER_DEFAULT
@@ -34,7 +36,9 @@ class _RetryAfterCustomizer(_ErrorCustomizer):
         try:
             return int(retry_after)
         except ValueError:
-            logging.debug(f'Invalid Retry-After header received: {retry_after}. Defaulting to {cls._RETRY_AFTER_DEFAULT}')
+            logging.debug(
+                f'Invalid Retry-After header received: {retry_after}. Defaulting to {cls._RETRY_AFTER_DEFAULT}'
+            )
             # defaulting to 1 sleep second to make self._is_retryable() simpler
             return cls._RETRY_AFTER_DEFAULT
 
@@ -43,5 +47,3 @@ class _RetryAfterCustomizer(_ErrorCustomizer):
         is_too_many_requests_or_unavailable = status_code in (429, 503)
         if is_too_many_requests_or_unavailable:
             kwargs['retry_after_secs'] = self._parse_retry_after(response)
-
-

--- a/databricks/sdk/errors/customizer.py
+++ b/databricks/sdk/errors/customizer.py
@@ -15,7 +15,7 @@ class _ErrorCustomizer(abc.ABC):
 class _RetryAfterCustomizer(_ErrorCustomizer):
     """An error customizer that sets the retry_after_secs parameter based on the Retry-After header."""
 
-    _DEFALT_RETRY_AFTER_SECONDS = 1
+    _DEFAULT_RETRY_AFTER_SECONDS = 1
     """The default number of seconds to wait before retrying a request if the Retry-After header is missing or is not
     a valid integer."""
 
@@ -24,11 +24,11 @@ class _RetryAfterCustomizer(_ErrorCustomizer):
         retry_after = response.headers.get("Retry-After")
         if retry_after is None:
             logging.debug(
-                f'No Retry-After header received in response with status code 429 or 503. Defaulting to {cls._DEFALT_RETRY_AFTER_SECONDS}'
+                f'No Retry-After header received in response with status code 429 or 503. Defaulting to {cls._DEFAULT_RETRY_AFTER_SECONDS}'
             )
             # 429 requests should include a `Retry-After` header, but if it's missing,
             # we default to 1 second.
-            return cls._DEFALT_RETRY_AFTER_SECONDS
+            return cls._DEFAULT_RETRY_AFTER_SECONDS
         # If the request is throttled, try parse the `Retry-After` header and sleep
         # for the specified number of seconds. Note that this header can contain either
         # an integer or a RFC1123 datetime string.
@@ -40,10 +40,10 @@ class _RetryAfterCustomizer(_ErrorCustomizer):
             return int(retry_after)
         except ValueError:
             logging.debug(
-                f'Invalid Retry-After header received: {retry_after}. Defaulting to {cls._DEFALT_RETRY_AFTER_SECONDS}'
+                f'Invalid Retry-After header received: {retry_after}. Defaulting to {cls._DEFAULT_RETRY_AFTER_SECONDS}'
             )
             # defaulting to 1 sleep second to make self._is_retryable() simpler
-            return cls._DEFALT_RETRY_AFTER_SECONDS
+            return cls._DEFAULT_RETRY_AFTER_SECONDS
 
     def customize_error(self, response: requests.Response, kwargs: dict):
         if response.status_code in (429, 503):

--- a/databricks/sdk/errors/deserializer.py
+++ b/databricks/sdk/errors/deserializer.py
@@ -2,9 +2,10 @@ import abc
 import json
 import logging
 import re
-from typing import Optional, List
+from typing import Optional
 
 import requests
+
 
 class _ErrorDeserializer(abc.ABC):
     """A parser for errors from the Databricks REST API."""
@@ -97,5 +98,3 @@ class _HtmlErrorDeserializer(_ErrorDeserializer):
                 }
         logging.debug('_HtmlErrorParser: no <pre> tag found in error response')
         return None
-
-

--- a/databricks/sdk/errors/deserializer.py
+++ b/databricks/sdk/errors/deserializer.py
@@ -1,0 +1,101 @@
+import abc
+import json
+import logging
+import re
+from typing import Optional, List
+
+import requests
+
+class _ErrorDeserializer(abc.ABC):
+    """A parser for errors from the Databricks REST API."""
+
+    @abc.abstractmethod
+    def parse_error(self, response: requests.Response, response_body: bytes) -> Optional[dict]:
+        """Parses an error from the Databricks REST API. If the error cannot be parsed, returns None."""
+
+
+class _EmptyDeserializer(_ErrorDeserializer):
+    """A parser that handles empty responses."""
+
+    def parse_error(self, response: requests.Response, response_body: bytes) -> Optional[dict]:
+        if len(response_body) == 0:
+            return {'message': response.reason}
+        return None
+
+
+class _StandardErrorDeserializer(_ErrorDeserializer):
+    """
+    Parses errors from the Databricks REST API using the standard error format.
+    """
+
+    def parse_error(self, response: requests.Response, response_body: bytes) -> Optional[dict]:
+        try:
+            payload_str = response_body.decode('utf-8')
+            resp: dict = json.loads(payload_str)
+        except json.JSONDecodeError as e:
+            logging.debug('_StandardErrorParser: unable to deserialize response as json', exc_info=e)
+            return None
+
+        error_args = {
+            'message': resp.get('message', 'request failed'),
+            'error_code': resp.get('error_code'),
+            'details': resp.get('details'),
+        }
+
+        # Handle API 1.2-style errors
+        if 'error' in resp:
+            error_args['message'] = resp['error']
+
+        # Handle SCIM Errors
+        detail = resp.get('detail')
+        status = resp.get('status')
+        scim_type = resp.get('scimType')
+        if detail:
+            # Handle SCIM error message details
+            # @see https://tools.ietf.org/html/rfc7644#section-3.7.3
+            if detail == "null":
+                detail = "SCIM API Internal Error"
+            error_args['message'] = f"{scim_type} {detail}".strip(" ")
+            error_args['error_code'] = f"SCIM_{status}"
+        return error_args
+
+
+class _StringErrorDeserializer(_ErrorDeserializer):
+    """
+    Parses errors from the Databricks REST API in the format "ERROR_CODE: MESSAGE".
+    """
+
+    __STRING_ERROR_REGEX = re.compile(r'([A-Z_]+): (.*)')
+
+    def parse_error(self, response: requests.Response, response_body: bytes) -> Optional[dict]:
+        payload_str = response_body.decode('utf-8')
+        match = self.__STRING_ERROR_REGEX.match(payload_str)
+        if not match:
+            logging.debug('_StringErrorParser: unable to parse response as string')
+            return None
+        error_code, message = match.groups()
+        return {'error_code': error_code, 'message': message, 'status': response.status_code, }
+
+
+class _HtmlErrorDeserializer(_ErrorDeserializer):
+    """
+    Parses errors from the Databricks REST API in HTML format.
+    """
+
+    __HTML_ERROR_REGEXES = [re.compile(r'<pre>(.*)</pre>'), re.compile(r'<title>(.*)</title>'), ]
+
+    def parse_error(self, response: requests.Response, response_body: bytes) -> Optional[dict]:
+        payload_str = response_body.decode('utf-8')
+        for regex in self.__HTML_ERROR_REGEXES:
+            match = regex.search(payload_str)
+            if match:
+                message = match.group(1) if match.group(1) else response.reason
+                return {
+                    'status': response.status_code,
+                    'message': message,
+                    'error_code': response.reason.upper().replace(' ', '_')
+                }
+        logging.debug('_HtmlErrorParser: no <pre> tag found in error response')
+        return None
+
+

--- a/databricks/sdk/errors/parser.py
+++ b/databricks/sdk/errors/parser.py
@@ -38,6 +38,12 @@ def _unknown_error(response: requests.Response) -> str:
 
 
 class _Parser:
+    """
+    A parser for errors from the Databricks REST API. It attempts to deserialize an error using a sequence of
+    deserializers, and then customizes the deserialized error using a sequence of customizers. If the error cannot be
+    deserialized, it returns a generic error with debugging information and instructions to report the issue to the SDK
+    issue tracker.
+    """
 
     def __init__(self,
                  extra_error_parsers: Optional[List[_ErrorDeserializer]] = None,

--- a/databricks/sdk/logger/round_trip_logger.py
+++ b/databricks/sdk/logger/round_trip_logger.py
@@ -48,7 +48,8 @@ class RoundTrip:
             # Raw streams with `Transfer-Encoding: chunked` do not have `Content-Type` header
             sb.append("< [raw stream]")
         elif self._response.content:
-            sb.append(self._redacted_dump("< ", self._response.content.decode('utf-8')))
+            decoded = self._response.content.decode('utf-8', errors='replace')
+            sb.append(self._redacted_dump("< ", decoded))
         return '\n'.join(sb)
 
     @staticmethod

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -423,6 +423,11 @@ def test_deletes(config, requests_mock):
     },
      errors.TemporarilyUnavailable('errorMessage', error_code='TEMPORARILY_UNAVAILABLE',
                                    retry_after_secs=100)),
+    (404, {}, {
+        'scimType': 'scim type',
+        'detail': 'detail',
+        'status': 'status',
+    }, errors.NotFound('scim type detail', error_code='SCIM_status')),
 ])
 def test_error(config, requests_mock, status_code, headers, body, expected_error):
     client = ApiClient(config)
@@ -441,12 +446,6 @@ def test_error(config, requests_mock, status_code, headers, body, expected_error
         assert expected.reason == actual.reason
         assert expected.domain == actual.domain
         assert expected.metadata == actual.metadata
-
-
-def test_error_with_scimType():
-    args = {"detail": "detail", "scimType": "scim type"}
-    error = DatabricksError(**args)
-    assert str(error) == f"scim type detail"
 
 
 @contextlib.contextmanager

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -124,3 +124,4 @@ def test_get_api_error(response, expected_error, expected_message):
         raise errors.get_api_error(response)
     assert isinstance(e.value, expected_error)
     assert str(e.value) == expected_message
+    assert e.value.message == expected_message

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -124,4 +124,3 @@ def test_get_api_error(response, expected_error, expected_message):
         raise errors.get_api_error(response)
     assert isinstance(e.value, expected_error)
     assert str(e.value) == expected_message
-    assert e.value.message == expected_message

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -120,7 +120,8 @@ subclass_test_cases = [(fake_valid_response('GET', x[0], x[1], 'nope'), x[2], 'n
              })), errors.NotFound, 'None Group with id 1234 is not found'
      ]])
 def test_get_api_error(response, expected_error, expected_message):
+    parser = errors._Parser()
     with pytest.raises(errors.DatabricksError) as e:
-        raise errors.get_api_error(response)
+        raise parser.get_api_error(response)
     assert isinstance(e.value, expected_error)
     assert str(e.value) == expected_message

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -12,13 +12,20 @@ def fake_response(method: str,
                   status_code: int,
                   response_body: str,
                   path: Optional[str] = None) -> requests.Response:
+    return fake_raw_response(method, status_code, response_body.encode('utf-8'), path)
+
+
+def fake_raw_response(method: str,
+                      status_code: int,
+                      response_body: bytes,
+                      path: Optional[str] = None) -> requests.Response:
     resp = requests.Response()
     resp.status_code = status_code
     resp.reason = http.client.responses.get(status_code, '')
     if path is None:
         path = '/api/2.0/service'
     resp.request = requests.Request(method, f"https://databricks.com{path}").prepare()
-    resp._content = response_body.encode('utf-8')
+    resp._content = response_body
     return resp
 
 
@@ -110,15 +117,19 @@ subclass_test_cases = [(fake_valid_response('GET', x[0], x[1], 'nope'), x[2], 'n
        'https://github.com/databricks/databricks-sdk-go/issues. Request log:```GET /api/2.0/service\n'
        '< 400 Bad Request\n'
        '< this is not a real response```')),
-     [
-         fake_response(
-             'GET', 404,
-             json.dumps({
-                 'detail': 'Group with id 1234 is not found',
-                 'status': '404',
-                 'schemas': ['urn:ietf:params:scim:api:messages:2.0:Error']
-             })), errors.NotFound, 'None Group with id 1234 is not found'
-     ]])
+     (fake_response(
+         'GET', 404,
+         json.dumps({
+             'detail': 'Group with id 1234 is not found',
+             'status': '404',
+             'schemas': ['urn:ietf:params:scim:api:messages:2.0:Error']
+         })), errors.NotFound, 'None Group with id 1234 is not found'),
+     (fake_response('GET', 404, json.dumps("This is JSON but not a dictionary")), errors.NotFound,
+      'unable to parse response. This is likely a bug in the Databricks SDK for Python or the underlying API. Please report this issue with the following debugging information to the SDK issue tracker at https://github.com/databricks/databricks-sdk-go/issues. Request log:```GET /api/2.0/service\n< 404 Not Found\n< "This is JSON but not a dictionary"```'
+      ),
+     (fake_raw_response('GET', 404, b'\x80'), errors.NotFound,
+      'unable to parse response. This is likely a bug in the Databricks SDK for Python or the underlying API. Please report this issue with the following debugging information to the SDK issue tracker at https://github.com/databricks/databricks-sdk-go/issues. Request log:```GET /api/2.0/service\n< 404 Not Found\n< �```'
+      )])
 def test_get_api_error(response, expected_error, expected_message):
     parser = errors._Parser()
     with pytest.raises(errors.DatabricksError) as e:


### PR DESCRIPTION
## Changes
#741 introduced a change to how an error message was modified in `ApiClient._perform`. Previously, arguments to the DatabricksError constructor were modified as a dictionary in `_perform`. After that change, `get_api_error` started to return a `DatabricksError` instance whose attributes were modified. The `message` attribute referred to in that change does not exist in the DatabricksError class: there is a `message` constructor parameter, but it is not set as an attribute.

This PR refactors the error handling logic slightly to restore the original behavior. In doing this, we decouple all error-parsing and customizing logic out of ApiClient. This also sets us up to allow for further extension of error parsing and customization in the future, a feature that I have seen present in other SDKs.

Fixes #755.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

