### PR TITLE
[Internal] Add DCO guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ To contribute to this repository, you must sign off your commits to certify
 that you have the right to contribute the code and that it complies with the 
 open source license. The rules are pretty simple, if you can certify the 
 content of [DCO](./DCO), then simply add a "Signed-off-by" line to your 
-commit message to certify your compliance. Please use use your real name as 
+commit message to certify your compliance. Please use your real name as 
 pseudonymous/anonymous contributions are not accepted.
 
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,54 +18,22 @@ Code style is enforced by a formatter check in your pull request. We use [yapf](
 ## Signed Commits
 This repo requires all contributors to sign their commits. To configure this, you can follow [Github's documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) to create a GPG key, upload it to your Github account, and configure your git client to sign commits.
 
-## Sign your work
-The sign-off is a simple line at the end of the explanation for the patch. Your signature certifies that you wrote the patch or otherwise have the right to pass it on as an open-source patch. The rules are pretty simple: if you can certify the below (from developercertificate.org):
+## Developer Certificate of Origin
 
-```
-Developer Certificate of Origin
-Version 1.1
-
-Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
-1 Letterman Drive
-Suite D4700
-San Francisco, CA, 94129
-
-Everyone is permitted to copy and distribute verbatim copies of this
-license document, but changing it is not allowed.
-
-
-Developer's Certificate of Origin 1.1
-
-By making a contribution to this project, I certify that:
-
-(a) The contribution was created in whole or in part by me and I
-    have the right to submit it under the open source license
-    indicated in the file; or
-
-(b) The contribution is based upon previous work that, to the best
-    of my knowledge, is covered under an appropriate open source
-    license and I have the right under that license to submit that
-    work with modifications, whether created in whole or in part
-    by me, under the same open source license (unless I am
-    permitted to submit under a different license), as indicated
-    in the file; or
-
-(c) The contribution was provided directly to me by some other
-    person who certified (a), (b) or (c) and I have not modified
-    it.
-
-(d) I understand and agree that this project and the contribution
-    are public and that a record of the contribution (including all
-    personal information I submit with it, including my sign-off) is
-    maintained indefinitely and may be redistributed consistent with
-    this project or the open source license(s) involved.
-```
-
-Then you just add a line to every git commit message:
+To contribute to this repository, you must sign off your commits to certify 
+that you have the right to contribute the code and that it complies with the 
+open source license. The rules are pretty simple, if you can certify the 
+content of [DCO](./DCO), then simply add a "Signed-off-by" line to your 
+commit message to certify your compliance. Please use use your real name as 
+pseudonymous/anonymous contributions are not accepted.
 
 ```
 Signed-off-by: Joe Smith <joe.smith@email.com>
 ```
 
-If you set your `user.name` and `user.email` git configs, you can sign your commit automatically with git commit -s.
-You must use your real name (sorry, no pseudonyms or anonymous contributions).
+If you set your `user.name` and `user.email` git configs, you can sign your 
+commit automatically with `git commit -s`:
+
+```
+git commit -s -m "Your commit message"
+```

--- a/DCO
+++ b/DCO
@@ -1,0 +1,25 @@
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.


### PR DESCRIPTION
## Changes

This PR updates the contributing guidelines to include the DCO (Developer Certificate of Origin) that external contributors must sign-off to contribute.

## Tests

N/A