### PR TITLE
[Internal] revert Support Models in `dbutils.fs` operations (#750)

### DIFF
--- a/databricks/sdk/mixins/files.py
+++ b/databricks/sdk/mixins/files.py
@@ -167,7 +167,7 @@ class _DbfsIO(BinaryIO):
         return f"<_DbfsIO {self._path} {'read' if self.readable() else 'write'}=True>"
 
 
-class _FilesIO(BinaryIO):
+class _VolumesIO(BinaryIO):
 
     def __init__(self, api: files.FilesAPI, path: str, *, read: bool, write: bool, overwrite: bool):
         self._buffer = []
@@ -262,7 +262,7 @@ class _FilesIO(BinaryIO):
         self.close()
 
     def __repr__(self) -> str:
-        return f"<_FilesIO {self._path} {'read' if self.readable() else 'write'}=True>"
+        return f"<_VolumesIO {self._path} {'read' if self.readable() else 'write'}=True>"
 
 
 class _Path(ABC):
@@ -398,7 +398,7 @@ class _LocalPath(_Path):
         return f'<_LocalPath {self._path}>'
 
 
-class _FilesPath(_Path):
+class _VolumesPath(_Path):
 
     def __init__(self, api: files.FilesAPI, src: Union[str, pathlib.Path]):
         self._path = pathlib.PurePosixPath(str(src).replace('dbfs:', '').replace('file:', ''))
@@ -411,7 +411,7 @@ class _FilesPath(_Path):
         return False
 
     def child(self, path: str) -> Self:
-        return _FilesPath(self._api, str(self._path / path))
+        return _VolumesPath(self._api, str(self._path / path))
 
     def _is_dir(self) -> bool:
         try:
@@ -431,7 +431,7 @@ class _FilesPath(_Path):
             return self.is_dir
 
     def open(self, *, read=False, write=False, overwrite=False) -> BinaryIO:
-        return _FilesIO(self._api, self.as_string, read=read, write=write, overwrite=overwrite)
+        return _VolumesIO(self._api, self.as_string, read=read, write=write, overwrite=overwrite)
 
     def list(self, *, recursive=False) -> Generator[files.FileInfo, None, None]:
         if not self.is_dir:
@@ -458,13 +458,13 @@ class _FilesPath(_Path):
     def delete(self, *, recursive=False):
         if self.is_dir:
             for entry in self.list(recursive=False):
-                _FilesPath(self._api, entry.path).delete(recursive=True)
+                _VolumesPath(self._api, entry.path).delete(recursive=True)
             self._api.delete_directory(self.as_string)
         else:
             self._api.delete(self.as_string)
 
     def __repr__(self) -> str:
-        return f'<_FilesPath {self._path}>'
+        return f'<_VolumesPath {self._path}>'
 
 
 class _DbfsPath(_Path):
@@ -589,8 +589,8 @@ class DbfsExt(files.DbfsAPI):
                 'UC Volumes paths, not external locations or DBFS mount points.')
         if src.scheme == 'file':
             return _LocalPath(src.geturl())
-        if src.path.startswith(('/Volumes', '/Models')):
-            return _FilesPath(self._files_api, src.geturl())
+        if src.path.startswith('/Volumes'):
+            return _VolumesPath(self._files_api, src.geturl())
         return _DbfsPath(self._dbfs_api, src.geturl())
 
     def copy(self, src: str, dst: str, *, recursive=False, overwrite=False):

--- a/tests/test_dbfs_mixins.py
+++ b/tests/test_dbfs_mixins.py
@@ -1,8 +1,8 @@
 import pytest
 
 from databricks.sdk.errors import NotFound
-from databricks.sdk.mixins.files import (DbfsExt, _DbfsPath, _FilesPath,
-                                         _LocalPath)
+from databricks.sdk.mixins.files import (DbfsExt, _DbfsPath, _LocalPath,
+                                         _VolumesPath)
 
 
 def test_moving_dbfs_file_to_local_dir(config, tmp_path, mocker):
@@ -55,14 +55,11 @@ def test_moving_local_dir_to_dbfs(config, tmp_path, mocker):
 
 
 @pytest.mark.parametrize('path,expected_type', [('/path/to/file', _DbfsPath),
-                                                ('/Volumes/path/to/file', _FilesPath),
-                                                ('/Models/path/to/file', _FilesPath),
+                                                ('/Volumes/path/to/file', _VolumesPath),
                                                 ('dbfs:/path/to/file', _DbfsPath),
-                                                ('dbfs:/Volumes/path/to/file', _FilesPath),
-                                                ('dbfs:/Models/path/to/file', _FilesPath),
+                                                ('dbfs:/Volumes/path/to/file', _VolumesPath),
                                                 ('file:/path/to/file', _LocalPath),
-                                                ('file:/Volumes/path/to/file', _LocalPath),
-                                                ('file:/Models/path/to/file', _LocalPath), ])
+                                                ('file:/Volumes/path/to/file', _LocalPath), ])
 def test_fs_path(config, path, expected_type):
     dbfs_ext = DbfsExt(config)
     assert isinstance(dbfs_ext._path(path), expected_type)


### PR DESCRIPTION
This reverts commit 3162545c476a05e8e8c993b9e46038ddeea953a3.
Verified that /Models download still work correctly.

## Changes
<!-- Summary of your changes that are easy to understand -->

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

