### PR TITLE
typo: isntall -> install

### DIFF
--- a/databricks/sdk/mixins/open_ai_client.py
+++ b/databricks/sdk/mixins/open_ai_client.py
@@ -29,7 +29,7 @@ class ServingEndpointsExt(ServingEndpointsAPI):
             from openai import OpenAI
         except Exception:
             raise ImportError(
-                "Open AI is not installed. Please install the Databricks SDK with the following command `pip isntall databricks-sdk[openai]`"
+                "Open AI is not installed. Please install the Databricks SDK with the following command `pip install databricks-sdk[openai]`"
             )
 
         return OpenAI(


### PR DESCRIPTION
## Changes

Fix typo `pip isntall` -> `pip install`

