### PR TITLE
[Fix] Correctly generate classes with nested body fields

### DIFF
--- a/.codegen/service.py.tmpl
+++ b/.codegen/service.py.tmpl
@@ -240,6 +240,9 @@ class {{.PascalName}}API:{{if .Description}}
 {{- end}}
 
 {{define "method-serialize" -}}
+        {{if and .Request.HasJsonField .RequestBodyField -}}
+        body = {{template "safe-snake-name" .RequestBodyField}}
+        {{- else -}}
         {{if or .Request.HasJsonField .Request.HasQueryField -}}
         {{if .Request.HasJsonField}}body = {}{{end}}{{if .Request.HasQueryField}}
         query = {}{{end}}
@@ -248,6 +251,7 @@ class {{.PascalName}}API:{{if .Description}}
         if {{template "safe-snake-name" .}} is not None: query['{{.Name}}'] = {{template "method-param-bind" .}}{{end}}
         {{- if .IsJson }}
         if {{template "safe-snake-name" .}} is not None: body['{{.Name}}'] = {{template "method-param-bind" .}}{{end}}
+        {{- end}}
         {{- end}}
         {{- end}}
         {{- end}}


### PR DESCRIPTION
## Changes
Correctly generate classes with nested body fields. 

### Backwards incompatible changes
The next time code is generated, the following backward incompatible changes will happen:
* Removal of the following classes: `apps.CreateAppDeploymentRequest`, `apps.CreateAppRequest`, `apps.UpdateAppRequest`, `catalog.CreateOnlineTableRequest`, `dashboards.CreateDashboardRequest`, `dashboards.CreateScheduleRequest`, `dashboards.CreateSubscriptionRequest`, `dashboards.UpdateDashboardRequest` and `dashboards.UpdateScheduleRequest`
* Change of signature for the following methods: `AppsAPI.create`, `AppsAPI.create_and_wait`, `AppsAPI.deploy`, `AppsAPI.deploy_and_wait`, `AppsAPI.update`, `OnlineTablesAPI.create`, `OnlineTablesAPI.create_and_wait`, `LakeviewAPI.create`, `LakeviewAPI.create_schedule`, `LakeviewAPI.create_subscription`, `LakeviewAPI.update` and `LakeviewAPI.update_schedule`. Each of those methods now take an object instead of a list of parameters.

## Tests
Preview
https://github.com/databricks/databricks-sdk-py/commit/66ce4505690ed7ca452a651df614ceb99bba24b1

- [ ] `make test` run locally
- [ ] `make fmt` applied
- [ ] relevant integration tests applied

