### PR TITLE
[Fix] Add DataPlane docs to the index

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,6 +17,7 @@ We are keen to hear feedback from you on these SDKs. Please `file GitHub issues 
    pagination
    logging
    dbutils
+   dataplane
    clients/workspace
    workspace/index
    clients/account


### PR DESCRIPTION
## Changes
Add DataPlane docs to the index

## Tests


- [ ] `make test` run locally
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

