### PR TITLE
[Fix] Include package name for external types when deserializing responses

### DIFF
--- a/.codegen/service.py.tmpl
+++ b/.codegen/service.py.tmpl
@@ -350,7 +350,7 @@ class {{.PascalName}}API:{{if .Description}}
           {{- else if .Response.MapValue -}}
             return res
           {{- else -}}
-            return {{.Response.PascalName}}.from_dict(res)
+            return {{template "type" .Response}}.from_dict(res)
           {{- end}}
         {{- end}}
 {{- end}}

--- a/databricks/sdk/service/sharing.py
+++ b/databricks/sdk/service/sharing.py
@@ -2496,7 +2496,7 @@ class SharesAPI:
                            f'/api/2.1/unity-catalog/shares/{name}/permissions',
                            query=query,
                            headers=headers)
-        return PermissionsList.from_dict(res)
+        return catalog.PermissionsList.from_dict(res)
 
     def update(self,
                name: str,


### PR DESCRIPTION
## Changes
#683 is caused by a small bug in the template used to generate the Python SDK. When referring to a class defined in a separate API package, only the module is imported, not the exact class, so the generated code needs to use the qualified name of the structure.

Resolved #683.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` run locally
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

