### PR TITLE
[Fix] Fix Model Serving Test

### DIFF
--- a/tests/test_model_serving_auth.py
+++ b/tests/test_model_serving_auth.py
@@ -12,29 +12,31 @@ default_auth_base_error_message = \
     "to configure credentials for your preferred authentication method"
 
 
-@pytest.mark.parametrize(
-    "env_values, del_env_values, oauth_file_name",
-    [([('IS_IN_DB_MODEL_SERVING_ENV', 'true'),
-       ('DB_MODEL_SERVING_HOST_URL', 'x')], ['DATABRICKS_MODEL_SERVING_HOST_URL'], "tests/testdata/model-serving-test-token"),
-     ([('IS_IN_DATABRICKS_MODEL_SERVING_ENV', 'true'),
-       ('DB_MODEL_SERVING_HOST_URL', 'x')], ['DATABRICKS_MODEL_SERVING_HOST_URL'], "tests/testdata/model-serving-test-token"),
-     ([('IS_IN_DB_MODEL_SERVING_ENV', 'true'),
-       ('DATABRICKS_MODEL_SERVING_HOST_URL', 'x')], ['DB_MODEL_SERVING_HOST_URL'], "tests/testdata/model-serving-test-token"),
-     ([('IS_IN_DATABRICKS_MODEL_SERVING_ENV', 'true'),
-       ('DATABRICKS_MODEL_SERVING_HOST_URL', 'x')], ['DB_MODEL_SERVING_HOST_URL'], "tests/testdata/model-serving-test-token"), ])
+@pytest.mark.parametrize("env_values, del_env_values, oauth_file_name",
+                         [([
+                             ('IS_IN_DB_MODEL_SERVING_ENV', 'true'), ('DB_MODEL_SERVING_HOST_URL', 'x')
+                         ], ['DATABRICKS_MODEL_SERVING_HOST_URL'], "tests/testdata/model-serving-test-token"),
+                          ([('IS_IN_DATABRICKS_MODEL_SERVING_ENV', 'true'),
+                            ('DB_MODEL_SERVING_HOST_URL', 'x')], ['DATABRICKS_MODEL_SERVING_HOST_URL'],
+                           "tests/testdata/model-serving-test-token"),
+                          ([('IS_IN_DB_MODEL_SERVING_ENV', 'true'), ('DATABRICKS_MODEL_SERVING_HOST_URL', 'x')
+                            ], ['DB_MODEL_SERVING_HOST_URL'], "tests/testdata/model-serving-test-token"),
+                          ([('IS_IN_DATABRICKS_MODEL_SERVING_ENV', 'true'),
+                            ('DATABRICKS_MODEL_SERVING_HOST_URL', 'x')
+                            ], ['DB_MODEL_SERVING_HOST_URL'], "tests/testdata/model-serving-test-token"), ])
 def test_model_serving_auth(env_values, del_env_values, oauth_file_name, monkeypatch, mocker):
     ## In mlflow we check for these two environment variables to return the correct config
     for (env_name, env_value) in env_values:
         monkeypatch.setenv(env_name, env_value)
-        
+
     for (env_name) in del_env_values:
         monkeypatch.delenv(env_name, raising=False)
-    
+
     # patch mlflow to read the file from the test directory
     monkeypatch.setattr(
         "databricks.sdk.credentials_provider.ModelServingAuthProvider._MODEL_DEPENDENCY_OAUTH_TOKEN_FILE_PATH",
         oauth_file_name)
-    mocker.patch('databricks.sdk.config.Config._known_file_config_loader')    
+    mocker.patch('databricks.sdk.config.Config._known_file_config_loader')
 
     cfg = Config(auth_type='model-serving')
 
@@ -72,7 +74,7 @@ def test_model_serving_auth_refresh(monkeypatch, mocker):
     monkeypatch.setattr(
         "databricks.sdk.credentials_provider.ModelServingAuthProvider._MODEL_DEPENDENCY_OAUTH_TOKEN_FILE_PATH",
         "tests/testdata/model-serving-test-token")
-    mocker.patch('databricks.sdk.config.Config._known_file_config_loader')    
+    mocker.patch('databricks.sdk.config.Config._known_file_config_loader')
 
     cfg = Config(auth_type='model-serving')
     assert cfg.auth_type == 'model-serving'

