### PR TITLE
Convert `Dashboard` objects to dict in `LakeviewAPI` `create` and `update` methods

### DIFF
--- a/databricks/sdk/service/dashboards.py
+++ b/databricks/sdk/service/dashboards.py
@@ -1144,7 +1144,7 @@ class LakeviewAPI:
         
         :returns: :class:`Dashboard`
         """
-        body = dashboard
+        body = dashboard.as_dict()
         headers = {'Accept': 'application/json', 'Content-Type': 'application/json', }
 
         res = self._api.do('POST', '/api/2.0/lakeview/dashboards', body=body, headers=headers)
@@ -1528,7 +1528,7 @@ class LakeviewAPI:
         
         :returns: :class:`Dashboard`
         """
-        body = dashboard
+        body = dashboard.as_dict()
         headers = {'Accept': 'application/json', 'Content-Type': 'application/json', }
 
         res = self._api.do('PATCH',


### PR DESCRIPTION
## What changes are proposed in this pull request?

Convert `Dashboard` objects to dict in `LakeviewAPI` `create` and `update` methods. The API expects a JSON serializable object where the Python dataclasses are not. By converting these dataclass instances to dicts the objects become JSON serializable. 

This issue
- Went undetected by the linter as the `_api` attribute misses type hinting
- Remains for other `LakeviewAPI` methods
- Breaks the current [ucx](https://github.com/databrickslabs/ucx) version
- Breaks the current [lsql](https://github.com/databrickslabs/lsql) version

## How is this tested?

Did not look into testing this. 