--- a/tests/test_model_serving_auth.py
+++ b/tests/test_model_serving_auth.py
@@ -13,25 +13,30 @@ default_auth_base_error_message = \
 
 
 @pytest.mark.parametrize(
-    "env_values, oauth_file_name",
+    "env_values, del_env_values, oauth_file_name",
     [([('IS_IN_DB_MODEL_SERVING_ENV', 'true'),
-       ('DB_MODEL_SERVING_HOST_URL', 'x')], "tests/testdata/model-serving-test-token"),
+       ('DB_MODEL_SERVING_HOST_URL', 'x')], ['DATABRICKS_MODEL_SERVING_HOST_URL'], "tests/testdata/model-serving-test-token"),
      ([('IS_IN_DATABRICKS_MODEL_SERVING_ENV', 'true'),
-       ('DB_MODEL_SERVING_HOST_URL', 'x')], "tests/testdata/model-serving-test-token"),
+       ('DB_MODEL_SERVING_HOST_URL', 'x')], ['DATABRICKS_MODEL_SERVING_HOST_URL'], "tests/testdata/model-serving-test-token"),
      ([('IS_IN_DB_MODEL_SERVING_ENV', 'true'),
-       ('DATABRICKS_MODEL_SERVING_HOST_URL', 'x')], "tests/testdata/model-serving-test-token"),
+       ('DATABRICKS_MODEL_SERVING_HOST_URL', 'x')], ['DB_MODEL_SERVING_HOST_URL'], "tests/testdata/model-serving-test-token"),
      ([('IS_IN_DATABRICKS_MODEL_SERVING_ENV', 'true'),
-       ('DATABRICKS_MODEL_SERVING_HOST_URL', 'x')], "tests/testdata/model-serving-test-token"), ])
-def test_model_serving_auth(env_values, oauth_file_name, monkeypatch):
+       ('DATABRICKS_MODEL_SERVING_HOST_URL', 'x')], ['DB_MODEL_SERVING_HOST_URL'], "tests/testdata/model-serving-test-token"), ])
+def test_model_serving_auth(env_values, del_env_values, oauth_file_name, monkeypatch, mocker):
     ## In mlflow we check for these two environment variables to return the correct config
     for (env_name, env_value) in env_values:
         monkeypatch.setenv(env_name, env_value)
+        
+    for (env_name) in del_env_values:
+        monkeypatch.delenv(env_name, raising=False)
+    
     # patch mlflow to read the file from the test directory
     monkeypatch.setattr(
         "databricks.sdk.credentials_provider.ModelServingAuthProvider._MODEL_DEPENDENCY_OAUTH_TOKEN_FILE_PATH",
         oauth_file_name)
+    mocker.patch('databricks.sdk.config.Config._known_file_config_loader')    
 
-    cfg = Config()
+    cfg = Config(auth_type='model-serving')
 
     assert cfg.auth_type == 'model-serving'
     headers = cfg.authenticate()
@@ -55,10 +60,10 @@ def test_model_serving_auth_errors(env_values, oauth_file_name, monkeypatch):
         "databricks.sdk.credentials_provider.ModelServingAuthProvider._MODEL_DEPENDENCY_OAUTH_TOKEN_FILE_PATH",
         oauth_file_name)
 
-    Config()
+    Config(auth_type='model-serving')
 
 
-def test_model_serving_auth_refresh(monkeypatch):
+def test_model_serving_auth_refresh(monkeypatch, mocker):
     ## In mlflow we check for these two environment variables to return the correct config
     monkeypatch.setenv('IS_IN_DB_MODEL_SERVING_ENV', 'true')
     monkeypatch.setenv('DB_MODEL_SERVING_HOST_URL', 'x')
@@ -67,8 +72,9 @@ def test_model_serving_auth_refresh(monkeypatch):
     monkeypatch.setattr(
         "databricks.sdk.credentials_provider.ModelServingAuthProvider._MODEL_DEPENDENCY_OAUTH_TOKEN_FILE_PATH",
         "tests/testdata/model-serving-test-token")
+    mocker.patch('databricks.sdk.config.Config._known_file_config_loader')    
 
-    cfg = Config()
+    cfg = Config(auth_type='model-serving')
     assert cfg.auth_type == 'model-serving'
 
     current_time = time.time()

--- a/tests/test_model_serving_auth.py
+++ b/tests/test_model_serving_auth.py
@@ -38,7 +38,7 @@ def test_model_serving_auth(env_values, del_env_values, oauth_file_name, monkeyp
         oauth_file_name)
     mocker.patch('databricks.sdk.config.Config._known_file_config_loader')
 
-    cfg = Config(auth_type='model-serving')
+    cfg = Config()
 
     assert cfg.auth_type == 'model-serving'
     headers = cfg.authenticate()
@@ -62,7 +62,7 @@ def test_model_serving_auth_errors(env_values, oauth_file_name, monkeypatch):
         "databricks.sdk.credentials_provider.ModelServingAuthProvider._MODEL_DEPENDENCY_OAUTH_TOKEN_FILE_PATH",
         oauth_file_name)
 
-    Config(auth_type='model-serving')
+    Config()
 
 
 def test_model_serving_auth_refresh(monkeypatch, mocker):
@@ -76,7 +76,7 @@ def test_model_serving_auth_refresh(monkeypatch, mocker):
         "tests/testdata/model-serving-test-token")
     mocker.patch('databricks.sdk.config.Config._known_file_config_loader')
 
-    cfg = Config(auth_type='model-serving')
+    cfg = Config()
     assert cfg.auth_type == 'model-serving'
 
     current_time = time.time()


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
Fix Model Serving Tests. 
- Added preffered auth_type so that test will not use other auth_types first.
- Patch function that reads `.databrickscfg`.
- Unsetting already existing environment variables.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` run locally
- [x] `make fmt` applied
- [ ] relevant integration tests applied

