### PR TITLE
[Internal] Update Doc generation to fix formatting issue

### DIFF
--- a/docs/account/billing/billable_usage.rst
+++ b/docs/account/billing/billable_usage.rst
@@ -41,4 +41,3 @@
           false.
         
         :returns: :class:`DownloadResponse`
-        

--- a/docs/account/billing/budgets.rst
+++ b/docs/account/billing/budgets.rst
@@ -55,7 +55,7 @@
           Properties of the new budget configuration.
         
         :returns: :class:`CreateBudgetConfigurationResponse`
-        
+
 
     .. py:method:: delete(budget_id: str)
 
@@ -67,8 +67,8 @@
         :param budget_id: str
           The Databricks budget configuration ID.
         
-        
-        
+
+
 
     .. py:method:: get(budget_id: str) -> GetBudgetConfigurationResponse
 
@@ -118,7 +118,7 @@
           The budget configuration ID
         
         :returns: :class:`GetBudgetConfigurationResponse`
-        
+
 
     .. py:method:: list( [, page_token: Optional[str]]) -> Iterator[BudgetConfiguration]
 
@@ -143,7 +143,7 @@
           retrieve the subsequent page. Requests first page if absent.
         
         :returns: Iterator over :class:`BudgetConfiguration`
-        
+
 
     .. py:method:: update(budget_id: str, budget: UpdateBudgetConfigurationBudget) -> UpdateBudgetConfigurationResponse
 
@@ -215,4 +215,3 @@
           The updated budget. This will overwrite the budget specified by the budget ID.
         
         :returns: :class:`UpdateBudgetConfigurationResponse`
-        

--- a/docs/account/billing/log_delivery.rst
+++ b/docs/account/billing/log_delivery.rst
@@ -113,7 +113,7 @@
         :param log_delivery_configuration: :class:`CreateLogDeliveryConfigurationParams` (optional)
         
         :returns: :class:`WrappedLogDeliveryConfiguration`
-        
+
 
     .. py:method:: get(log_delivery_configuration_id: str) -> WrappedLogDeliveryConfiguration
 
@@ -161,7 +161,7 @@
           Databricks log delivery configuration ID
         
         :returns: :class:`WrappedLogDeliveryConfiguration`
-        
+
 
     .. py:method:: list( [, credentials_id: Optional[str], status: Optional[LogDeliveryConfigStatus], storage_configuration_id: Optional[str]]) -> Iterator[LogDeliveryConfiguration]
 
@@ -189,7 +189,7 @@
           Filter by storage configuration ID.
         
         :returns: Iterator over :class:`LogDeliveryConfiguration`
-        
+
 
     .. py:method:: patch_status(log_delivery_configuration_id: str, status: LogDeliveryConfigStatus)
 
@@ -208,5 +208,4 @@
           configuration](#operation/patch-log-delivery-config-status) later. Deletion of a configuration is
           not supported, so disable a log delivery configuration that is no longer needed.
         
-        
-        
+

--- a/docs/account/billing/usage_dashboards.rst
+++ b/docs/account/billing/usage_dashboards.rst
@@ -21,7 +21,7 @@
           The workspace ID of the workspace in which the usage dashboard is created.
         
         :returns: :class:`CreateBillingUsageDashboardResponse`
-        
+
 
     .. py:method:: get( [, dashboard_type: Optional[UsageDashboardType], workspace_id: Optional[int]]) -> GetBillingUsageDashboardResponse
 
@@ -36,4 +36,3 @@
           The workspace ID of the workspace in which the usage dashboard is created.
         
         :returns: :class:`GetBillingUsageDashboardResponse`
-        

--- a/docs/account/catalog/metastore_assignments.rst
+++ b/docs/account/catalog/metastore_assignments.rst
@@ -18,8 +18,8 @@
           Unity Catalog metastore ID
         :param metastore_assignment: :class:`CreateMetastoreAssignment` (optional)
         
-        
-        
+
+
 
     .. py:method:: delete(workspace_id: int, metastore_id: str)
 
@@ -32,8 +32,8 @@
         :param metastore_id: str
           Unity Catalog metastore ID
         
-        
-        
+
+
 
     .. py:method:: get(workspace_id: int) -> AccountsMetastoreAssignment
 
@@ -47,7 +47,7 @@
           Workspace ID.
         
         :returns: :class:`AccountsMetastoreAssignment`
-        
+
 
     .. py:method:: list(metastore_id: str) -> Iterator[int]
 
@@ -72,7 +72,7 @@
           Unity Catalog metastore ID
         
         :returns: Iterator over int
-        
+
 
     .. py:method:: update(workspace_id: int, metastore_id: str [, metastore_assignment: Optional[UpdateMetastoreAssignment]])
 
@@ -87,5 +87,4 @@
           Unity Catalog metastore ID
         :param metastore_assignment: :class:`UpdateMetastoreAssignment` (optional)
         
-        
-        
+

--- a/docs/account/catalog/metastores.rst
+++ b/docs/account/catalog/metastores.rst
@@ -16,7 +16,7 @@
         :param metastore_info: :class:`CreateMetastore` (optional)
         
         :returns: :class:`AccountsMetastoreInfo`
-        
+
 
     .. py:method:: delete(metastore_id: str [, force: Optional[bool]])
 
@@ -29,8 +29,8 @@
         :param force: bool (optional)
           Force deletion even if the metastore is not empty. Default is false.
         
-        
-        
+
+
 
     .. py:method:: get(metastore_id: str) -> AccountsMetastoreInfo
 
@@ -42,7 +42,7 @@
           Unity Catalog metastore ID
         
         :returns: :class:`AccountsMetastoreInfo`
-        
+
 
     .. py:method:: list() -> Iterator[MetastoreInfo]
 
@@ -51,7 +51,7 @@
         Gets all Unity Catalog metastores associated with an account specified by ID.
         
         :returns: Iterator over :class:`MetastoreInfo`
-        
+
 
     .. py:method:: update(metastore_id: str [, metastore_info: Optional[UpdateMetastore]]) -> AccountsMetastoreInfo
 
@@ -64,4 +64,3 @@
         :param metastore_info: :class:`UpdateMetastore` (optional)
         
         :returns: :class:`AccountsMetastoreInfo`
-        

--- a/docs/account/catalog/storage_credentials.rst
+++ b/docs/account/catalog/storage_credentials.rst
@@ -23,7 +23,7 @@
         :param credential_info: :class:`CreateStorageCredential` (optional)
         
         :returns: :class:`AccountsStorageCredentialInfo`
-        
+
 
     .. py:method:: delete(metastore_id: str, storage_credential_name: str [, force: Optional[bool]])
 
@@ -39,8 +39,8 @@
         :param force: bool (optional)
           Force deletion even if the Storage Credential is not empty. Default is false.
         
-        
-        
+
+
 
     .. py:method:: get(metastore_id: str, storage_credential_name: str) -> AccountsStorageCredentialInfo
 
@@ -55,7 +55,7 @@
           Name of the storage credential.
         
         :returns: :class:`AccountsStorageCredentialInfo`
-        
+
 
     .. py:method:: list(metastore_id: str) -> Iterator[StorageCredentialInfo]
 
@@ -67,7 +67,7 @@
           Unity Catalog metastore ID
         
         :returns: Iterator over :class:`StorageCredentialInfo`
-        
+
 
     .. py:method:: update(metastore_id: str, storage_credential_name: str [, credential_info: Optional[UpdateStorageCredential]]) -> AccountsStorageCredentialInfo
 
@@ -83,4 +83,3 @@
         :param credential_info: :class:`UpdateStorageCredential` (optional)
         
         :returns: :class:`AccountsStorageCredentialInfo`
-        

--- a/docs/account/iam/access_control.rst
+++ b/docs/account/iam/access_control.rst
@@ -19,7 +19,7 @@
           The resource name for which assignable roles will be listed.
         
         :returns: :class:`GetAssignableRolesForResourceResponse`
-        
+
 
     .. py:method:: get_rule_set(name: str, etag: str) -> RuleSetResponse
 
@@ -39,7 +39,7 @@
           version you are updating.
         
         :returns: :class:`RuleSetResponse`
-        
+
 
     .. py:method:: update_rule_set(name: str, rule_set: RuleSetUpdateRequest) -> RuleSetResponse
 
@@ -53,4 +53,3 @@
         :param rule_set: :class:`RuleSetUpdateRequest`
         
         :returns: :class:`RuleSetResponse`
-        

--- a/docs/account/iam/groups.rst
+++ b/docs/account/iam/groups.rst
@@ -37,7 +37,7 @@
           The schema of the group.
         
         :returns: :class:`Group`
-        
+
 
     .. py:method:: delete(id: str)
 
@@ -48,8 +48,8 @@
         :param id: str
           Unique ID for a group in the Databricks account.
         
-        
-        
+
+
 
     .. py:method:: get(id: str) -> Group
 
@@ -61,7 +61,7 @@
           Unique ID for a group in the Databricks account.
         
         :returns: :class:`Group`
-        
+
 
     .. py:method:: list( [, attributes: Optional[str], count: Optional[int], excluded_attributes: Optional[str], filter: Optional[str], sort_by: Optional[str], sort_order: Optional[ListSortOrder], start_index: Optional[int]]) -> Iterator[Group]
 
@@ -90,7 +90,7 @@
           Specifies the index of the first result. First item is number 1.
         
         :returns: Iterator over :class:`Group`
-        
+
 
     .. py:method:: patch(id: str [, operations: Optional[List[Patch]], schemas: Optional[List[PatchSchema]]])
 
@@ -104,8 +104,8 @@
         :param schemas: List[:class:`PatchSchema`] (optional)
           The schema of the patch request. Must be ["urn:ietf:params:scim:api:messages:2.0:PatchOp"].
         
-        
-        
+
+
 
     .. py:method:: update(id: str [, display_name: Optional[str], entitlements: Optional[List[ComplexValue]], external_id: Optional[str], groups: Optional[List[ComplexValue]], members: Optional[List[ComplexValue]], meta: Optional[ResourceMeta], roles: Optional[List[ComplexValue]], schemas: Optional[List[GroupSchema]]])
 
@@ -132,5 +132,4 @@
         :param schemas: List[:class:`GroupSchema`] (optional)
           The schema of the group.
         
-        
-        
+

--- a/docs/account/iam/service_principals.rst
+++ b/docs/account/iam/service_principals.rst
@@ -53,7 +53,7 @@
           The schema of the List response.
         
         :returns: :class:`ServicePrincipal`
-        
+
 
     .. py:method:: delete(id: str)
 
@@ -64,8 +64,8 @@
         :param id: str
           Unique ID for a service principal in the Databricks account.
         
-        
-        
+
+
 
     .. py:method:: get(id: str) -> ServicePrincipal
 
@@ -95,7 +95,7 @@
           Unique ID for a service principal in the Databricks account.
         
         :returns: :class:`ServicePrincipal`
-        
+
 
     .. py:method:: list( [, attributes: Optional[str], count: Optional[int], excluded_attributes: Optional[str], filter: Optional[str], sort_by: Optional[str], sort_order: Optional[ListSortOrder], start_index: Optional[int]]) -> Iterator[ServicePrincipal]
 
@@ -144,7 +144,7 @@
           Specifies the index of the first result. First item is number 1.
         
         :returns: Iterator over :class:`ServicePrincipal`
-        
+
 
     .. py:method:: patch(id: str [, operations: Optional[List[Patch]], schemas: Optional[List[PatchSchema]]])
 
@@ -181,8 +181,8 @@
         :param schemas: List[:class:`PatchSchema`] (optional)
           The schema of the patch request. Must be ["urn:ietf:params:scim:api:messages:2.0:PatchOp"].
         
-        
-        
+
+
 
     .. py:method:: update(id: str [, active: Optional[bool], application_id: Optional[str], display_name: Optional[str], entitlements: Optional[List[ComplexValue]], external_id: Optional[str], groups: Optional[List[ComplexValue]], roles: Optional[List[ComplexValue]], schemas: Optional[List[ServicePrincipalSchema]]])
 
@@ -232,5 +232,4 @@
         :param schemas: List[:class:`ServicePrincipalSchema`] (optional)
           The schema of the List response.
         
-        
-        
+

--- a/docs/account/iam/users.rst
+++ b/docs/account/iam/users.rst
@@ -66,7 +66,7 @@
           Email address of the Databricks user.
         
         :returns: :class:`User`
-        
+
 
     .. py:method:: delete(id: str)
 
@@ -93,8 +93,8 @@
         :param id: str
           Unique ID for a user in the Databricks account.
         
-        
-        
+
+
 
     .. py:method:: get(id: str [, attributes: Optional[str], count: Optional[int], excluded_attributes: Optional[str], filter: Optional[str], sort_by: Optional[str], sort_order: Optional[GetSortOrder], start_index: Optional[int]]) -> User
 
@@ -144,7 +144,7 @@
           Specifies the index of the first result. First item is number 1.
         
         :returns: :class:`User`
-        
+
 
     .. py:method:: list( [, attributes: Optional[str], count: Optional[int], excluded_attributes: Optional[str], filter: Optional[str], sort_by: Optional[str], sort_order: Optional[ListSortOrder], start_index: Optional[int]]) -> Iterator[User]
 
@@ -174,7 +174,7 @@
           Specifies the index of the first result. First item is number 1.
         
         :returns: Iterator over :class:`User`
-        
+
 
     .. py:method:: patch(id: str [, operations: Optional[List[Patch]], schemas: Optional[List[PatchSchema]]])
 
@@ -212,8 +212,8 @@
         :param schemas: List[:class:`PatchSchema`] (optional)
           The schema of the patch request. Must be ["urn:ietf:params:scim:api:messages:2.0:PatchOp"].
         
-        
-        
+
+
 
     .. py:method:: update(id: str [, active: Optional[bool], display_name: Optional[str], emails: Optional[List[ComplexValue]], entitlements: Optional[List[ComplexValue]], external_id: Optional[str], groups: Optional[List[ComplexValue]], name: Optional[Name], roles: Optional[List[ComplexValue]], schemas: Optional[List[UserSchema]], user_name: Optional[str]])
 
@@ -249,5 +249,4 @@
         :param user_name: str (optional)
           Email address of the Databricks user.
         
-        
-        
+

--- a/docs/account/iam/workspace_assignment.rst
+++ b/docs/account/iam/workspace_assignment.rst
@@ -19,8 +19,8 @@
         :param principal_id: int
           The ID of the user, service principal, or group.
         
-        
-        
+
+
 
     .. py:method:: get(workspace_id: int) -> WorkspacePermissions
 
@@ -32,7 +32,7 @@
           The workspace ID.
         
         :returns: :class:`WorkspacePermissions`
-        
+
 
     .. py:method:: list(workspace_id: int) -> Iterator[PermissionAssignment]
 
@@ -59,7 +59,7 @@
           The workspace ID for the account.
         
         :returns: Iterator over :class:`PermissionAssignment`
-        
+
 
     .. py:method:: update(workspace_id: int, principal_id: int [, permissions: Optional[List[WorkspacePermission]]]) -> PermissionAssignment
 
@@ -103,4 +103,3 @@
           principal.
         
         :returns: :class:`PermissionAssignment`
-        

--- a/docs/account/oauth2/custom_app_integration.rst
+++ b/docs/account/oauth2/custom_app_integration.rst
@@ -28,7 +28,7 @@
           Token access policy
         
         :returns: :class:`CreateCustomAppIntegrationOutput`
-        
+
 
     .. py:method:: delete(integration_id: str)
 
@@ -39,8 +39,8 @@
         
         :param integration_id: str
         
-        
-        
+
+
 
     .. py:method:: get(integration_id: str) -> GetCustomAppIntegrationOutput
 
@@ -52,7 +52,7 @@
           The OAuth app integration ID.
         
         :returns: :class:`GetCustomAppIntegrationOutput`
-        
+
 
     .. py:method:: list( [, include_creator_username: Optional[bool], page_size: Optional[int], page_token: Optional[str]]) -> Iterator[GetCustomAppIntegrationOutput]
 
@@ -65,7 +65,7 @@
         :param page_token: str (optional)
         
         :returns: Iterator over :class:`GetCustomAppIntegrationOutput`
-        
+
 
     .. py:method:: update(integration_id: str [, redirect_urls: Optional[List[str]], token_access_policy: Optional[TokenAccessPolicy]])
 
@@ -80,5 +80,4 @@
         :param token_access_policy: :class:`TokenAccessPolicy` (optional)
           Token access policy to be updated in the custom OAuth app integration
         
-        
-        
+

--- a/docs/account/oauth2/federation_policy.rst
+++ b/docs/account/oauth2/federation_policy.rst
@@ -54,7 +54,7 @@
           The identifier for the federation policy. If unspecified, the id will be assigned by Databricks.
         
         :returns: :class:`FederationPolicy`
-        
+
 
     .. py:method:: delete(policy_id: str)
 
@@ -62,8 +62,8 @@
         
         :param policy_id: str
         
-        
-        
+
+
 
     .. py:method:: get(policy_id: str) -> FederationPolicy
 
@@ -72,7 +72,7 @@
         :param policy_id: str
         
         :returns: :class:`FederationPolicy`
-        
+
 
     .. py:method:: list( [, page_size: Optional[int], page_token: Optional[str]]) -> Iterator[FederationPolicy]
 
@@ -82,7 +82,7 @@
         :param page_token: str (optional)
         
         :returns: Iterator over :class:`FederationPolicy`
-        
+
 
     .. py:method:: update(policy_id: str, update_mask: str [, policy: Optional[FederationPolicy]]) -> FederationPolicy
 
@@ -96,4 +96,3 @@
         :param policy: :class:`FederationPolicy` (optional)
         
         :returns: :class:`FederationPolicy`
-        

--- a/docs/account/oauth2/o_auth_published_apps.rst
+++ b/docs/account/oauth2/o_auth_published_apps.rst
@@ -20,4 +20,3 @@
           A token that can be used to get the next page of results.
         
         :returns: Iterator over :class:`PublishedAppOutput`
-        

--- a/docs/account/oauth2/published_app_integration.rst
+++ b/docs/account/oauth2/published_app_integration.rst
@@ -21,7 +21,7 @@
           Token access policy
         
         :returns: :class:`CreatePublishedAppIntegrationOutput`
-        
+
 
     .. py:method:: delete(integration_id: str)
 
@@ -32,8 +32,8 @@
         
         :param integration_id: str
         
-        
-        
+
+
 
     .. py:method:: get(integration_id: str) -> GetPublishedAppIntegrationOutput
 
@@ -44,7 +44,7 @@
         :param integration_id: str
         
         :returns: :class:`GetPublishedAppIntegrationOutput`
-        
+
 
     .. py:method:: list( [, page_size: Optional[int], page_token: Optional[str]]) -> Iterator[GetPublishedAppIntegrationOutput]
 
@@ -56,7 +56,7 @@
         :param page_token: str (optional)
         
         :returns: Iterator over :class:`GetPublishedAppIntegrationOutput`
-        
+
 
     .. py:method:: update(integration_id: str [, token_access_policy: Optional[TokenAccessPolicy]])
 
@@ -69,5 +69,4 @@
         :param token_access_policy: :class:`TokenAccessPolicy` (optional)
           Token access policy to be updated in the published OAuth app integration
         
-        
-        
+

--- a/docs/account/oauth2/service_principal_federation_policy.rst
+++ b/docs/account/oauth2/service_principal_federation_policy.rst
@@ -56,7 +56,7 @@
           The identifier for the federation policy. If unspecified, the id will be assigned by Databricks.
         
         :returns: :class:`FederationPolicy`
-        
+
 
     .. py:method:: delete(service_principal_id: int, policy_id: str)
 
@@ -66,8 +66,8 @@
           The service principal id for the federation policy.
         :param policy_id: str
         
-        
-        
+
+
 
     .. py:method:: get(service_principal_id: int, policy_id: str) -> FederationPolicy
 
@@ -78,7 +78,7 @@
         :param policy_id: str
         
         :returns: :class:`FederationPolicy`
-        
+
 
     .. py:method:: list(service_principal_id: int [, page_size: Optional[int], page_token: Optional[str]]) -> Iterator[FederationPolicy]
 
@@ -90,7 +90,7 @@
         :param page_token: str (optional)
         
         :returns: Iterator over :class:`FederationPolicy`
-        
+
 
     .. py:method:: update(service_principal_id: int, policy_id: str, update_mask: str [, policy: Optional[FederationPolicy]]) -> FederationPolicy
 
@@ -106,4 +106,3 @@
         :param policy: :class:`FederationPolicy` (optional)
         
         :returns: :class:`FederationPolicy`
-        

--- a/docs/account/oauth2/service_principal_secrets.rst
+++ b/docs/account/oauth2/service_principal_secrets.rst
@@ -26,7 +26,7 @@
           The service principal ID.
         
         :returns: :class:`CreateServicePrincipalSecretResponse`
-        
+
 
     .. py:method:: delete(service_principal_id: int, secret_id: str)
 
@@ -39,8 +39,8 @@
         :param secret_id: str
           The secret ID.
         
-        
-        
+
+
 
     .. py:method:: list(service_principal_id: int [, page_token: Optional[str]]) -> Iterator[SecretInfo]
 
@@ -60,4 +60,3 @@
           of entries returned must not be used to determine when the listing is complete.
         
         :returns: Iterator over :class:`SecretInfo`
-        

--- a/docs/account/provisioning/credentials.rst
+++ b/docs/account/provisioning/credentials.rst
@@ -52,7 +52,7 @@
         :param aws_credentials: :class:`CreateCredentialAwsCredentials`
         
         :returns: :class:`Credential`
-        
+
 
     .. py:method:: delete(credentials_id: str)
 
@@ -64,8 +64,8 @@
         :param credentials_id: str
           Databricks Account API credential configuration ID
         
-        
-        
+
+
 
     .. py:method:: get(credentials_id: str) -> Credential
 
@@ -100,7 +100,7 @@
           Databricks Account API credential configuration ID
         
         :returns: :class:`Credential`
-        
+
 
     .. py:method:: list() -> Iterator[Credential]
 
@@ -120,4 +120,3 @@
         Gets all Databricks credential configurations associated with an account specified by ID.
         
         :returns: Iterator over :class:`Credential`
-        

--- a/docs/account/provisioning/encryption_keys.rst
+++ b/docs/account/provisioning/encryption_keys.rst
@@ -61,7 +61,7 @@
         :param gcp_key_info: :class:`CreateGcpKeyInfo` (optional)
         
         :returns: :class:`CustomerManagedKey`
-        
+
 
     .. py:method:: delete(customer_managed_key_id: str)
 
@@ -73,8 +73,8 @@
         :param customer_managed_key_id: str
           Databricks encryption key configuration ID.
         
-        
-        
+
+
 
     .. py:method:: get(customer_managed_key_id: str) -> CustomerManagedKey
 
@@ -118,7 +118,7 @@
           Databricks encryption key configuration ID.
         
         :returns: :class:`CustomerManagedKey`
-        
+
 
     .. py:method:: list() -> Iterator[CustomerManagedKey]
 
@@ -147,4 +147,3 @@
         This operation is available only if your account is on the E2 version of the platform.
         
         :returns: Iterator over :class:`CustomerManagedKey`
-        

--- a/docs/account/provisioning/networks.rst
+++ b/docs/account/provisioning/networks.rst
@@ -52,7 +52,7 @@
           configurations.
         
         :returns: :class:`Network`
-        
+
 
     .. py:method:: delete(network_id: str)
 
@@ -66,8 +66,8 @@
         :param network_id: str
           Databricks Account API network configuration ID.
         
-        
-        
+
+
 
     .. py:method:: get(network_id: str) -> Network
 
@@ -98,7 +98,7 @@
           Databricks Account API network configuration ID.
         
         :returns: :class:`Network`
-        
+
 
     .. py:method:: list() -> Iterator[Network]
 
@@ -120,4 +120,3 @@
         This operation is available only if your account is on the E2 version of the platform.
         
         :returns: Iterator over :class:`Network`
-        

--- a/docs/account/provisioning/private_access.rst
+++ b/docs/account/provisioning/private_access.rst
@@ -70,7 +70,7 @@
           PrivateLink connections. Otherwise, specify `true`, which means that public access is enabled.
         
         :returns: :class:`PrivateAccessSettings`
-        
+
 
     .. py:method:: delete(private_access_settings_id: str)
 
@@ -87,8 +87,8 @@
         :param private_access_settings_id: str
           Databricks Account API private access settings ID.
         
-        
-        
+
+
 
     .. py:method:: get(private_access_settings_id: str) -> PrivateAccessSettings
 
@@ -126,7 +126,7 @@
           Databricks Account API private access settings ID.
         
         :returns: :class:`PrivateAccessSettings`
-        
+
 
     .. py:method:: list() -> Iterator[PrivateAccessSettings]
 
@@ -146,7 +146,7 @@
         Gets a list of all private access settings objects for an account, specified by ID.
         
         :returns: Iterator over :class:`PrivateAccessSettings`
-        
+
 
     .. py:method:: replace(private_access_settings_id: str, private_access_settings_name: str, region: str [, allowed_vpc_endpoint_ids: Optional[List[str]], private_access_level: Optional[PrivateAccessLevel], public_access_enabled: Optional[bool]])
 
@@ -222,5 +222,4 @@
           can optionally specify `false`, but only if you implement both the front-end and the back-end
           PrivateLink connections. Otherwise, specify `true`, which means that public access is enabled.
         
-        
-        
+

--- a/docs/account/provisioning/storage.rst
+++ b/docs/account/provisioning/storage.rst
@@ -49,7 +49,7 @@
           Root S3 bucket information.
         
         :returns: :class:`StorageConfiguration`
-        
+
 
     .. py:method:: delete(storage_configuration_id: str)
 
@@ -61,8 +61,8 @@
         :param storage_configuration_id: str
           Databricks Account API storage configuration ID.
         
-        
-        
+
+
 
     .. py:method:: get(storage_configuration_id: str) -> StorageConfiguration
 
@@ -91,7 +91,7 @@
           Databricks Account API storage configuration ID.
         
         :returns: :class:`StorageConfiguration`
-        
+
 
     .. py:method:: list() -> Iterator[StorageConfiguration]
 
@@ -111,4 +111,3 @@
         Gets a list of all Databricks storage configurations for your account, specified by ID.
         
         :returns: Iterator over :class:`StorageConfiguration`
-        

--- a/docs/account/provisioning/vpc_endpoints.rst
+++ b/docs/account/provisioning/vpc_endpoints.rst
@@ -52,7 +52,7 @@
           The AWS region in which this VPC endpoint object exists.
         
         :returns: :class:`VpcEndpoint`
-        
+
 
     .. py:method:: delete(vpc_endpoint_id: str)
 
@@ -70,8 +70,8 @@
         :param vpc_endpoint_id: str
           Databricks VPC endpoint ID.
         
-        
-        
+
+
 
     .. py:method:: get(vpc_endpoint_id: str) -> VpcEndpoint
 
@@ -108,7 +108,7 @@
           Databricks VPC endpoint ID.
         
         :returns: :class:`VpcEndpoint`
-        
+
 
     .. py:method:: list() -> Iterator[VpcEndpoint]
 
@@ -132,4 +132,3 @@
         [Databricks article about PrivateLink]: https://docs.databricks.com/administration-guide/cloud-configurations/aws/privatelink.html
         
         :returns: Iterator over :class:`VpcEndpoint`
-        

--- a/docs/account/provisioning/workspaces.rst
+++ b/docs/account/provisioning/workspaces.rst
@@ -148,7 +148,7 @@
         :returns:
           Long-running operation waiter for :class:`Workspace`.
           See :method:wait_get_workspace_running for more details.
-        
+
 
     .. py:method:: create_and_wait(workspace_name: str [, aws_region: Optional[str], cloud: Optional[str], cloud_resource_container: Optional[CloudResourceContainer], credentials_id: Optional[str], custom_tags: Optional[Dict[str, str]], deployment_name: Optional[str], gcp_managed_network_config: Optional[GcpManagedNetworkConfig], gke_config: Optional[GkeConfig], is_no_public_ip_enabled: Optional[bool], location: Optional[str], managed_services_customer_managed_key_id: Optional[str], network_id: Optional[str], pricing_tier: Optional[PricingTier], private_access_settings_id: Optional[str], storage_configuration_id: Optional[str], storage_customer_managed_key_id: Optional[str], timeout: datetime.timedelta = 0:20:00]) -> Workspace
 
@@ -167,8 +167,8 @@
         :param workspace_id: int
           Workspace ID.
         
-        
-        
+
+
 
     .. py:method:: get(workspace_id: int) -> Workspace
 
@@ -204,7 +204,7 @@
           Workspace ID.
         
         :returns: :class:`Workspace`
-        
+
 
     .. py:method:: list() -> Iterator[Workspace]
 
@@ -227,7 +227,7 @@
         custom plan that allows multiple workspaces per account.
         
         :returns: Iterator over :class:`Workspace`
-        
+
 
     .. py:method:: update(workspace_id: int [, aws_region: Optional[str], credentials_id: Optional[str], custom_tags: Optional[Dict[str, str]], managed_services_customer_managed_key_id: Optional[str], network_connectivity_config_id: Optional[str], network_id: Optional[str], private_access_settings_id: Optional[str], storage_configuration_id: Optional[str], storage_customer_managed_key_id: Optional[str]]) -> Wait[Workspace]
 
@@ -385,7 +385,7 @@
         :returns:
           Long-running operation waiter for :class:`Workspace`.
           See :method:wait_get_workspace_running for more details.
-        
+
 
     .. py:method:: update_and_wait(workspace_id: int [, aws_region: Optional[str], credentials_id: Optional[str], custom_tags: Optional[Dict[str, str]], managed_services_customer_managed_key_id: Optional[str], network_connectivity_config_id: Optional[str], network_id: Optional[str], private_access_settings_id: Optional[str], storage_configuration_id: Optional[str], storage_customer_managed_key_id: Optional[str], timeout: datetime.timedelta = 0:20:00]) -> Workspace
 

--- a/docs/account/settings/csp_enablement_account.rst
+++ b/docs/account/settings/csp_enablement_account.rst
@@ -25,7 +25,7 @@
           request, and pass it with the DELETE request to identify the rule set version you are deleting.
         
         :returns: :class:`CspEnablementAccountSetting`
-        
+
 
     .. py:method:: update(allow_missing: bool, setting: CspEnablementAccountSetting, field_mask: str) -> CspEnablementAccountSetting
 
@@ -42,4 +42,3 @@
           multiple fields in the field mask, use comma as the separator (no space).
         
         :returns: :class:`CspEnablementAccountSetting`
-        

--- a/docs/account/settings/disable_legacy_features.rst
+++ b/docs/account/settings/disable_legacy_features.rst
@@ -24,7 +24,7 @@
           request, and pass it with the DELETE request to identify the rule set version you are deleting.
         
         :returns: :class:`DeleteDisableLegacyFeaturesResponse`
-        
+
 
     .. py:method:: get( [, etag: Optional[str]]) -> DisableLegacyFeatures
 
@@ -40,7 +40,7 @@
           request, and pass it with the DELETE request to identify the rule set version you are deleting.
         
         :returns: :class:`DisableLegacyFeatures`
-        
+
 
     .. py:method:: update(allow_missing: bool, setting: DisableLegacyFeatures, field_mask: str) -> DisableLegacyFeatures
 
@@ -57,4 +57,3 @@
           multiple fields in the field mask, use comma as the separator (no space).
         
         :returns: :class:`DisableLegacyFeatures`
-        

--- a/docs/account/settings/esm_enablement_account.rst
+++ b/docs/account/settings/esm_enablement_account.rst
@@ -22,7 +22,7 @@
           request, and pass it with the DELETE request to identify the rule set version you are deleting.
         
         :returns: :class:`EsmEnablementAccountSetting`
-        
+
 
     .. py:method:: update(allow_missing: bool, setting: EsmEnablementAccountSetting, field_mask: str) -> EsmEnablementAccountSetting
 
@@ -39,4 +39,3 @@
           multiple fields in the field mask, use comma as the separator (no space).
         
         :returns: :class:`EsmEnablementAccountSetting`
-        

--- a/docs/account/settings/ip_access_lists.rst
+++ b/docs/account/settings/ip_access_lists.rst
@@ -51,7 +51,7 @@
         :param ip_addresses: List[str] (optional)
         
         :returns: :class:`CreateIpAccessListResponse`
-        
+
 
     .. py:method:: delete(ip_access_list_id: str)
 
@@ -62,8 +62,8 @@
         :param ip_access_list_id: str
           The ID for the corresponding IP access list
         
-        
-        
+
+
 
     .. py:method:: get(ip_access_list_id: str) -> GetIpAccessListResponse
 
@@ -75,7 +75,7 @@
           The ID for the corresponding IP access list
         
         :returns: :class:`GetIpAccessListResponse`
-        
+
 
     .. py:method:: list() -> Iterator[IpAccessListInfo]
 
@@ -84,7 +84,7 @@
         Gets all IP access lists for the specified account.
         
         :returns: Iterator over :class:`IpAccessListInfo`
-        
+
 
     .. py:method:: replace(ip_access_list_id: str, label: str, list_type: ListType, enabled: bool [, ip_addresses: Optional[List[str]]])
 
@@ -113,8 +113,8 @@
           Specifies whether this IP access list is enabled.
         :param ip_addresses: List[str] (optional)
         
-        
-        
+
+
 
     .. py:method:: update(ip_access_list_id: str [, enabled: Optional[bool], ip_addresses: Optional[List[str]], label: Optional[str], list_type: Optional[ListType]])
 
@@ -147,5 +147,4 @@
           * `ALLOW`: An allow list. Include this IP or range. * `BLOCK`: A block list. Exclude this IP or
           range. IP addresses in the block list are excluded even if they are included in an allow list.
         
-        
-        
+

--- a/docs/account/settings/network_connectivity.rst
+++ b/docs/account/settings/network_connectivity.rst
@@ -20,7 +20,7 @@
           attached to the network connectivity configuration.
         
         :returns: :class:`NetworkConnectivityConfiguration`
-        
+
 
     .. py:method:: create_private_endpoint_rule(network_connectivity_config_id: str, resource_id: str, group_id: CreatePrivateEndpointRuleRequestGroupId) -> NccAzurePrivateEndpointRule
 
@@ -45,7 +45,7 @@
           storage (root DBFS), you need two endpoints, one for `blob` and one for `dfs`.
         
         :returns: :class:`NccAzurePrivateEndpointRule`
-        
+
 
     .. py:method:: delete_network_connectivity_configuration(network_connectivity_config_id: str)
 
@@ -56,8 +56,8 @@
         :param network_connectivity_config_id: str
           Your Network Connectvity Configuration ID.
         
-        
-        
+
+
 
     .. py:method:: delete_private_endpoint_rule(network_connectivity_config_id: str, private_endpoint_rule_id: str) -> NccAzurePrivateEndpointRule
 
@@ -74,7 +74,7 @@
           Your private endpoint rule ID.
         
         :returns: :class:`NccAzurePrivateEndpointRule`
-        
+
 
     .. py:method:: get_network_connectivity_configuration(network_connectivity_config_id: str) -> NetworkConnectivityConfiguration
 
@@ -86,7 +86,7 @@
           Your Network Connectvity Configuration ID.
         
         :returns: :class:`NetworkConnectivityConfiguration`
-        
+
 
     .. py:method:: get_private_endpoint_rule(network_connectivity_config_id: str, private_endpoint_rule_id: str) -> NccAzurePrivateEndpointRule
 
@@ -100,7 +100,7 @@
           Your private endpoint rule ID.
         
         :returns: :class:`NccAzurePrivateEndpointRule`
-        
+
 
     .. py:method:: list_network_connectivity_configurations( [, page_token: Optional[str]]) -> Iterator[NetworkConnectivityConfiguration]
 
@@ -112,7 +112,7 @@
           Pagination token to go to next page based on previous query.
         
         :returns: Iterator over :class:`NetworkConnectivityConfiguration`
-        
+
 
     .. py:method:: list_private_endpoint_rules(network_connectivity_config_id: str [, page_token: Optional[str]]) -> Iterator[NccAzurePrivateEndpointRule]
 
@@ -126,4 +126,3 @@
           Pagination token to go to next page based on previous query.
         
         :returns: Iterator over :class:`NccAzurePrivateEndpointRule`
-        

--- a/docs/account/settings/personal_compute.rst
+++ b/docs/account/settings/personal_compute.rst
@@ -26,7 +26,7 @@
           request, and pass it with the DELETE request to identify the rule set version you are deleting.
         
         :returns: :class:`DeletePersonalComputeSettingResponse`
-        
+
 
     .. py:method:: get( [, etag: Optional[str]]) -> PersonalComputeSetting
 
@@ -42,7 +42,7 @@
           request, and pass it with the DELETE request to identify the rule set version you are deleting.
         
         :returns: :class:`PersonalComputeSetting`
-        
+
 
     .. py:method:: update(allow_missing: bool, setting: PersonalComputeSetting, field_mask: str) -> PersonalComputeSetting
 
@@ -59,4 +59,3 @@
           multiple fields in the field mask, use comma as the separator (no space).
         
         :returns: :class:`PersonalComputeSetting`
-        

--- a/docs/gen-client-docs.py
+++ b/docs/gen-client-docs.py
@@ -67,8 +67,7 @@ class PropertyDoc:
         if self.doc is not None:
             # This is a class doc, which comes with 4 indentation spaces. 
             # Here we are using the doc as property doc, which needs 8 indentation spaces.
-            formatted_doc = re.sub(r'\n', '\n    ', self.doc)
-            out.append(f'\n        {formatted_doc}')
+            out.append(f'\n{format_doc(self.doc, 8)}')
         return "\n".join(out)
 
 @dataclass
@@ -92,9 +91,14 @@ class MethodDoc:
         if usage != '':
             out.append(usage)
         if self.doc is not None:
-            out.append(f'        {self.doc}')
+            out.append(format_doc(self.doc, 8))
         return "\n".join(out)
 
+
+def format_doc(doc: str, indentation: int) -> str:
+    # Depending on the environment, the input docstring might be or not be indented.
+    # This function will make sure that the output docstring is consistently indented.
+    return ' ' * indentation + re.sub(rf'\n(?!$)( {{{indentation}}})?', '\n' + ' ' * indentation, doc)
 
 @dataclass
 class ServiceDoc:
@@ -113,7 +117,7 @@ class ServiceDoc:
         out = [
             title, '=' * len(title),
             f'.. currentmodule:: databricks.sdk.service.{self.tag.package.name}', '',
-            f'.. py:class:: {self.class_name}', '', f'    {self.doc}'
+            f'.. py:class:: {self.class_name}', '', format_doc(self.doc, 4)
         ]
         for m in self.methods:
             usage = self.usage_example(m)

--- a/docs/workspace/apps/apps.rst
+++ b/docs/workspace/apps/apps.rst
@@ -18,7 +18,7 @@
         :returns:
           Long-running operation waiter for :class:`App`.
           See :method:wait_get_app_active for more details.
-        
+
 
     .. py:method:: create_and_wait( [, app: Optional[App], timeout: datetime.timedelta = 0:20:00]) -> App
 
@@ -33,7 +33,7 @@
           The name of the app.
         
         :returns: :class:`App`
-        
+
 
     .. py:method:: deploy(app_name: str [, app_deployment: Optional[AppDeployment]]) -> Wait[AppDeployment]
 
@@ -48,7 +48,7 @@
         :returns:
           Long-running operation waiter for :class:`AppDeployment`.
           See :method:wait_get_deployment_app_succeeded for more details.
-        
+
 
     .. py:method:: deploy_and_wait(app_name: str [, app_deployment: Optional[AppDeployment], timeout: datetime.timedelta = 0:20:00]) -> AppDeployment
 
@@ -63,7 +63,7 @@
           The name of the app.
         
         :returns: :class:`App`
-        
+
 
     .. py:method:: get_deployment(app_name: str, deployment_id: str) -> AppDeployment
 
@@ -77,7 +77,7 @@
           The unique id of the deployment.
         
         :returns: :class:`AppDeployment`
-        
+
 
     .. py:method:: get_permission_levels(app_name: str) -> GetAppPermissionLevelsResponse
 
@@ -89,7 +89,7 @@
           The app for which to get or manage permissions.
         
         :returns: :class:`GetAppPermissionLevelsResponse`
-        
+
 
     .. py:method:: get_permissions(app_name: str) -> AppPermissions
 
@@ -101,7 +101,7 @@
           The app for which to get or manage permissions.
         
         :returns: :class:`AppPermissions`
-        
+
 
     .. py:method:: list( [, page_size: Optional[int], page_token: Optional[str]]) -> Iterator[App]
 
@@ -115,7 +115,7 @@
           Pagination token to go to the next page of apps. Requests first page if absent.
         
         :returns: Iterator over :class:`App`
-        
+
 
     .. py:method:: list_deployments(app_name: str [, page_size: Optional[int], page_token: Optional[str]]) -> Iterator[AppDeployment]
 
@@ -131,7 +131,7 @@
           Pagination token to go to the next page of apps. Requests first page if absent.
         
         :returns: Iterator over :class:`AppDeployment`
-        
+
 
     .. py:method:: set_permissions(app_name: str [, access_control_list: Optional[List[AppAccessControlRequest]]]) -> AppPermissions
 
@@ -145,7 +145,7 @@
         :param access_control_list: List[:class:`AppAccessControlRequest`] (optional)
         
         :returns: :class:`AppPermissions`
-        
+
 
     .. py:method:: start(name: str) -> Wait[App]
 
@@ -159,7 +159,7 @@
         :returns:
           Long-running operation waiter for :class:`App`.
           See :method:wait_get_app_active for more details.
-        
+
 
     .. py:method:: start_and_wait(name: str, timeout: datetime.timedelta = 0:20:00) -> App
 
@@ -176,7 +176,7 @@
         :returns:
           Long-running operation waiter for :class:`App`.
           See :method:wait_get_app_stopped for more details.
-        
+
 
     .. py:method:: stop_and_wait(name: str, timeout: datetime.timedelta = 0:20:00) -> App
 
@@ -193,7 +193,7 @@
         :param app: :class:`App` (optional)
         
         :returns: :class:`App`
-        
+
 
     .. py:method:: update_permissions(app_name: str [, access_control_list: Optional[List[AppAccessControlRequest]]]) -> AppPermissions
 
@@ -206,7 +206,7 @@
         :param access_control_list: List[:class:`AppAccessControlRequest`] (optional)
         
         :returns: :class:`AppPermissions`
-        
+
 
     .. py:method:: wait_get_app_active(name: str, timeout: datetime.timedelta = 0:20:00, callback: Optional[Callable[[App], None]]) -> App
 

--- a/docs/workspace/catalog/artifact_allowlists.rst
+++ b/docs/workspace/catalog/artifact_allowlists.rst
@@ -18,7 +18,7 @@
           The artifact type of the allowlist.
         
         :returns: :class:`ArtifactAllowlistInfo`
-        
+
 
     .. py:method:: update(artifact_type: ArtifactType, artifact_matchers: List[ArtifactMatcher]) -> ArtifactAllowlistInfo
 
@@ -34,4 +34,3 @@
           A list of allowed artifact match patterns.
         
         :returns: :class:`ArtifactAllowlistInfo`
-        

--- a/docs/workspace/catalog/catalogs.rst
+++ b/docs/workspace/catalog/catalogs.rst
@@ -54,7 +54,7 @@
           Storage root URL for managed tables within catalog.
         
         :returns: :class:`CatalogInfo`
-        
+
 
     .. py:method:: delete(name: str [, force: Optional[bool]])
 
@@ -68,8 +68,8 @@
         :param force: bool (optional)
           Force deletion even if the catalog is not empty.
         
-        
-        
+
+
 
     .. py:method:: get(name: str [, include_browse: Optional[bool]]) -> CatalogInfo
 
@@ -103,7 +103,7 @@
           metadata for
         
         :returns: :class:`CatalogInfo`
-        
+
 
     .. py:method:: list( [, include_browse: Optional[bool], max_results: Optional[int], page_token: Optional[str]]) -> Iterator[CatalogInfo]
 
@@ -141,7 +141,7 @@
           Opaque pagination token to go to next page based on previous query.
         
         :returns: Iterator over :class:`CatalogInfo`
-        
+
 
     .. py:method:: update(name: str [, comment: Optional[str], enable_predictive_optimization: Optional[EnablePredictiveOptimization], isolation_mode: Optional[CatalogIsolationMode], new_name: Optional[str], owner: Optional[str], properties: Optional[Dict[str, str]]]) -> CatalogInfo
 
@@ -184,4 +184,3 @@
           A map of key-value properties attached to the securable.
         
         :returns: :class:`CatalogInfo`
-        

--- a/docs/workspace/catalog/connections.rst
+++ b/docs/workspace/catalog/connections.rst
@@ -63,7 +63,7 @@
           If the connection is read only.
         
         :returns: :class:`ConnectionInfo`
-        
+
 
     .. py:method:: delete(name: str)
 
@@ -74,8 +74,8 @@
         :param name: str
           The name of the connection to be deleted.
         
-        
-        
+
+
 
     .. py:method:: get(name: str) -> ConnectionInfo
 
@@ -126,7 +126,7 @@
           Name of the connection.
         
         :returns: :class:`ConnectionInfo`
-        
+
 
     .. py:method:: list( [, max_results: Optional[int], page_token: Optional[str]]) -> Iterator[ConnectionInfo]
 
@@ -155,7 +155,7 @@
           Opaque pagination token to go to next page based on previous query.
         
         :returns: Iterator over :class:`ConnectionInfo`
-        
+
 
     .. py:method:: update(name: str, options: Dict[str, str] [, new_name: Optional[str], owner: Optional[str]]) -> ConnectionInfo
 
@@ -210,4 +210,3 @@
           Username of current owner of the connection.
         
         :returns: :class:`ConnectionInfo`
-        

--- a/docs/workspace/catalog/external_locations.rst
+++ b/docs/workspace/catalog/external_locations.rst
@@ -73,7 +73,7 @@
           Skips validation of the storage credential associated with the external location.
         
         :returns: :class:`ExternalLocationInfo`
-        
+
 
     .. py:method:: delete(name: str [, force: Optional[bool]])
 
@@ -87,8 +87,8 @@
         :param force: bool (optional)
           Force deletion even if there are dependent external tables or mounts.
         
-        
-        
+
+
 
     .. py:method:: get(name: str [, include_browse: Optional[bool]]) -> ExternalLocationInfo
 
@@ -131,7 +131,7 @@
           selective metadata for
         
         :returns: :class:`ExternalLocationInfo`
-        
+
 
     .. py:method:: list( [, include_browse: Optional[bool], max_results: Optional[int], page_token: Optional[str]]) -> Iterator[ExternalLocationInfo]
 
@@ -165,7 +165,7 @@
           Opaque pagination token to go to next page based on previous query.
         
         :returns: Iterator over :class:`ExternalLocationInfo`
-        
+
 
     .. py:method:: update(name: str [, access_point: Optional[str], comment: Optional[str], credential_name: Optional[str], encryption_details: Optional[EncryptionDetails], fallback: Optional[bool], force: Optional[bool], isolation_mode: Optional[IsolationMode], new_name: Optional[str], owner: Optional[str], read_only: Optional[bool], skip_validation: Optional[bool], url: Optional[str]]) -> ExternalLocationInfo
 
@@ -233,4 +233,3 @@
           Path URL of the external location.
         
         :returns: :class:`ExternalLocationInfo`
-        

--- a/docs/workspace/catalog/functions.rst
+++ b/docs/workspace/catalog/functions.rst
@@ -26,7 +26,7 @@
           Partial __FunctionInfo__ specifying the function to be created.
         
         :returns: :class:`FunctionInfo`
-        
+
 
     .. py:method:: delete(name: str [, force: Optional[bool]])
 
@@ -44,8 +44,8 @@
         :param force: bool (optional)
           Force deletion even if the function is notempty.
         
-        
-        
+
+
 
     .. py:method:: get(name: str [, include_browse: Optional[bool]]) -> FunctionInfo
 
@@ -66,7 +66,7 @@
           metadata for
         
         :returns: :class:`FunctionInfo`
-        
+
 
     .. py:method:: list(catalog_name: str, schema_name: str [, include_browse: Optional[bool], max_results: Optional[int], page_token: Optional[str]]) -> Iterator[FunctionInfo]
 
@@ -94,7 +94,7 @@
           Opaque pagination token to go to next page based on previous query.
         
         :returns: Iterator over :class:`FunctionInfo`
-        
+
 
     .. py:method:: update(name: str [, owner: Optional[str]]) -> FunctionInfo
 
@@ -114,4 +114,3 @@
           Username of current owner of function.
         
         :returns: :class:`FunctionInfo`
-        

--- a/docs/workspace/catalog/grants.rst
+++ b/docs/workspace/catalog/grants.rst
@@ -63,7 +63,7 @@
           If provided, only the permissions for the specified principal (user or group) are returned.
         
         :returns: :class:`PermissionsList`
-        
+
 
     .. py:method:: get_effective(securable_type: SecurableType, full_name: str [, principal: Optional[str]]) -> EffectivePermissionsList
 
@@ -115,7 +115,7 @@
           returned.
         
         :returns: :class:`EffectivePermissionsList`
-        
+
 
     .. py:method:: update(securable_type: SecurableType, full_name: str [, changes: Optional[List[PermissionsChange]]]) -> PermissionsList
 
@@ -173,4 +173,3 @@
           Array of permissions change objects.
         
         :returns: :class:`PermissionsList`
-        

--- a/docs/workspace/catalog/metastores.rst
+++ b/docs/workspace/catalog/metastores.rst
@@ -55,8 +55,8 @@
           The name of the default catalog in the metastore. This field is depracted. Please use "Default
           Namespace API" to configure the default catalog for a Databricks workspace.
         
-        
-        
+
+
 
     .. py:method:: create(name: str [, region: Optional[str], storage_root: Optional[str]]) -> MetastoreInfo
 
@@ -96,7 +96,7 @@
           The storage root URL for metastore
         
         :returns: :class:`MetastoreInfo`
-        
+
 
     .. py:method:: current() -> MetastoreAssignment
 
@@ -116,7 +116,7 @@
         Gets the metastore assignment for the workspace being accessed.
         
         :returns: :class:`MetastoreAssignment`
-        
+
 
     .. py:method:: delete(id: str [, force: Optional[bool]])
 
@@ -129,8 +129,8 @@
         :param force: bool (optional)
           Force deletion even if the metastore is not empty. Default is false.
         
-        
-        
+
+
 
     .. py:method:: get(id: str) -> MetastoreInfo
 
@@ -164,7 +164,7 @@
           Unique ID of the metastore.
         
         :returns: :class:`MetastoreInfo`
-        
+
 
     .. py:method:: list() -> Iterator[MetastoreInfo]
 
@@ -185,7 +185,7 @@
         to retrieve this info. There is no guarantee of a specific ordering of the elements in the array.
         
         :returns: Iterator over :class:`MetastoreInfo`
-        
+
 
     .. py:method:: summary() -> GetMetastoreSummaryResponse
 
@@ -206,7 +206,7 @@
         the cloud region, and the global metastore ID.
         
         :returns: :class:`GetMetastoreSummaryResponse`
-        
+
 
     .. py:method:: unassign(workspace_id: int, metastore_id: str)
 
@@ -242,8 +242,8 @@
         :param metastore_id: str
           Query for the ID of the metastore to delete.
         
-        
-        
+
+
 
     .. py:method:: update(id: str [, delta_sharing_organization_name: Optional[str], delta_sharing_recipient_token_lifetime_in_seconds: Optional[int], delta_sharing_scope: Optional[UpdateMetastoreDeltaSharingScope], new_name: Optional[str], owner: Optional[str], privilege_model_version: Optional[str], storage_root_credential_id: Optional[str]]) -> MetastoreInfo
 
@@ -292,7 +292,7 @@
           UUID of storage credential to access the metastore storage_root.
         
         :returns: :class:`MetastoreInfo`
-        
+
 
     .. py:method:: update_assignment(workspace_id: int [, default_catalog_name: Optional[str], metastore_id: Optional[str]])
 
@@ -311,5 +311,4 @@
         :param metastore_id: str (optional)
           The unique ID of the metastore.
         
-        
-        
+

--- a/docs/workspace/catalog/model_versions.rst
+++ b/docs/workspace/catalog/model_versions.rst
@@ -27,8 +27,8 @@
         :param version: int
           The integer version number of the model version
         
-        
-        
+
+
 
     .. py:method:: get(full_name: str, version: int [, include_aliases: Optional[bool], include_browse: Optional[bool]]) -> ModelVersionInfo
 
@@ -51,7 +51,7 @@
           metadata for
         
         :returns: :class:`ModelVersionInfo`
-        
+
 
     .. py:method:: get_by_alias(full_name: str, alias: str [, include_aliases: Optional[bool]]) -> ModelVersionInfo
 
@@ -71,7 +71,7 @@
           Whether to include aliases associated with the model version in the response
         
         :returns: :class:`ModelVersionInfo`
-        
+
 
     .. py:method:: list(full_name: str [, include_browse: Optional[bool], max_results: Optional[int], page_token: Optional[str]]) -> Iterator[ModelVersionInfo]
 
@@ -104,7 +104,7 @@
           Opaque pagination token to go to next page based on previous query.
         
         :returns: Iterator over :class:`ModelVersionInfo`
-        
+
 
     .. py:method:: update(full_name: str, version: int [, comment: Optional[str]]) -> ModelVersionInfo
 
@@ -126,4 +126,3 @@
           The comment attached to the model version
         
         :returns: :class:`ModelVersionInfo`
-        

--- a/docs/workspace/catalog/online_tables.rst
+++ b/docs/workspace/catalog/online_tables.rst
@@ -18,7 +18,7 @@
         :returns:
           Long-running operation waiter for :class:`OnlineTable`.
           See :method:wait_get_online_table_active for more details.
-        
+
 
     .. py:method:: create_and_wait( [, table: Optional[OnlineTable], timeout: datetime.timedelta = 0:20:00]) -> OnlineTable
 
@@ -34,8 +34,8 @@
         :param name: str
           Full three-part (catalog, schema, table) name of the table.
         
-        
-        
+
+
 
     .. py:method:: get(name: str) -> OnlineTable
 
@@ -47,6 +47,6 @@
           Full three-part (catalog, schema, table) name of the table.
         
         :returns: :class:`OnlineTable`
-        
+
 
     .. py:method:: wait_get_online_table_active(name: str, timeout: datetime.timedelta = 0:20:00, callback: Optional[Callable[[OnlineTable], None]]) -> OnlineTable

--- a/docs/workspace/catalog/quality_monitors.rst
+++ b/docs/workspace/catalog/quality_monitors.rst
@@ -29,8 +29,8 @@
         :param refresh_id: str
           ID of the refresh.
         
-        
-        
+
+
 
     .. py:method:: create(table_name: str, assets_dir: str, output_schema_name: str [, baseline_table_name: Optional[str], custom_metrics: Optional[List[MonitorMetric]], data_classification_config: Optional[MonitorDataClassificationConfig], inference_log: Optional[MonitorInferenceLog], notifications: Optional[MonitorNotifications], schedule: Optional[MonitorCronSchedule], skip_builtin_dashboard: Optional[bool], slicing_exprs: Optional[List[str]], snapshot: Optional[MonitorSnapshot], time_series: Optional[MonitorTimeSeries], warehouse_id: Optional[str]]) -> MonitorInfo
 
@@ -81,7 +81,7 @@
           running warehouse will be used.
         
         :returns: :class:`MonitorInfo`
-        
+
 
     .. py:method:: delete(table_name: str)
 
@@ -102,8 +102,8 @@
         :param table_name: str
           Full name of the table.
         
-        
-        
+
+
 
     .. py:method:: get(table_name: str) -> MonitorInfo
 
@@ -124,7 +124,7 @@
           Full name of the table.
         
         :returns: :class:`MonitorInfo`
-        
+
 
     .. py:method:: get_refresh(table_name: str, refresh_id: str) -> MonitorRefreshInfo
 
@@ -145,7 +145,7 @@
           ID of the refresh.
         
         :returns: :class:`MonitorRefreshInfo`
-        
+
 
     .. py:method:: list_refreshes(table_name: str) -> MonitorRefreshListResponse
 
@@ -164,7 +164,7 @@
           Full name of the table.
         
         :returns: :class:`MonitorRefreshListResponse`
-        
+
 
     .. py:method:: regenerate_dashboard(table_name: str [, warehouse_id: Optional[str]]) -> RegenerateDashboardResponse
 
@@ -187,7 +187,7 @@
           running warehouse will be used.
         
         :returns: :class:`RegenerateDashboardResponse`
-        
+
 
     .. py:method:: run_refresh(table_name: str) -> MonitorRefreshInfo
 
@@ -207,7 +207,7 @@
           Full name of the table.
         
         :returns: :class:`MonitorRefreshInfo`
-        
+
 
     .. py:method:: update(table_name: str, output_schema_name: str [, baseline_table_name: Optional[str], custom_metrics: Optional[List[MonitorMetric]], dashboard_id: Optional[str], data_classification_config: Optional[MonitorDataClassificationConfig], inference_log: Optional[MonitorInferenceLog], notifications: Optional[MonitorNotifications], schedule: Optional[MonitorCronSchedule], slicing_exprs: Optional[List[str]], snapshot: Optional[MonitorSnapshot], time_series: Optional[MonitorTimeSeries]]) -> MonitorInfo
 
@@ -256,4 +256,3 @@
           Configuration for monitoring time series tables.
         
         :returns: :class:`MonitorInfo`
-        

--- a/docs/workspace/catalog/registered_models.rst
+++ b/docs/workspace/catalog/registered_models.rst
@@ -55,7 +55,7 @@
           The storage location on the cloud under which model version data files are stored
         
         :returns: :class:`RegisteredModelInfo`
-        
+
 
     .. py:method:: delete(full_name: str)
 
@@ -70,8 +70,8 @@
         :param full_name: str
           The three-level (fully qualified) name of the registered model
         
-        
-        
+
+
 
     .. py:method:: delete_alias(full_name: str, alias: str)
 
@@ -88,8 +88,8 @@
         :param alias: str
           The name of the alias
         
-        
-        
+
+
 
     .. py:method:: get(full_name: str [, include_aliases: Optional[bool], include_browse: Optional[bool]]) -> RegisteredModelInfo
 
@@ -110,7 +110,7 @@
           selective metadata for
         
         :returns: :class:`RegisteredModelInfo`
-        
+
 
     .. py:method:: list( [, catalog_name: Optional[str], include_browse: Optional[bool], max_results: Optional[int], page_token: Optional[str], schema_name: Optional[str]]) -> Iterator[RegisteredModelInfo]
 
@@ -154,7 +154,7 @@
           be specified.
         
         :returns: Iterator over :class:`RegisteredModelInfo`
-        
+
 
     .. py:method:: set_alias(full_name: str, alias: str, version_num: int) -> RegisteredModelAlias
 
@@ -174,7 +174,7 @@
           The version number of the model version to which the alias points
         
         :returns: :class:`RegisteredModelAlias`
-        
+
 
     .. py:method:: update(full_name: str [, comment: Optional[str], new_name: Optional[str], owner: Optional[str]]) -> RegisteredModelInfo
 
@@ -198,4 +198,3 @@
           The identifier of the user who owns the registered model
         
         :returns: :class:`RegisteredModelInfo`
-        

--- a/docs/workspace/catalog/resource_quotas.rst
+++ b/docs/workspace/catalog/resource_quotas.rst
@@ -27,7 +27,7 @@
           Name of the quota. Follows the pattern of the quota type, with "-quota" added as a suffix.
         
         :returns: :class:`GetQuotaResponse`
-        
+
 
     .. py:method:: list_quotas( [, max_results: Optional[int], page_token: Optional[str]]) -> Iterator[QuotaInfo]
 
@@ -42,4 +42,3 @@
           Opaque token for the next page of results.
         
         :returns: Iterator over :class:`QuotaInfo`
-        

--- a/docs/workspace/catalog/schemas.rst
+++ b/docs/workspace/catalog/schemas.rst
@@ -47,7 +47,7 @@
           Storage root URL for managed tables within schema.
         
         :returns: :class:`SchemaInfo`
-        
+
 
     .. py:method:: delete(full_name: str [, force: Optional[bool]])
 
@@ -61,8 +61,8 @@
         :param force: bool (optional)
           Force deletion even if the schema is not empty.
         
-        
-        
+
+
 
     .. py:method:: get(full_name: str [, include_browse: Optional[bool]]) -> SchemaInfo
 
@@ -99,7 +99,7 @@
           metadata for
         
         :returns: :class:`SchemaInfo`
-        
+
 
     .. py:method:: list(catalog_name: str [, include_browse: Optional[bool], max_results: Optional[int], page_token: Optional[str]]) -> Iterator[SchemaInfo]
 
@@ -142,7 +142,7 @@
           Opaque pagination token to go to next page based on previous query.
         
         :returns: Iterator over :class:`SchemaInfo`
-        
+
 
     .. py:method:: update(full_name: str [, comment: Optional[str], enable_predictive_optimization: Optional[EnablePredictiveOptimization], new_name: Optional[str], owner: Optional[str], properties: Optional[Dict[str, str]]]) -> SchemaInfo
 
@@ -188,4 +188,3 @@
           A map of key-value properties attached to the securable.
         
         :returns: :class:`SchemaInfo`
-        

--- a/docs/workspace/catalog/storage_credentials.rst
+++ b/docs/workspace/catalog/storage_credentials.rst
@@ -61,7 +61,7 @@
           Supplying true to this argument skips validation of the created credential.
         
         :returns: :class:`StorageCredentialInfo`
-        
+
 
     .. py:method:: delete(name: str [, force: Optional[bool]])
 
@@ -75,8 +75,8 @@
         :param force: bool (optional)
           Force deletion even if there are dependent external locations or external tables.
         
-        
-        
+
+
 
     .. py:method:: get(name: str) -> StorageCredentialInfo
 
@@ -111,7 +111,7 @@
           Name of the storage credential.
         
         :returns: :class:`StorageCredentialInfo`
-        
+
 
     .. py:method:: list( [, max_results: Optional[int], page_token: Optional[str]]) -> Iterator[StorageCredentialInfo]
 
@@ -143,7 +143,7 @@
           Opaque pagination token to go to next page based on previous query.
         
         :returns: Iterator over :class:`StorageCredentialInfo`
-        
+
 
     .. py:method:: update(name: str [, aws_iam_role: Optional[AwsIamRoleRequest], azure_managed_identity: Optional[AzureManagedIdentityResponse], azure_service_principal: Optional[AzureServicePrincipal], cloudflare_api_token: Optional[CloudflareApiToken], comment: Optional[str], databricks_gcp_service_account: Optional[DatabricksGcpServiceAccountRequest], force: Optional[bool], isolation_mode: Optional[IsolationMode], new_name: Optional[str], owner: Optional[str], read_only: Optional[bool], skip_validation: Optional[bool]]) -> StorageCredentialInfo
 
@@ -203,7 +203,7 @@
           Supplying true to this argument skips validation of the updated credential.
         
         :returns: :class:`StorageCredentialInfo`
-        
+
 
     .. py:method:: validate( [, aws_iam_role: Optional[AwsIamRoleRequest], azure_managed_identity: Optional[AzureManagedIdentityRequest], azure_service_principal: Optional[AzureServicePrincipal], cloudflare_api_token: Optional[CloudflareApiToken], databricks_gcp_service_account: Optional[DatabricksGcpServiceAccountRequest], external_location_name: Optional[str], read_only: Optional[bool], storage_credential_name: Optional[str], url: Optional[str]]) -> ValidateStorageCredentialResponse
 
@@ -239,4 +239,3 @@
           The external location url to validate.
         
         :returns: :class:`ValidateStorageCredentialResponse`
-        

--- a/docs/workspace/catalog/system_schemas.rst
+++ b/docs/workspace/catalog/system_schemas.rst
@@ -19,8 +19,8 @@
         :param schema_name: str
           Full name of the system schema.
         
-        
-        
+
+
 
     .. py:method:: enable(metastore_id: str, schema_name: str)
 
@@ -34,8 +34,8 @@
         :param schema_name: str
           Full name of the system schema.
         
-        
-        
+
+
 
     .. py:method:: list(metastore_id: str [, max_results: Optional[int], page_token: Optional[str]]) -> Iterator[SystemSchemaInfo]
 
@@ -55,4 +55,3 @@
           Opaque pagination token to go to next page based on previous query.
         
         :returns: Iterator over :class:`SystemSchemaInfo`
-        

--- a/docs/workspace/catalog/table_constraints.rst
+++ b/docs/workspace/catalog/table_constraints.rst
@@ -35,7 +35,7 @@
           __primary_key_constraint__, __foreign_key_constraint__, __named_table_constraint__.
         
         :returns: :class:`TableConstraint`
-        
+
 
     .. py:method:: delete(full_name: str, constraint_name: str, cascade: bool)
 
@@ -58,5 +58,4 @@
           If true, try deleting all child constraints of the current constraint. If false, reject this
           operation if the current constraint has any child constraints.
         
-        
-        
+

--- a/docs/workspace/catalog/tables.rst
+++ b/docs/workspace/catalog/tables.rst
@@ -25,8 +25,8 @@
         :param full_name: str
           Full name of the table.
         
-        
-        
+
+
 
     .. py:method:: exists(full_name: str) -> TableExistsResponse
 
@@ -43,7 +43,7 @@
           Full name of the table.
         
         :returns: :class:`TableExistsResponse`
-        
+
 
     .. py:method:: get(full_name: str [, include_browse: Optional[bool], include_delta_metadata: Optional[bool], include_manifest_capabilities: Optional[bool]]) -> TableInfo
 
@@ -98,7 +98,7 @@
           Whether to include a manifest containing capabilities the table has.
         
         :returns: :class:`TableInfo`
-        
+
 
     .. py:method:: list(catalog_name: str, schema_name: str [, include_browse: Optional[bool], include_delta_metadata: Optional[bool], include_manifest_capabilities: Optional[bool], max_results: Optional[int], omit_columns: Optional[bool], omit_properties: Optional[bool], omit_username: Optional[bool], page_token: Optional[str]]) -> Iterator[TableInfo]
 
@@ -158,7 +158,7 @@
           Opaque token to send for the next page of results (pagination).
         
         :returns: Iterator over :class:`TableInfo`
-        
+
 
     .. py:method:: list_summaries(catalog_name: str [, include_manifest_capabilities: Optional[bool], max_results: Optional[int], page_token: Optional[str], schema_name_pattern: Optional[str], table_name_pattern: Optional[str]]) -> Iterator[TableSummary]
 
@@ -215,7 +215,7 @@
           A sql LIKE pattern (% and _) for table names. All tables will be returned if not set or empty.
         
         :returns: Iterator over :class:`TableSummary`
-        
+
 
     .. py:method:: update(full_name: str [, owner: Optional[str]])
 
@@ -230,5 +230,4 @@
           Full name of the table.
         :param owner: str (optional)
         
-        
-        
+

--- a/docs/workspace/catalog/temporary_table_credentials.rst
+++ b/docs/workspace/catalog/temporary_table_credentials.rst
@@ -33,4 +33,3 @@
           UUID of the table to read or write.
         
         :returns: :class:`GenerateTemporaryTableCredentialResponse`
-        

--- a/docs/workspace/catalog/volumes.rst
+++ b/docs/workspace/catalog/volumes.rst
@@ -85,7 +85,7 @@
           The storage location on the cloud
         
         :returns: :class:`VolumeInfo`
-        
+
 
     .. py:method:: delete(name: str)
 
@@ -100,8 +100,8 @@
         :param name: str
           The three-level (fully qualified) name of the volume
         
-        
-        
+
+
 
     .. py:method:: list(catalog_name: str, schema_name: str [, include_browse: Optional[bool], max_results: Optional[int], page_token: Optional[str]]) -> Iterator[VolumeInfo]
 
@@ -162,7 +162,7 @@
           page of results (pagination).
         
         :returns: Iterator over :class:`VolumeInfo`
-        
+
 
     .. py:method:: read(name: str [, include_browse: Optional[bool]]) -> VolumeInfo
 
@@ -224,7 +224,7 @@
           metadata for
         
         :returns: :class:`VolumeInfo`
-        
+
 
     .. py:method:: update(name: str [, comment: Optional[str], new_name: Optional[str], owner: Optional[str]]) -> VolumeInfo
 
@@ -293,4 +293,3 @@
           The identifier of the user who owns the volume
         
         :returns: :class:`VolumeInfo`
-        

--- a/docs/workspace/catalog/workspace_bindings.rst
+++ b/docs/workspace/catalog/workspace_bindings.rst
@@ -48,7 +48,7 @@
           The name of the catalog.
         
         :returns: :class:`CurrentWorkspaceBindings`
-        
+
 
     .. py:method:: get_bindings(securable_type: GetBindingsSecurableType, securable_name: str [, max_results: Optional[int], page_token: Optional[str]]) -> Iterator[WorkspaceBinding]
 
@@ -70,7 +70,7 @@
           Opaque pagination token to go to next page based on previous query.
         
         :returns: Iterator over :class:`WorkspaceBinding`
-        
+
 
     .. py:method:: update(name: str [, assign_workspaces: Optional[List[int]], unassign_workspaces: Optional[List[int]]]) -> CurrentWorkspaceBindings
 
@@ -108,7 +108,7 @@
           A list of workspace IDs.
         
         :returns: :class:`CurrentWorkspaceBindings`
-        
+
 
     .. py:method:: update_bindings(securable_type: UpdateBindingsSecurableType, securable_name: str [, add: Optional[List[WorkspaceBinding]], remove: Optional[List[WorkspaceBinding]]]) -> WorkspaceBindingsResponse
 
@@ -127,4 +127,3 @@
           List of workspace bindings
         
         :returns: :class:`WorkspaceBindingsResponse`
-        

--- a/docs/workspace/cleanrooms/clean_room_assets.rst
+++ b/docs/workspace/cleanrooms/clean_room_assets.rst
@@ -22,7 +22,7 @@
           Metadata of the clean room asset
         
         :returns: :class:`CleanRoomAsset`
-        
+
 
     .. py:method:: delete(clean_room_name: str, asset_type: CleanRoomAssetAssetType, asset_full_name: str)
 
@@ -37,8 +37,8 @@
         :param asset_full_name: str
           The fully qualified name of the asset, it is same as the name field in CleanRoomAsset.
         
-        
-        
+
+
 
     .. py:method:: get(clean_room_name: str, asset_type: CleanRoomAssetAssetType, asset_full_name: str) -> CleanRoomAsset
 
@@ -54,7 +54,7 @@
           The fully qualified name of the asset, it is same as the name field in CleanRoomAsset.
         
         :returns: :class:`CleanRoomAsset`
-        
+
 
     .. py:method:: list(clean_room_name: str [, page_token: Optional[str]]) -> Iterator[CleanRoomAsset]
 
@@ -66,7 +66,7 @@
           Opaque pagination token to go to next page based on previous query.
         
         :returns: Iterator over :class:`CleanRoomAsset`
-        
+
 
     .. py:method:: update(clean_room_name: str, asset_type: CleanRoomAssetAssetType, name: str [, asset: Optional[CleanRoomAsset]]) -> CleanRoomAsset
 
@@ -91,4 +91,3 @@
           Metadata of the clean room asset
         
         :returns: :class:`CleanRoomAsset`
-        

--- a/docs/workspace/cleanrooms/clean_room_task_runs.rst
+++ b/docs/workspace/cleanrooms/clean_room_task_runs.rst
@@ -22,4 +22,3 @@
           Opaque pagination token to go to next page based on previous query.
         
         :returns: Iterator over :class:`CleanRoomNotebookTaskRun`
-        

--- a/docs/workspace/cleanrooms/clean_rooms.rst
+++ b/docs/workspace/cleanrooms/clean_rooms.rst
@@ -22,7 +22,7 @@
         :param clean_room: :class:`CleanRoom` (optional)
         
         :returns: :class:`CleanRoom`
-        
+
 
     .. py:method:: create_output_catalog(clean_room_name: str [, output_catalog: Optional[CleanRoomOutputCatalog]]) -> CreateCleanRoomOutputCatalogResponse
 
@@ -35,7 +35,7 @@
         :param output_catalog: :class:`CleanRoomOutputCatalog` (optional)
         
         :returns: :class:`CreateCleanRoomOutputCatalogResponse`
-        
+
 
     .. py:method:: delete(name: str)
 
@@ -48,8 +48,8 @@
         :param name: str
           Name of the clean room.
         
-        
-        
+
+
 
     .. py:method:: get(name: str) -> CleanRoom
 
@@ -60,7 +60,7 @@
         :param name: str
         
         :returns: :class:`CleanRoom`
-        
+
 
     .. py:method:: list( [, page_size: Optional[int], page_token: Optional[str]]) -> Iterator[CleanRoom]
 
@@ -75,7 +75,7 @@
           Opaque pagination token to go to next page based on previous query.
         
         :returns: Iterator over :class:`CleanRoom`
-        
+
 
     .. py:method:: update(name: str [, clean_room: Optional[CleanRoom]]) -> CleanRoom
 
@@ -91,4 +91,3 @@
         :param clean_room: :class:`CleanRoom` (optional)
         
         :returns: :class:`CleanRoom`
-        

--- a/docs/workspace/compute/cluster_policies.rst
+++ b/docs/workspace/compute/cluster_policies.rst
@@ -82,7 +82,7 @@
           policy definition.
         
         :returns: :class:`CreatePolicyResponse`
-        
+
 
     .. py:method:: delete(policy_id: str)
 
@@ -93,8 +93,8 @@
         :param policy_id: str
           The ID of the policy to delete.
         
-        
-        
+
+
 
     .. py:method:: edit(policy_id: str [, definition: Optional[str], description: Optional[str], libraries: Optional[List[Library]], max_clusters_per_user: Optional[int], name: Optional[str], policy_family_definition_overrides: Optional[str], policy_family_id: Optional[str]])
 
@@ -170,8 +170,8 @@
           Cannot be used with `definition`. Use `policy_family_definition_overrides` instead to customize the
           policy definition.
         
-        
-        
+
+
 
     .. py:method:: get(policy_id: str) -> Policy
 
@@ -208,7 +208,7 @@
           Canonical unique identifier for the Cluster Policy.
         
         :returns: :class:`Policy`
-        
+
 
     .. py:method:: get_permission_levels(cluster_policy_id: str) -> GetClusterPolicyPermissionLevelsResponse
 
@@ -220,7 +220,7 @@
           The cluster policy for which to get or manage permissions.
         
         :returns: :class:`GetClusterPolicyPermissionLevelsResponse`
-        
+
 
     .. py:method:: get_permissions(cluster_policy_id: str) -> ClusterPolicyPermissions
 
@@ -233,7 +233,7 @@
           The cluster policy for which to get or manage permissions.
         
         :returns: :class:`ClusterPolicyPermissions`
-        
+
 
     .. py:method:: list( [, sort_column: Optional[ListSortColumn], sort_order: Optional[ListSortOrder]]) -> Iterator[Policy]
 
@@ -261,7 +261,7 @@
           - Sort result list in ascending order.
         
         :returns: Iterator over :class:`Policy`
-        
+
 
     .. py:method:: set_permissions(cluster_policy_id: str [, access_control_list: Optional[List[ClusterPolicyAccessControlRequest]]]) -> ClusterPolicyPermissions
 
@@ -275,7 +275,7 @@
         :param access_control_list: List[:class:`ClusterPolicyAccessControlRequest`] (optional)
         
         :returns: :class:`ClusterPolicyPermissions`
-        
+
 
     .. py:method:: update_permissions(cluster_policy_id: str [, access_control_list: Optional[List[ClusterPolicyAccessControlRequest]]]) -> ClusterPolicyPermissions
 
@@ -289,4 +289,3 @@
         :param access_control_list: List[:class:`ClusterPolicyAccessControlRequest`] (optional)
         
         :returns: :class:`ClusterPolicyPermissions`
-        

--- a/docs/workspace/compute/clusters.rst
+++ b/docs/workspace/compute/clusters.rst
@@ -68,8 +68,8 @@
         :param owner_username: str
           New owner of the cluster_id after this RPC.
         
-        
-        
+
+
 
     .. py:method:: create(spark_version: str [, apply_policy_default_values: Optional[bool], autoscale: Optional[AutoScale], autotermination_minutes: Optional[int], aws_attributes: Optional[AwsAttributes], azure_attributes: Optional[AzureAttributes], clone_from: Optional[CloneCluster], cluster_log_conf: Optional[ClusterLogConf], cluster_name: Optional[str], custom_tags: Optional[Dict[str, str]], data_security_mode: Optional[DataSecurityMode], docker_image: Optional[DockerImage], driver_instance_pool_id: Optional[str], driver_node_type_id: Optional[str], enable_elastic_disk: Optional[bool], enable_local_disk_encryption: Optional[bool], gcp_attributes: Optional[GcpAttributes], init_scripts: Optional[List[InitScriptInfo]], instance_pool_id: Optional[str], is_single_node: Optional[bool], kind: Optional[Kind], node_type_id: Optional[str], num_workers: Optional[int], policy_id: Optional[str], runtime_engine: Optional[RuntimeEngine], single_user_name: Optional[str], spark_conf: Optional[Dict[str, str]], spark_env_vars: Optional[Dict[str, str]], ssh_public_keys: Optional[List[str]], use_ml_runtime: Optional[bool], workload_type: Optional[WorkloadType]]) -> Wait[ClusterDetails]
 
@@ -263,7 +263,7 @@
         :returns:
           Long-running operation waiter for :class:`ClusterDetails`.
           See :method:wait_get_cluster_running for more details.
-        
+
 
     .. py:method:: create_and_wait(spark_version: str [, apply_policy_default_values: Optional[bool], autoscale: Optional[AutoScale], autotermination_minutes: Optional[int], aws_attributes: Optional[AwsAttributes], azure_attributes: Optional[AzureAttributes], clone_from: Optional[CloneCluster], cluster_log_conf: Optional[ClusterLogConf], cluster_name: Optional[str], custom_tags: Optional[Dict[str, str]], data_security_mode: Optional[DataSecurityMode], docker_image: Optional[DockerImage], driver_instance_pool_id: Optional[str], driver_node_type_id: Optional[str], enable_elastic_disk: Optional[bool], enable_local_disk_encryption: Optional[bool], gcp_attributes: Optional[GcpAttributes], init_scripts: Optional[List[InitScriptInfo]], instance_pool_id: Optional[str], is_single_node: Optional[bool], kind: Optional[Kind], node_type_id: Optional[str], num_workers: Optional[int], policy_id: Optional[str], runtime_engine: Optional[RuntimeEngine], single_user_name: Optional[str], spark_conf: Optional[Dict[str, str]], spark_env_vars: Optional[Dict[str, str]], ssh_public_keys: Optional[List[str]], use_ml_runtime: Optional[bool], workload_type: Optional[WorkloadType], timeout: datetime.timedelta = 0:20:00]) -> ClusterDetails
 
@@ -309,7 +309,7 @@
         :returns:
           Long-running operation waiter for :class:`ClusterDetails`.
           See :method:wait_get_cluster_terminated for more details.
-        
+
 
     .. py:method:: delete_and_wait(cluster_id: str, timeout: datetime.timedelta = 0:20:00) -> ClusterDetails
 
@@ -513,7 +513,7 @@
         :returns:
           Long-running operation waiter for :class:`ClusterDetails`.
           See :method:wait_get_cluster_running for more details.
-        
+
 
     .. py:method:: edit_and_wait(cluster_id: str, spark_version: str [, apply_policy_default_values: Optional[bool], autoscale: Optional[AutoScale], autotermination_minutes: Optional[int], aws_attributes: Optional[AwsAttributes], azure_attributes: Optional[AzureAttributes], cluster_log_conf: Optional[ClusterLogConf], cluster_name: Optional[str], custom_tags: Optional[Dict[str, str]], data_security_mode: Optional[DataSecurityMode], docker_image: Optional[DockerImage], driver_instance_pool_id: Optional[str], driver_node_type_id: Optional[str], enable_elastic_disk: Optional[bool], enable_local_disk_encryption: Optional[bool], gcp_attributes: Optional[GcpAttributes], init_scripts: Optional[List[InitScriptInfo]], instance_pool_id: Optional[str], is_single_node: Optional[bool], kind: Optional[Kind], node_type_id: Optional[str], num_workers: Optional[int], policy_id: Optional[str], runtime_engine: Optional[RuntimeEngine], single_user_name: Optional[str], spark_conf: Optional[Dict[str, str]], spark_env_vars: Optional[Dict[str, str]], ssh_public_keys: Optional[List[str]], use_ml_runtime: Optional[bool], workload_type: Optional[WorkloadType], timeout: datetime.timedelta = 0:20:00]) -> ClusterDetails
 
@@ -596,7 +596,7 @@
           The start time in epoch milliseconds. If empty, returns events starting from the beginning of time.
         
         :returns: Iterator over :class:`ClusterEvent`
-        
+
 
     .. py:method:: get(cluster_id: str) -> ClusterDetails
 
@@ -636,7 +636,7 @@
           The cluster about which to retrieve information.
         
         :returns: :class:`ClusterDetails`
-        
+
 
     .. py:method:: get_permission_levels(cluster_id: str) -> GetClusterPermissionLevelsResponse
 
@@ -648,7 +648,7 @@
           The cluster for which to get or manage permissions.
         
         :returns: :class:`GetClusterPermissionLevelsResponse`
-        
+
 
     .. py:method:: get_permissions(cluster_id: str) -> ClusterPermissions
 
@@ -660,7 +660,7 @@
           The cluster for which to get or manage permissions.
         
         :returns: :class:`ClusterPermissions`
-        
+
 
     .. py:method:: list( [, filter_by: Optional[ListClustersFilterBy], page_size: Optional[int], page_token: Optional[str], sort_by: Optional[ListClustersSortBy]]) -> Iterator[ClusterDetails]
 
@@ -693,7 +693,7 @@
           Sort the list of clusters by a specific criteria.
         
         :returns: Iterator over :class:`ClusterDetails`
-        
+
 
     .. py:method:: list_node_types() -> ListNodeTypesResponse
 
@@ -713,7 +713,7 @@
         Returns a list of supported Spark node types. These node types can be used to launch a cluster.
         
         :returns: :class:`ListNodeTypesResponse`
-        
+
 
     .. py:method:: list_zones() -> ListAvailableZonesResponse
 
@@ -723,7 +723,7 @@
         zones can be used to launch a cluster.
         
         :returns: :class:`ListAvailableZonesResponse`
-        
+
 
     .. py:method:: permanent_delete(cluster_id: str)
 
@@ -738,8 +738,8 @@
         :param cluster_id: str
           The cluster to be deleted.
         
-        
-        
+
+
 
     .. py:method:: pin(cluster_id: str)
 
@@ -778,8 +778,8 @@
         :param cluster_id: str
           <needs content added>
         
-        
-        
+
+
 
     .. py:method:: resize(cluster_id: str [, autoscale: Optional[AutoScale], num_workers: Optional[int]]) -> Wait[ClusterDetails]
 
@@ -833,7 +833,7 @@
         :returns:
           Long-running operation waiter for :class:`ClusterDetails`.
           See :method:wait_get_cluster_running for more details.
-        
+
 
     .. py:method:: resize_and_wait(cluster_id: str [, autoscale: Optional[AutoScale], num_workers: Optional[int], timeout: datetime.timedelta = 0:20:00]) -> ClusterDetails
 
@@ -880,7 +880,7 @@
         :returns:
           Long-running operation waiter for :class:`ClusterDetails`.
           See :method:wait_get_cluster_running for more details.
-        
+
 
     .. py:method:: restart_and_wait(cluster_id: str [, restart_user: Optional[str], timeout: datetime.timedelta = 0:20:00]) -> ClusterDetails
 
@@ -899,7 +899,7 @@
             smallest = w.clusters.select_node_type(local_disk=True)
 
         Selects smallest available node type given the conditions.
-
+        
         :param min_memory_gb: int
         :param gb_per_core: int
         :param min_cores: int
@@ -913,9 +913,9 @@
         :param is_io_cache_enabled: bool
         :param support_port_forwarding: bool
         :param fleet: bool
-
-        :returns: `node_type` compatible string
         
+        :returns: `node_type` compatible string
+
 
     .. py:method:: select_spark_version(long_term_support: bool = False, beta: bool = False, latest: bool = True, ml: bool = False, genomics: bool = False, gpu: bool = False, scala: str = 2.12, spark_version: str, photon: bool = False, graviton: bool = False) -> str
 
@@ -931,7 +931,7 @@
             latest = w.clusters.select_spark_version(latest=True, long_term_support=True)
 
         Selects the latest Databricks Runtime Version.
-
+        
         :param long_term_support: bool
         :param beta: bool
         :param latest: bool
@@ -942,9 +942,9 @@
         :param spark_version: str
         :param photon: bool
         :param graviton: bool
-
-        :returns: `spark_version` compatible string
         
+        :returns: `spark_version` compatible string
+
 
     .. py:method:: set_permissions(cluster_id: str [, access_control_list: Optional[List[ClusterAccessControlRequest]]]) -> ClusterPermissions
 
@@ -958,7 +958,7 @@
         :param access_control_list: List[:class:`ClusterAccessControlRequest`] (optional)
         
         :returns: :class:`ClusterPermissions`
-        
+
 
     .. py:method:: spark_versions() -> GetSparkVersionsResponse
 
@@ -967,7 +967,7 @@
         Returns the list of available Spark versions. These versions can be used to launch a cluster.
         
         :returns: :class:`GetSparkVersionsResponse`
-        
+
 
     .. py:method:: start(cluster_id: str) -> Wait[ClusterDetails]
 
@@ -1013,7 +1013,7 @@
         :returns:
           Long-running operation waiter for :class:`ClusterDetails`.
           See :method:wait_get_cluster_running for more details.
-        
+
 
     .. py:method:: start_and_wait(cluster_id: str, timeout: datetime.timedelta = 0:20:00) -> ClusterDetails
 
@@ -1056,8 +1056,8 @@
         :param cluster_id: str
           <needs content added>
         
-        
-        
+
+
 
     .. py:method:: update(cluster_id: str, update_mask: str [, cluster: Optional[UpdateClusterResource]]) -> Wait[ClusterDetails]
 
@@ -1085,7 +1085,7 @@
         :returns:
           Long-running operation waiter for :class:`ClusterDetails`.
           See :method:wait_get_cluster_running for more details.
-        
+
 
     .. py:method:: update_and_wait(cluster_id: str, update_mask: str [, cluster: Optional[UpdateClusterResource], timeout: datetime.timedelta = 0:20:00]) -> ClusterDetails
 
@@ -1101,7 +1101,7 @@
         :param access_control_list: List[:class:`ClusterAccessControlRequest`] (optional)
         
         :returns: :class:`ClusterPermissions`
-        
+
 
     .. py:method:: wait_get_cluster_running(cluster_id: str, timeout: datetime.timedelta = 0:20:00, callback: Optional[Callable[[ClusterDetails], None]]) -> ClusterDetails
 

--- a/docs/workspace/compute/command_execution.rst
+++ b/docs/workspace/compute/command_execution.rst
@@ -22,7 +22,7 @@
         :returns:
           Long-running operation waiter for :class:`CommandStatusResponse`.
           See :method:wait_command_status_command_execution_cancelled for more details.
-        
+
 
     .. py:method:: cancel_and_wait( [, cluster_id: Optional[str], command_id: Optional[str], context_id: Optional[str], timeout: datetime.timedelta = 0:20:00]) -> CommandStatusResponse
 
@@ -40,7 +40,7 @@
         :param command_id: str
         
         :returns: :class:`CommandStatusResponse`
-        
+
 
     .. py:method:: context_status(cluster_id: str, context_id: str) -> ContextStatusResponse
 
@@ -52,7 +52,7 @@
         :param context_id: str
         
         :returns: :class:`ContextStatusResponse`
-        
+
 
     .. py:method:: create( [, cluster_id: Optional[str], language: Optional[Language]]) -> Wait[ContextStatusResponse]
 
@@ -88,7 +88,7 @@
         :returns:
           Long-running operation waiter for :class:`ContextStatusResponse`.
           See :method:wait_context_status_command_execution_running for more details.
-        
+
 
     .. py:method:: create_and_wait( [, cluster_id: Optional[str], language: Optional[Language], timeout: datetime.timedelta = 0:20:00]) -> ContextStatusResponse
 
@@ -102,8 +102,8 @@
         :param cluster_id: str
         :param context_id: str
         
-        
-        
+
+
 
     .. py:method:: execute( [, cluster_id: Optional[str], command: Optional[str], context_id: Optional[str], language: Optional[Language]]) -> Wait[CommandStatusResponse]
 
@@ -148,7 +148,7 @@
         :returns:
           Long-running operation waiter for :class:`CommandStatusResponse`.
           See :method:wait_command_status_command_execution_finished_or_error for more details.
-        
+
 
     .. py:method:: execute_and_wait( [, cluster_id: Optional[str], command: Optional[str], context_id: Optional[str], language: Optional[Language], timeout: datetime.timedelta = 0:20:00]) -> CommandStatusResponse
 

--- a/docs/workspace/compute/global_init_scripts.rst
+++ b/docs/workspace/compute/global_init_scripts.rst
@@ -56,7 +56,7 @@
           position and all later scripts have their positions incremented by 1.
         
         :returns: :class:`CreateResponse`
-        
+
 
     .. py:method:: delete(script_id: str)
 
@@ -67,8 +67,8 @@
         :param script_id: str
           The ID of the global init script.
         
-        
-        
+
+
 
     .. py:method:: get(script_id: str) -> GlobalInitScriptDetailsWithContent
 
@@ -102,7 +102,7 @@
           The ID of the global init script.
         
         :returns: :class:`GlobalInitScriptDetailsWithContent`
-        
+
 
     .. py:method:: list() -> Iterator[GlobalInitScriptDetails]
 
@@ -124,7 +124,7 @@
         script](:method:globalinitscripts/get) operation.
         
         :returns: Iterator over :class:`GlobalInitScriptDetails`
-        
+
 
     .. py:method:: update(script_id: str, name: str, script: str [, enabled: Optional[bool], position: Optional[int]])
 
@@ -176,5 +176,4 @@
           If an explicit position value conflicts with an existing script, your request succeeds, but the
           original script at that position and all later scripts have their positions incremented by 1.
         
-        
-        
+

--- a/docs/workspace/compute/instance_pools.rst
+++ b/docs/workspace/compute/instance_pools.rst
@@ -91,7 +91,7 @@
           be retrieved by using the :method:clusters/sparkVersions API call.
         
         :returns: :class:`CreateInstancePoolResponse`
-        
+
 
     .. py:method:: delete(instance_pool_id: str)
 
@@ -102,8 +102,8 @@
         :param instance_pool_id: str
           The instance pool to be terminated.
         
-        
-        
+
+
 
     .. py:method:: edit(instance_pool_id: str, instance_pool_name: str, node_type_id: str [, custom_tags: Optional[Dict[str, str]], idle_instance_autotermination_minutes: Optional[int], max_capacity: Optional[int], min_idle_instances: Optional[int]])
 
@@ -161,8 +161,8 @@
         :param min_idle_instances: int (optional)
           Minimum number of idle instances to keep in the instance pool
         
-        
-        
+
+
 
     .. py:method:: get(instance_pool_id: str) -> GetInstancePool
 
@@ -194,7 +194,7 @@
           The canonical unique identifier for the instance pool.
         
         :returns: :class:`GetInstancePool`
-        
+
 
     .. py:method:: get_permission_levels(instance_pool_id: str) -> GetInstancePoolPermissionLevelsResponse
 
@@ -206,7 +206,7 @@
           The instance pool for which to get or manage permissions.
         
         :returns: :class:`GetInstancePoolPermissionLevelsResponse`
-        
+
 
     .. py:method:: get_permissions(instance_pool_id: str) -> InstancePoolPermissions
 
@@ -219,7 +219,7 @@
           The instance pool for which to get or manage permissions.
         
         :returns: :class:`InstancePoolPermissions`
-        
+
 
     .. py:method:: list() -> Iterator[InstancePoolAndStats]
 
@@ -239,7 +239,7 @@
         Gets a list of instance pools with their statistics.
         
         :returns: Iterator over :class:`InstancePoolAndStats`
-        
+
 
     .. py:method:: set_permissions(instance_pool_id: str [, access_control_list: Optional[List[InstancePoolAccessControlRequest]]]) -> InstancePoolPermissions
 
@@ -253,7 +253,7 @@
         :param access_control_list: List[:class:`InstancePoolAccessControlRequest`] (optional)
         
         :returns: :class:`InstancePoolPermissions`
-        
+
 
     .. py:method:: update_permissions(instance_pool_id: str [, access_control_list: Optional[List[InstancePoolAccessControlRequest]]]) -> InstancePoolPermissions
 
@@ -267,4 +267,3 @@
         :param access_control_list: List[:class:`InstancePoolAccessControlRequest`] (optional)
         
         :returns: :class:`InstancePoolPermissions`
-        

--- a/docs/workspace/compute/instance_profiles.rst
+++ b/docs/workspace/compute/instance_profiles.rst
@@ -54,8 +54,8 @@
           requested instance type is not supported in your requested availability zone”), you can pass this
           flag to skip the validation and forcibly add the instance profile.
         
-        
-        
+
+
 
     .. py:method:: edit(instance_profile_arn: str [, iam_role_arn: Optional[str], is_meta_instance_profile: Optional[bool]])
 
@@ -103,8 +103,8 @@
           wide range of roles. Therefore it should always be used with authorization. This field is optional,
           the default value is `false`.
         
-        
-        
+
+
 
     .. py:method:: list() -> Iterator[InstanceProfile]
 
@@ -126,7 +126,7 @@
         This API is available to all users.
         
         :returns: Iterator over :class:`InstanceProfile`
-        
+
 
     .. py:method:: remove(instance_profile_arn: str)
 
@@ -140,5 +140,4 @@
         :param instance_profile_arn: str
           The ARN of the instance profile to remove. This field is required.
         
-        
-        
+

--- a/docs/workspace/compute/libraries.rst
+++ b/docs/workspace/compute/libraries.rst
@@ -26,7 +26,7 @@
         this cluster via the API or the libraries UI.
         
         :returns: Iterator over :class:`ClusterLibraryStatuses`
-        
+
 
     .. py:method:: cluster_status(cluster_id: str) -> Iterator[LibraryFullStatus]
 
@@ -42,7 +42,7 @@
           Unique identifier of the cluster whose status should be retrieved.
         
         :returns: Iterator over :class:`LibraryFullStatus`
-        
+
 
     .. py:method:: install(cluster_id: str, libraries: List[Library])
 
@@ -56,8 +56,8 @@
         :param libraries: List[:class:`Library`]
           The libraries to install.
         
-        
-        
+
+
 
     .. py:method:: uninstall(cluster_id: str, libraries: List[Library])
 
@@ -71,5 +71,4 @@
         :param libraries: List[:class:`Library`]
           The libraries to uninstall.
         
-        
-        
+

--- a/docs/workspace/compute/policy_compliance_for_clusters.rst
+++ b/docs/workspace/compute/policy_compliance_for_clusters.rst
@@ -36,7 +36,7 @@
           update the cluster.
         
         :returns: :class:`EnforceClusterComplianceResponse`
-        
+
 
     .. py:method:: get_compliance(cluster_id: str) -> GetClusterComplianceResponse
 
@@ -49,7 +49,7 @@
           The ID of the cluster to get the compliance status
         
         :returns: :class:`GetClusterComplianceResponse`
-        
+
 
     .. py:method:: list_compliance(policy_id: str [, page_size: Optional[int], page_token: Optional[str]]) -> Iterator[ClusterCompliance]
 
@@ -68,4 +68,3 @@
           `next_page_token` or `prev_page_token`.
         
         :returns: Iterator over :class:`ClusterCompliance`
-        

--- a/docs/workspace/compute/policy_families.rst
+++ b/docs/workspace/compute/policy_families.rst
@@ -40,7 +40,7 @@
           The version number for the family to fetch. Defaults to the latest version.
         
         :returns: :class:`PolicyFamily`
-        
+
 
     .. py:method:: list( [, max_results: Optional[int], page_token: Optional[str]]) -> Iterator[PolicyFamily]
 
@@ -67,4 +67,3 @@
           A token that can be used to get the next page of results.
         
         :returns: Iterator over :class:`PolicyFamily`
-        

--- a/docs/workspace/dashboards/genie.rst
+++ b/docs/workspace/dashboards/genie.rst
@@ -26,7 +26,7 @@
         :returns:
           Long-running operation waiter for :class:`GenieMessage`.
           See :method:wait_get_message_genie_completed for more details.
-        
+
 
     .. py:method:: create_message_and_wait(space_id: str, conversation_id: str, content: str, timeout: datetime.timedelta = 0:20:00) -> GenieMessage
 
@@ -45,7 +45,7 @@
           Message ID
         
         :returns: :class:`GenieGetMessageQueryResultResponse`
-        
+
 
     .. py:method:: get_message(space_id: str, conversation_id: str, message_id: str) -> GenieMessage
 
@@ -61,7 +61,7 @@
           The ID associated with the target message from the identified conversation.
         
         :returns: :class:`GenieMessage`
-        
+
 
     .. py:method:: get_message_query_result(space_id: str, conversation_id: str, message_id: str) -> GenieGetMessageQueryResultResponse
 
@@ -78,7 +78,7 @@
           Message ID
         
         :returns: :class:`GenieGetMessageQueryResultResponse`
-        
+
 
     .. py:method:: start_conversation(space_id: str, content: str) -> Wait[GenieMessage]
 
@@ -94,7 +94,7 @@
         :returns:
           Long-running operation waiter for :class:`GenieMessage`.
           See :method:wait_get_message_genie_completed for more details.
-        
+
 
     .. py:method:: start_conversation_and_wait(space_id: str, content: str, timeout: datetime.timedelta = 0:20:00) -> GenieMessage
 

--- a/docs/workspace/dashboards/lakeview.rst
+++ b/docs/workspace/dashboards/lakeview.rst
@@ -16,7 +16,7 @@
         :param dashboard: :class:`Dashboard` (optional)
         
         :returns: :class:`Dashboard`
-        
+
 
     .. py:method:: create_schedule(dashboard_id: str [, schedule: Optional[Schedule]]) -> Schedule
 
@@ -27,7 +27,7 @@
         :param schedule: :class:`Schedule` (optional)
         
         :returns: :class:`Schedule`
-        
+
 
     .. py:method:: create_subscription(dashboard_id: str, schedule_id: str [, subscription: Optional[Subscription]]) -> Subscription
 
@@ -40,7 +40,7 @@
         :param subscription: :class:`Subscription` (optional)
         
         :returns: :class:`Subscription`
-        
+
 
     .. py:method:: delete_schedule(dashboard_id: str, schedule_id: str [, etag: Optional[str]])
 
@@ -54,8 +54,8 @@
           The etag for the schedule. Optionally, it can be provided to verify that the schedule has not been
           modified from its last retrieval.
         
-        
-        
+
+
 
     .. py:method:: delete_subscription(dashboard_id: str, schedule_id: str, subscription_id: str [, etag: Optional[str]])
 
@@ -71,8 +71,8 @@
           The etag for the subscription. Can be optionally provided to ensure that the subscription has not
           been modified since the last read.
         
-        
-        
+
+
 
     .. py:method:: get(dashboard_id: str) -> Dashboard
 
@@ -84,7 +84,7 @@
           UUID identifying the dashboard.
         
         :returns: :class:`Dashboard`
-        
+
 
     .. py:method:: get_published(dashboard_id: str) -> PublishedDashboard
 
@@ -96,7 +96,7 @@
           UUID identifying the published dashboard.
         
         :returns: :class:`PublishedDashboard`
-        
+
 
     .. py:method:: get_schedule(dashboard_id: str, schedule_id: str) -> Schedule
 
@@ -108,7 +108,7 @@
           UUID identifying the schedule.
         
         :returns: :class:`Schedule`
-        
+
 
     .. py:method:: get_subscription(dashboard_id: str, schedule_id: str, subscription_id: str) -> Subscription
 
@@ -122,7 +122,7 @@
           UUID identifying the subscription.
         
         :returns: :class:`Subscription`
-        
+
 
     .. py:method:: list( [, page_size: Optional[int], page_token: Optional[str], show_trashed: Optional[bool], view: Optional[DashboardView]]) -> Iterator[Dashboard]
 
@@ -140,7 +140,7 @@
           `DASHBOARD_VIEW_BASIC`only includes summary metadata from the dashboard.
         
         :returns: Iterator over :class:`Dashboard`
-        
+
 
     .. py:method:: list_schedules(dashboard_id: str [, page_size: Optional[int], page_token: Optional[str]]) -> Iterator[Schedule]
 
@@ -155,7 +155,7 @@
           page.
         
         :returns: Iterator over :class:`Schedule`
-        
+
 
     .. py:method:: list_subscriptions(dashboard_id: str, schedule_id: str [, page_size: Optional[int], page_token: Optional[str]]) -> Iterator[Subscription]
 
@@ -172,7 +172,7 @@
           page.
         
         :returns: Iterator over :class:`Subscription`
-        
+
 
     .. py:method:: migrate(source_dashboard_id: str [, display_name: Optional[str], parent_path: Optional[str], update_parameter_syntax: Optional[bool]]) -> Dashboard
 
@@ -191,7 +191,7 @@
           (:param) when converting datasets in the dashboard.
         
         :returns: :class:`Dashboard`
-        
+
 
     .. py:method:: publish(dashboard_id: str [, embed_credentials: Optional[bool], warehouse_id: Optional[str]]) -> PublishedDashboard
 
@@ -208,7 +208,7 @@
           The ID of the warehouse that can be used to override the warehouse which was set in the draft.
         
         :returns: :class:`PublishedDashboard`
-        
+
 
     .. py:method:: trash(dashboard_id: str)
 
@@ -219,8 +219,8 @@
         :param dashboard_id: str
           UUID identifying the dashboard.
         
-        
-        
+
+
 
     .. py:method:: unpublish(dashboard_id: str)
 
@@ -231,8 +231,8 @@
         :param dashboard_id: str
           UUID identifying the published dashboard.
         
-        
-        
+
+
 
     .. py:method:: update(dashboard_id: str [, dashboard: Optional[Dashboard]]) -> Dashboard
 
@@ -245,7 +245,7 @@
         :param dashboard: :class:`Dashboard` (optional)
         
         :returns: :class:`Dashboard`
-        
+
 
     .. py:method:: update_schedule(dashboard_id: str, schedule_id: str [, schedule: Optional[Schedule]]) -> Schedule
 
@@ -258,4 +258,3 @@
         :param schedule: :class:`Schedule` (optional)
         
         :returns: :class:`Schedule`
-        

--- a/docs/workspace/files/dbfs.rst
+++ b/docs/workspace/files/dbfs.rst
@@ -21,8 +21,8 @@
         :param data: str
           The base64-encoded data to append to the stream. This has a limit of 1 MB.
         
-        
-        
+
+
 
     .. py:method:: close(handle: int)
 
@@ -34,8 +34,8 @@
         :param handle: int
           The handle on an open stream.
         
-        
-        
+
+
 
     .. py:method:: copy(src: str, dst: str [, recursive: bool = False, overwrite: bool = False])
 
@@ -60,7 +60,7 @@
           The flag that specifies whether to overwrite existing file/files.
         
         :returns: :class:`CreateResponse`
-        
+
 
     .. py:method:: delete(path: str [, recursive: bool = False])
 
@@ -106,22 +106,22 @@
           The path of the file or directory. The path should be the absolute DBFS path.
         
         :returns: :class:`FileInfo`
-        
+
 
     .. py:method:: list(path: str [, recursive: bool = False]) -> Iterator[files.FileInfo]
 
         List directory contents or file details.
-
+        
         List the contents of a directory, or details of the file. If the file or directory does not exist,
         this call throws an exception with `RESOURCE_DOES_NOT_EXIST`.
-
+        
         When calling list on a large directory, the list operation will time out after approximately 60
         seconds.
-
+        
         :param path: the DBFS or UC Volume path to list
         :param recursive: traverse deep into directory tree
         :returns iterator of metadata for every file
-        
+
 
     .. py:method:: mkdirs(path: str)
 
@@ -141,8 +141,8 @@
         :param destination_path: str
           The destination path of the file or directory. The path should be the absolute DBFS path.
         
-        
-        
+
+
 
     .. py:method:: move_(src: str, dst: str [, recursive: bool = False, overwrite: bool = False])
 
@@ -173,8 +173,8 @@
         :param overwrite: bool (optional)
           The flag that specifies whether to overwrite existing file/files.
         
-        
-        
+
+
 
     .. py:method:: read(path: str [, length: Optional[int], offset: Optional[int]]) -> ReadResponse
 
@@ -197,7 +197,7 @@
           The offset to read from in bytes.
         
         :returns: :class:`ReadResponse`
-        
+
 
     .. py:method:: upload(path: str, src: BinaryIO [, overwrite: bool = False])
 

--- a/docs/workspace/files/files.rst
+++ b/docs/workspace/files/files.rst
@@ -30,8 +30,8 @@
         :param directory_path: str
           The absolute path of a directory.
         
-        
-        
+
+
 
     .. py:method:: delete(file_path: str)
 
@@ -42,8 +42,8 @@
         :param file_path: str
           The absolute path of the file.
         
-        
-        
+
+
 
     .. py:method:: delete_directory(directory_path: str)
 
@@ -57,8 +57,8 @@
         :param directory_path: str
           The absolute path of a directory.
         
-        
-        
+
+
 
     .. py:method:: download(file_path: str) -> DownloadResponse
 
@@ -71,7 +71,7 @@
           The absolute path of the file.
         
         :returns: :class:`DownloadResponse`
-        
+
 
     .. py:method:: get_directory_metadata(directory_path: str)
 
@@ -88,8 +88,8 @@
         :param directory_path: str
           The absolute path of a directory.
         
-        
-        
+
+
 
     .. py:method:: get_metadata(file_path: str) -> GetMetadataResponse
 
@@ -101,7 +101,7 @@
           The absolute path of the file.
         
         :returns: :class:`GetMetadataResponse`
-        
+
 
     .. py:method:: list_directory_contents(directory_path: str [, page_size: Optional[int], page_token: Optional[str]]) -> Iterator[DirectoryEntry]
 
@@ -131,7 +131,7 @@
           must not be used to determine when the listing is complete.
         
         :returns: Iterator over :class:`DirectoryEntry`
-        
+
 
     .. py:method:: upload(file_path: str, contents: BinaryIO [, overwrite: Optional[bool]])
 
@@ -148,5 +148,4 @@
         :param overwrite: bool (optional)
           If true, an existing file will be overwritten.
         
-        
-        
+

--- a/docs/workspace/iam/account_access_control_proxy.rst
+++ b/docs/workspace/iam/account_access_control_proxy.rst
@@ -19,7 +19,7 @@
           The resource name for which assignable roles will be listed.
         
         :returns: :class:`GetAssignableRolesForResourceResponse`
-        
+
 
     .. py:method:: get_rule_set(name: str, etag: str) -> RuleSetResponse
 
@@ -39,7 +39,7 @@
           version you are updating.
         
         :returns: :class:`RuleSetResponse`
-        
+
 
     .. py:method:: update_rule_set(name: str, rule_set: RuleSetUpdateRequest) -> RuleSetResponse
 
@@ -53,4 +53,3 @@
         :param rule_set: :class:`RuleSetUpdateRequest`
         
         :returns: :class:`RuleSetResponse`
-        

--- a/docs/workspace/iam/current_user.rst
+++ b/docs/workspace/iam/current_user.rst
@@ -24,4 +24,3 @@
         Get details about the current method caller's identity.
         
         :returns: :class:`User`
-        

--- a/docs/workspace/iam/groups.rst
+++ b/docs/workspace/iam/groups.rst
@@ -53,7 +53,7 @@
           The schema of the group.
         
         :returns: :class:`Group`
-        
+
 
     .. py:method:: delete(id: str)
 
@@ -79,8 +79,8 @@
         :param id: str
           Unique ID for a group in the Databricks workspace.
         
-        
-        
+
+
 
     .. py:method:: get(id: str) -> Group
 
@@ -110,7 +110,7 @@
           Unique ID for a group in the Databricks workspace.
         
         :returns: :class:`Group`
-        
+
 
     .. py:method:: list( [, attributes: Optional[str], count: Optional[int], excluded_attributes: Optional[str], filter: Optional[str], sort_by: Optional[str], sort_order: Optional[ListSortOrder], start_index: Optional[int]]) -> Iterator[Group]
 
@@ -139,7 +139,7 @@
           Specifies the index of the first result. First item is number 1.
         
         :returns: Iterator over :class:`Group`
-        
+
 
     .. py:method:: patch(id: str [, operations: Optional[List[Patch]], schemas: Optional[List[PatchSchema]]])
 
@@ -183,8 +183,8 @@
         :param schemas: List[:class:`PatchSchema`] (optional)
           The schema of the patch request. Must be ["urn:ietf:params:scim:api:messages:2.0:PatchOp"].
         
-        
-        
+
+
 
     .. py:method:: update(id: str [, display_name: Optional[str], entitlements: Optional[List[ComplexValue]], external_id: Optional[str], groups: Optional[List[ComplexValue]], members: Optional[List[ComplexValue]], meta: Optional[ResourceMeta], roles: Optional[List[ComplexValue]], schemas: Optional[List[GroupSchema]]])
 
@@ -211,5 +211,4 @@
         :param schemas: List[:class:`GroupSchema`] (optional)
           The schema of the group.
         
-        
-        
+

--- a/docs/workspace/iam/permission_migration.rst
+++ b/docs/workspace/iam/permission_migration.rst
@@ -20,4 +20,3 @@
           The maximum number of permissions that will be migrated.
         
         :returns: :class:`MigratePermissionsResponse`
-        

--- a/docs/workspace/iam/permissions.rst
+++ b/docs/workspace/iam/permissions.rst
@@ -87,7 +87,7 @@
           The id of the request object.
         
         :returns: :class:`ObjectPermissions`
-        
+
 
     .. py:method:: get_permission_levels(request_object_type: str, request_object_id: str) -> GetPermissionLevelsResponse
 
@@ -119,7 +119,7 @@
           <needs content>
         
         :returns: :class:`GetPermissionLevelsResponse`
-        
+
 
     .. py:method:: set(request_object_type: str, request_object_id: str [, access_control_list: Optional[List[AccessControlRequest]]]) -> ObjectPermissions
 
@@ -166,7 +166,7 @@
         :param access_control_list: List[:class:`AccessControlRequest`] (optional)
         
         :returns: :class:`ObjectPermissions`
-        
+
 
     .. py:method:: update(request_object_type: str, request_object_id: str [, access_control_list: Optional[List[AccessControlRequest]]]) -> ObjectPermissions
 
@@ -184,4 +184,3 @@
         :param access_control_list: List[:class:`AccessControlRequest`] (optional)
         
         :returns: :class:`ObjectPermissions`
-        

--- a/docs/workspace/iam/service_principals.rst
+++ b/docs/workspace/iam/service_principals.rst
@@ -57,7 +57,7 @@
           The schema of the List response.
         
         :returns: :class:`ServicePrincipal`
-        
+
 
     .. py:method:: delete(id: str)
 
@@ -68,8 +68,8 @@
         :param id: str
           Unique ID for a service principal in the Databricks workspace.
         
-        
-        
+
+
 
     .. py:method:: get(id: str) -> ServicePrincipal
 
@@ -99,7 +99,7 @@
           Unique ID for a service principal in the Databricks workspace.
         
         :returns: :class:`ServicePrincipal`
-        
+
 
     .. py:method:: list( [, attributes: Optional[str], count: Optional[int], excluded_attributes: Optional[str], filter: Optional[str], sort_by: Optional[str], sort_order: Optional[ListSortOrder], start_index: Optional[int]]) -> Iterator[ServicePrincipal]
 
@@ -140,7 +140,7 @@
           Specifies the index of the first result. First item is number 1.
         
         :returns: Iterator over :class:`ServicePrincipal`
-        
+
 
     .. py:method:: patch(id: str [, operations: Optional[List[Patch]], schemas: Optional[List[PatchSchema]]])
 
@@ -177,8 +177,8 @@
         :param schemas: List[:class:`PatchSchema`] (optional)
           The schema of the patch request. Must be ["urn:ietf:params:scim:api:messages:2.0:PatchOp"].
         
-        
-        
+
+
 
     .. py:method:: update(id: str [, active: Optional[bool], application_id: Optional[str], display_name: Optional[str], entitlements: Optional[List[ComplexValue]], external_id: Optional[str], groups: Optional[List[ComplexValue]], roles: Optional[List[ComplexValue]], schemas: Optional[List[ServicePrincipalSchema]]])
 
@@ -229,5 +229,4 @@
         :param schemas: List[:class:`ServicePrincipalSchema`] (optional)
           The schema of the List response.
         
-        
-        
+

--- a/docs/workspace/iam/users.rst
+++ b/docs/workspace/iam/users.rst
@@ -63,7 +63,7 @@
           Email address of the Databricks user.
         
         :returns: :class:`User`
-        
+
 
     .. py:method:: delete(id: str)
 
@@ -90,8 +90,8 @@
         :param id: str
           Unique ID for a user in the Databricks workspace.
         
-        
-        
+
+
 
     .. py:method:: get(id: str [, attributes: Optional[str], count: Optional[int], excluded_attributes: Optional[str], filter: Optional[str], sort_by: Optional[str], sort_order: Optional[GetSortOrder], start_index: Optional[int]]) -> User
 
@@ -138,7 +138,7 @@
           Specifies the index of the first result. First item is number 1.
         
         :returns: :class:`User`
-        
+
 
     .. py:method:: get_permission_levels() -> GetPasswordPermissionLevelsResponse
 
@@ -147,7 +147,7 @@
         Gets the permission levels that a user can have on an object.
         
         :returns: :class:`GetPasswordPermissionLevelsResponse`
-        
+
 
     .. py:method:: get_permissions() -> PasswordPermissions
 
@@ -156,7 +156,7 @@
         Gets the permissions of all passwords. Passwords can inherit permissions from their root object.
         
         :returns: :class:`PasswordPermissions`
-        
+
 
     .. py:method:: list( [, attributes: Optional[str], count: Optional[int], excluded_attributes: Optional[str], filter: Optional[str], sort_by: Optional[str], sort_order: Optional[ListSortOrder], start_index: Optional[int]]) -> Iterator[User]
 
@@ -200,7 +200,7 @@
           Specifies the index of the first result. First item is number 1.
         
         :returns: Iterator over :class:`User`
-        
+
 
     .. py:method:: patch(id: str [, operations: Optional[List[Patch]], schemas: Optional[List[PatchSchema]]])
 
@@ -232,8 +232,8 @@
         :param schemas: List[:class:`PatchSchema`] (optional)
           The schema of the patch request. Must be ["urn:ietf:params:scim:api:messages:2.0:PatchOp"].
         
-        
-        
+
+
 
     .. py:method:: set_permissions( [, access_control_list: Optional[List[PasswordAccessControlRequest]]]) -> PasswordPermissions
 
@@ -245,7 +245,7 @@
         :param access_control_list: List[:class:`PasswordAccessControlRequest`] (optional)
         
         :returns: :class:`PasswordPermissions`
-        
+
 
     .. py:method:: update(id: str [, active: Optional[bool], display_name: Optional[str], emails: Optional[List[ComplexValue]], entitlements: Optional[List[ComplexValue]], external_id: Optional[str], groups: Optional[List[ComplexValue]], name: Optional[Name], roles: Optional[List[ComplexValue]], schemas: Optional[List[UserSchema]], user_name: Optional[str]])
 
@@ -296,8 +296,8 @@
         :param user_name: str (optional)
           Email address of the Databricks user.
         
-        
-        
+
+
 
     .. py:method:: update_permissions( [, access_control_list: Optional[List[PasswordAccessControlRequest]]]) -> PasswordPermissions
 
@@ -308,4 +308,3 @@
         :param access_control_list: List[:class:`PasswordAccessControlRequest`] (optional)
         
         :returns: :class:`PasswordPermissions`
-        

--- a/docs/workspace/jobs/jobs.rst
+++ b/docs/workspace/jobs/jobs.rst
@@ -65,8 +65,8 @@
         :param job_id: int (optional)
           The canonical identifier of the job to cancel all runs of.
         
-        
-        
+
+
 
     .. py:method:: cancel_run(run_id: int) -> Wait[Run]
 
@@ -115,7 +115,7 @@
         :returns:
           Long-running operation waiter for :class:`Run`.
           See :method:wait_get_run_job_terminated_or_skipped for more details.
-        
+
 
     .. py:method:: cancel_run_and_wait(run_id: int, timeout: datetime.timedelta = 0:20:00) -> Run
 
@@ -241,7 +241,7 @@
           A collection of system notification IDs to notify when runs of this job begin or complete.
         
         :returns: :class:`CreateResponse`
-        
+
 
     .. py:method:: delete(job_id: int)
 
@@ -252,8 +252,8 @@
         :param job_id: int
           The canonical identifier of the job to delete. This field is required.
         
-        
-        
+
+
 
     .. py:method:: delete_run(run_id: int)
 
@@ -264,8 +264,8 @@
         :param run_id: int
           ID of the run to delete.
         
-        
-        
+
+
 
     .. py:method:: export_run(run_id: int [, views_to_export: Optional[ViewsToExport]]) -> ExportRunOutput
 
@@ -313,7 +313,7 @@
           Which views to export (CODE, DASHBOARDS, or ALL). Defaults to CODE.
         
         :returns: :class:`ExportRunOutput`
-        
+
 
     .. py:method:: get(job_id: int) -> Job
 
@@ -355,7 +355,7 @@
           The canonical identifier of the job to retrieve information about. This field is required.
         
         :returns: :class:`Job`
-        
+
 
     .. py:method:: get_permission_levels(job_id: str) -> GetJobPermissionLevelsResponse
 
@@ -367,7 +367,7 @@
           The job for which to get or manage permissions.
         
         :returns: :class:`GetJobPermissionLevelsResponse`
-        
+
 
     .. py:method:: get_permissions(job_id: str) -> JobPermissions
 
@@ -379,7 +379,7 @@
           The job for which to get or manage permissions.
         
         :returns: :class:`JobPermissions`
-        
+
 
     .. py:method:: get_run(run_id: int [, include_history: bool, include_resolved_values: bool, page_token: str]) -> Run
 
@@ -426,7 +426,7 @@
           To list the next page or the previous page of job tasks, set this field to the value of the
           `next_page_token` or `prev_page_token` returned in the GetJob response.
         :returns: :class:`Run`
-        
+
 
     .. py:method:: get_run_output(run_id: int) -> RunOutput
 
@@ -475,7 +475,7 @@
           The canonical identifier for the run.
         
         :returns: :class:`RunOutput`
-        
+
 
     .. py:method:: list( [, expand_tasks: Optional[bool], limit: Optional[int], name: Optional[str], offset: Optional[int], page_token: Optional[str]]) -> Iterator[BaseJob]
 
@@ -530,7 +530,7 @@
           previous page of jobs respectively.
         
         :returns: Iterator over :class:`BaseJob`
-        
+
 
     .. py:method:: list_runs( [, active_only: Optional[bool], completed_only: Optional[bool], expand_tasks: Optional[bool], job_id: Optional[int], limit: Optional[int], offset: Optional[int], page_token: Optional[str], run_type: Optional[RunType], start_time_from: Optional[int], start_time_to: Optional[int]]) -> Iterator[BaseRun]
 
@@ -600,7 +600,7 @@
           Can be combined with _start_time_from_ to filter by a time range.
         
         :returns: Iterator over :class:`BaseRun`
-        
+
 
     .. py:method:: repair_run(run_id: int [, dbt_commands: Optional[List[str]], jar_params: Optional[List[str]], job_parameters: Optional[Dict[str, str]], latest_repair_id: Optional[int], notebook_params: Optional[Dict[str, str]], pipeline_params: Optional[PipelineParams], python_named_params: Optional[Dict[str, str]], python_params: Optional[List[str]], rerun_all_failed_tasks: Optional[bool], rerun_dependent_tasks: Optional[bool], rerun_tasks: Optional[List[str]], spark_submit_params: Optional[List[str]], sql_params: Optional[Dict[str, str]]]) -> Wait[Run]
 
@@ -730,7 +730,7 @@
         :returns:
           Long-running operation waiter for :class:`Run`.
           See :method:wait_get_run_job_terminated_or_skipped for more details.
-        
+
 
     .. py:method:: repair_run_and_wait(run_id: int [, dbt_commands: Optional[List[str]], jar_params: Optional[List[str]], job_parameters: Optional[Dict[str, str]], latest_repair_id: Optional[int], notebook_params: Optional[Dict[str, str]], pipeline_params: Optional[PipelineParams], python_named_params: Optional[Dict[str, str]], python_params: Optional[List[str]], rerun_all_failed_tasks: Optional[bool], rerun_dependent_tasks: Optional[bool], rerun_tasks: Optional[List[str]], spark_submit_params: Optional[List[str]], sql_params: Optional[Dict[str, str]], timeout: datetime.timedelta = 0:20:00]) -> Run
 
@@ -786,8 +786,8 @@
           Changes to the field `JobBaseSettings.timeout_seconds` are applied to active runs. Changes to other
           fields are applied to future runs only.
         
-        
-        
+
+
 
     .. py:method:: run_now(job_id: int [, dbt_commands: Optional[List[str]], idempotency_token: Optional[str], jar_params: Optional[List[str]], job_parameters: Optional[Dict[str, str]], notebook_params: Optional[Dict[str, str]], only: Optional[List[str]], pipeline_params: Optional[PipelineParams], python_named_params: Optional[Dict[str, str]], python_params: Optional[List[str]], queue: Optional[QueueSettings], spark_submit_params: Optional[List[str]], sql_params: Optional[Dict[str, str]]]) -> Wait[Run]
 
@@ -919,7 +919,7 @@
         :returns:
           Long-running operation waiter for :class:`Run`.
           See :method:wait_get_run_job_terminated_or_skipped for more details.
-        
+
 
     .. py:method:: run_now_and_wait(job_id: int [, dbt_commands: Optional[List[str]], idempotency_token: Optional[str], jar_params: Optional[List[str]], job_parameters: Optional[Dict[str, str]], notebook_params: Optional[Dict[str, str]], only: Optional[List[str]], pipeline_params: Optional[PipelineParams], python_named_params: Optional[Dict[str, str]], python_params: Optional[List[str]], queue: Optional[QueueSettings], spark_submit_params: Optional[List[str]], sql_params: Optional[Dict[str, str]], timeout: datetime.timedelta = 0:20:00]) -> Run
 
@@ -936,7 +936,7 @@
         :param access_control_list: List[:class:`JobAccessControlRequest`] (optional)
         
         :returns: :class:`JobPermissions`
-        
+
 
     .. py:method:: submit( [, access_control_list: Optional[List[JobAccessControlRequest]], budget_policy_id: Optional[str], email_notifications: Optional[JobEmailNotifications], environments: Optional[List[JobEnvironment]], git_source: Optional[GitSource], health: Optional[JobsHealthRules], idempotency_token: Optional[str], notification_settings: Optional[JobNotificationSettings], queue: Optional[QueueSettings], run_as: Optional[JobRunAs], run_name: Optional[str], tasks: Optional[List[SubmitTask]], timeout_seconds: Optional[int], webhook_notifications: Optional[WebhookNotifications]]) -> Wait[Run]
 
@@ -1026,7 +1026,7 @@
         :returns:
           Long-running operation waiter for :class:`Run`.
           See :method:wait_get_run_job_terminated_or_skipped for more details.
-        
+
 
     .. py:method:: submit_and_wait( [, access_control_list: Optional[List[JobAccessControlRequest]], budget_policy_id: Optional[str], email_notifications: Optional[JobEmailNotifications], environments: Optional[List[JobEnvironment]], git_source: Optional[GitSource], health: Optional[JobsHealthRules], idempotency_token: Optional[str], notification_settings: Optional[JobNotificationSettings], queue: Optional[QueueSettings], run_as: Optional[JobRunAs], run_name: Optional[str], tasks: Optional[List[SubmitTask]], timeout_seconds: Optional[int], webhook_notifications: Optional[WebhookNotifications], timeout: datetime.timedelta = 0:20:00]) -> Run
 
@@ -1089,8 +1089,8 @@
           Changes to the field `JobSettings.timeout_seconds` are applied to active runs. Changes to other
           fields are applied to future runs only.
         
-        
-        
+
+
 
     .. py:method:: update_permissions(job_id: str [, access_control_list: Optional[List[JobAccessControlRequest]]]) -> JobPermissions
 
@@ -1103,6 +1103,6 @@
         :param access_control_list: List[:class:`JobAccessControlRequest`] (optional)
         
         :returns: :class:`JobPermissions`
-        
+
 
     .. py:method:: wait_get_run_job_terminated_or_skipped(run_id: int, timeout: datetime.timedelta = 0:20:00, callback: Optional[Callable[[Run], None]]) -> Run

--- a/docs/workspace/jobs/policy_compliance_for_jobs.rst
+++ b/docs/workspace/jobs/policy_compliance_for_jobs.rst
@@ -29,7 +29,7 @@
           If set, previews changes made to the job to comply with its policy, but does not update the job.
         
         :returns: :class:`EnforcePolicyComplianceResponse`
-        
+
 
     .. py:method:: get_compliance(job_id: int) -> GetPolicyComplianceResponse
 
@@ -43,7 +43,7 @@
           The ID of the job whose compliance status you are requesting.
         
         :returns: :class:`GetPolicyComplianceResponse`
-        
+
 
     .. py:method:: list_compliance(policy_id: str [, page_size: Optional[int], page_token: Optional[str]]) -> Iterator[JobCompliance]
 
@@ -63,4 +63,3 @@
           `next_page_token` or `prev_page_token`.
         
         :returns: Iterator over :class:`JobCompliance`
-        

--- a/docs/workspace/marketplace/consumer_fulfillments.rst
+++ b/docs/workspace/marketplace/consumer_fulfillments.rst
@@ -17,7 +17,7 @@
         :param page_token: str (optional)
         
         :returns: Iterator over :class:`SharedDataObject`
-        
+
 
     .. py:method:: list(listing_id: str [, page_size: Optional[int], page_token: Optional[str]]) -> Iterator[ListingFulfillment]
 
@@ -33,4 +33,3 @@
         :param page_token: str (optional)
         
         :returns: Iterator over :class:`ListingFulfillment`
-        

--- a/docs/workspace/marketplace/consumer_installations.rst
+++ b/docs/workspace/marketplace/consumer_installations.rst
@@ -21,7 +21,7 @@
         :param share_name: str (optional)
         
         :returns: :class:`Installation`
-        
+
 
     .. py:method:: delete(listing_id: str, installation_id: str)
 
@@ -32,8 +32,8 @@
         :param listing_id: str
         :param installation_id: str
         
-        
-        
+
+
 
     .. py:method:: list( [, page_size: Optional[int], page_token: Optional[str]]) -> Iterator[InstallationDetail]
 
@@ -45,7 +45,7 @@
         :param page_token: str (optional)
         
         :returns: Iterator over :class:`InstallationDetail`
-        
+
 
     .. py:method:: list_listing_installations(listing_id: str [, page_size: Optional[int], page_token: Optional[str]]) -> Iterator[InstallationDetail]
 
@@ -58,7 +58,7 @@
         :param page_token: str (optional)
         
         :returns: Iterator over :class:`InstallationDetail`
-        
+
 
     .. py:method:: update(listing_id: str, installation_id: str, installation: InstallationDetail [, rotate_token: Optional[bool]]) -> UpdateInstallationResponse
 
@@ -75,4 +75,3 @@
         :param rotate_token: bool (optional)
         
         :returns: :class:`UpdateInstallationResponse`
-        

--- a/docs/workspace/marketplace/consumer_listings.rst
+++ b/docs/workspace/marketplace/consumer_listings.rst
@@ -16,7 +16,7 @@
         :param ids: List[str] (optional)
         
         :returns: :class:`BatchGetListingsResponse`
-        
+
 
     .. py:method:: get(id: str) -> GetListingResponse
 
@@ -27,7 +27,7 @@
         :param id: str
         
         :returns: :class:`GetListingResponse`
-        
+
 
     .. py:method:: list( [, assets: Optional[List[AssetType]], categories: Optional[List[Category]], is_free: Optional[bool], is_private_exchange: Optional[bool], is_staff_pick: Optional[bool], page_size: Optional[int], page_token: Optional[str], provider_ids: Optional[List[str]], tags: Optional[List[ListingTag]]]) -> Iterator[Listing]
 
@@ -53,7 +53,7 @@
           Matches any of the following tags
         
         :returns: Iterator over :class:`Listing`
-        
+
 
     .. py:method:: search(query: str [, assets: Optional[List[AssetType]], categories: Optional[List[Category]], is_free: Optional[bool], is_private_exchange: Optional[bool], page_size: Optional[int], page_token: Optional[str], provider_ids: Optional[List[str]]]) -> Iterator[Listing]
 
@@ -76,4 +76,3 @@
           Matches any of the following provider ids
         
         :returns: Iterator over :class:`Listing`
-        

--- a/docs/workspace/marketplace/consumer_personalization_requests.rst
+++ b/docs/workspace/marketplace/consumer_personalization_requests.rst
@@ -23,7 +23,7 @@
         :param recipient_type: :class:`DeltaSharingRecipientType` (optional)
         
         :returns: :class:`CreatePersonalizationRequestResponse`
-        
+
 
     .. py:method:: get(listing_id: str) -> GetPersonalizationRequestResponse
 
@@ -35,7 +35,7 @@
         :param listing_id: str
         
         :returns: :class:`GetPersonalizationRequestResponse`
-        
+
 
     .. py:method:: list( [, page_size: Optional[int], page_token: Optional[str]]) -> Iterator[PersonalizationRequest]
 
@@ -47,4 +47,3 @@
         :param page_token: str (optional)
         
         :returns: Iterator over :class:`PersonalizationRequest`
-        

--- a/docs/workspace/marketplace/consumer_providers.rst
+++ b/docs/workspace/marketplace/consumer_providers.rst
@@ -15,7 +15,7 @@
         :param ids: List[str] (optional)
         
         :returns: :class:`BatchGetProvidersResponse`
-        
+
 
     .. py:method:: get(id: str) -> GetProviderResponse
 
@@ -26,7 +26,7 @@
         :param id: str
         
         :returns: :class:`GetProviderResponse`
-        
+
 
     .. py:method:: list( [, is_featured: Optional[bool], page_size: Optional[int], page_token: Optional[str]]) -> Iterator[ProviderInfo]
 
@@ -39,4 +39,3 @@
         :param page_token: str (optional)
         
         :returns: Iterator over :class:`ProviderInfo`
-        

--- a/docs/workspace/marketplace/provider_exchange_filters.rst
+++ b/docs/workspace/marketplace/provider_exchange_filters.rst
@@ -15,7 +15,7 @@
         :param filter: :class:`ExchangeFilter`
         
         :returns: :class:`CreateExchangeFilterResponse`
-        
+
 
     .. py:method:: delete(id: str)
 
@@ -25,8 +25,8 @@
         
         :param id: str
         
-        
-        
+
+
 
     .. py:method:: list(exchange_id: str [, page_size: Optional[int], page_token: Optional[str]]) -> Iterator[ExchangeFilter]
 
@@ -39,7 +39,7 @@
         :param page_token: str (optional)
         
         :returns: Iterator over :class:`ExchangeFilter`
-        
+
 
     .. py:method:: update(id: str, filter: ExchangeFilter) -> UpdateExchangeFilterResponse
 
@@ -51,4 +51,3 @@
         :param filter: :class:`ExchangeFilter`
         
         :returns: :class:`UpdateExchangeFilterResponse`
-        

--- a/docs/workspace/marketplace/provider_exchanges.rst
+++ b/docs/workspace/marketplace/provider_exchanges.rst
@@ -16,7 +16,7 @@
         :param exchange_id: str
         
         :returns: :class:`AddExchangeForListingResponse`
-        
+
 
     .. py:method:: create(exchange: Exchange) -> CreateExchangeResponse
 
@@ -27,7 +27,7 @@
         :param exchange: :class:`Exchange`
         
         :returns: :class:`CreateExchangeResponse`
-        
+
 
     .. py:method:: delete(id: str)
 
@@ -37,8 +37,8 @@
         
         :param id: str
         
-        
-        
+
+
 
     .. py:method:: delete_listing_from_exchange(id: str)
 
@@ -48,8 +48,8 @@
         
         :param id: str
         
-        
-        
+
+
 
     .. py:method:: get(id: str) -> GetExchangeResponse
 
@@ -60,7 +60,7 @@
         :param id: str
         
         :returns: :class:`GetExchangeResponse`
-        
+
 
     .. py:method:: list( [, page_size: Optional[int], page_token: Optional[str]]) -> Iterator[Exchange]
 
@@ -72,7 +72,7 @@
         :param page_token: str (optional)
         
         :returns: Iterator over :class:`Exchange`
-        
+
 
     .. py:method:: list_exchanges_for_listing(listing_id: str [, page_size: Optional[int], page_token: Optional[str]]) -> Iterator[ExchangeListing]
 
@@ -85,7 +85,7 @@
         :param page_token: str (optional)
         
         :returns: Iterator over :class:`ExchangeListing`
-        
+
 
     .. py:method:: list_listings_for_exchange(exchange_id: str [, page_size: Optional[int], page_token: Optional[str]]) -> Iterator[ExchangeListing]
 
@@ -98,7 +98,7 @@
         :param page_token: str (optional)
         
         :returns: Iterator over :class:`ExchangeListing`
-        
+
 
     .. py:method:: update(id: str, exchange: Exchange) -> UpdateExchangeResponse
 
@@ -110,4 +110,3 @@
         :param exchange: :class:`Exchange`
         
         :returns: :class:`UpdateExchangeResponse`
-        

--- a/docs/workspace/marketplace/provider_files.rst
+++ b/docs/workspace/marketplace/provider_files.rst
@@ -18,7 +18,7 @@
         :param display_name: str (optional)
         
         :returns: :class:`CreateFileResponse`
-        
+
 
     .. py:method:: delete(file_id: str)
 
@@ -28,8 +28,8 @@
         
         :param file_id: str
         
-        
-        
+
+
 
     .. py:method:: get(file_id: str) -> GetFileResponse
 
@@ -40,7 +40,7 @@
         :param file_id: str
         
         :returns: :class:`GetFileResponse`
-        
+
 
     .. py:method:: list(file_parent: FileParent [, page_size: Optional[int], page_token: Optional[str]]) -> Iterator[FileInfo]
 
@@ -53,4 +53,3 @@
         :param page_token: str (optional)
         
         :returns: Iterator over :class:`FileInfo`
-        

--- a/docs/workspace/marketplace/provider_listings.rst
+++ b/docs/workspace/marketplace/provider_listings.rst
@@ -16,7 +16,7 @@
         :param listing: :class:`Listing`
         
         :returns: :class:`CreateListingResponse`
-        
+
 
     .. py:method:: delete(id: str)
 
@@ -26,8 +26,8 @@
         
         :param id: str
         
-        
-        
+
+
 
     .. py:method:: get(id: str) -> GetListingResponse
 
@@ -38,7 +38,7 @@
         :param id: str
         
         :returns: :class:`GetListingResponse`
-        
+
 
     .. py:method:: list( [, page_size: Optional[int], page_token: Optional[str]]) -> Iterator[Listing]
 
@@ -50,7 +50,7 @@
         :param page_token: str (optional)
         
         :returns: Iterator over :class:`Listing`
-        
+
 
     .. py:method:: update(id: str, listing: Listing) -> UpdateListingResponse
 
@@ -62,4 +62,3 @@
         :param listing: :class:`Listing`
         
         :returns: :class:`UpdateListingResponse`
-        

--- a/docs/workspace/marketplace/provider_personalization_requests.rst
+++ b/docs/workspace/marketplace/provider_personalization_requests.rst
@@ -18,7 +18,7 @@
         :param page_token: str (optional)
         
         :returns: Iterator over :class:`PersonalizationRequest`
-        
+
 
     .. py:method:: update(listing_id: str, request_id: str, status: PersonalizationRequestStatus [, reason: Optional[str], share: Optional[ShareInfo]]) -> UpdatePersonalizationRequestResponse
 
@@ -33,4 +33,3 @@
         :param share: :class:`ShareInfo` (optional)
         
         :returns: :class:`UpdatePersonalizationRequestResponse`
-        

--- a/docs/workspace/marketplace/provider_provider_analytics_dashboards.rst
+++ b/docs/workspace/marketplace/provider_provider_analytics_dashboards.rst
@@ -14,7 +14,7 @@
         Lakeview dashboard id.
         
         :returns: :class:`ProviderAnalyticsDashboard`
-        
+
 
     .. py:method:: get() -> ListProviderAnalyticsDashboardResponse
 
@@ -23,7 +23,7 @@
         Get provider analytics dashboard.
         
         :returns: :class:`ListProviderAnalyticsDashboardResponse`
-        
+
 
     .. py:method:: get_latest_version() -> GetLatestVersionProviderAnalyticsDashboardResponse
 
@@ -32,7 +32,7 @@
         Get latest version of provider analytics dashboard.
         
         :returns: :class:`GetLatestVersionProviderAnalyticsDashboardResponse`
-        
+
 
     .. py:method:: update(id: str [, version: Optional[int]]) -> UpdateProviderAnalyticsDashboardResponse
 
@@ -47,4 +47,3 @@
           that it should be equal to latest version of the dashboard template
         
         :returns: :class:`UpdateProviderAnalyticsDashboardResponse`
-        

--- a/docs/workspace/marketplace/provider_providers.rst
+++ b/docs/workspace/marketplace/provider_providers.rst
@@ -15,7 +15,7 @@
         :param provider: :class:`ProviderInfo`
         
         :returns: :class:`CreateProviderResponse`
-        
+
 
     .. py:method:: delete(id: str)
 
@@ -25,8 +25,8 @@
         
         :param id: str
         
-        
-        
+
+
 
     .. py:method:: get(id: str) -> GetProviderResponse
 
@@ -37,7 +37,7 @@
         :param id: str
         
         :returns: :class:`GetProviderResponse`
-        
+
 
     .. py:method:: list( [, page_size: Optional[int], page_token: Optional[str]]) -> Iterator[ProviderInfo]
 
@@ -49,7 +49,7 @@
         :param page_token: str (optional)
         
         :returns: Iterator over :class:`ProviderInfo`
-        
+
 
     .. py:method:: update(id: str, provider: ProviderInfo) -> UpdateProviderResponse
 
@@ -61,4 +61,3 @@
         :param provider: :class:`ProviderInfo`
         
         :returns: :class:`UpdateProviderResponse`
-        

--- a/docs/workspace/ml/experiments.rst
+++ b/docs/workspace/ml/experiments.rst
@@ -49,7 +49,7 @@
           support up to 20 tags per request.
         
         :returns: :class:`CreateExperimentResponse`
-        
+
 
     .. py:method:: create_run( [, experiment_id: Optional[str], start_time: Optional[int], tags: Optional[List[RunTag]], user_id: Optional[str]]) -> CreateRunResponse
 
@@ -91,7 +91,7 @@
           a future MLflow release. Use 'mlflow.user' tag instead.
         
         :returns: :class:`CreateRunResponse`
-        
+
 
     .. py:method:: delete_experiment(experiment_id: str)
 
@@ -103,8 +103,8 @@
         :param experiment_id: str
           ID of the associated experiment.
         
-        
-        
+
+
 
     .. py:method:: delete_run(run_id: str)
 
@@ -115,8 +115,8 @@
         :param run_id: str
           ID of the run to delete.
         
-        
-        
+
+
 
     .. py:method:: delete_runs(experiment_id: str, max_timestamp_millis: int [, max_runs: Optional[int]]) -> DeleteRunsResponse
 
@@ -136,7 +136,7 @@
           value for max_runs is 10000.
         
         :returns: :class:`DeleteRunsResponse`
-        
+
 
     .. py:method:: delete_tag(run_id: str, key: str)
 
@@ -150,8 +150,8 @@
         :param key: str
           Name of the tag. Maximum size is 255 bytes. Must be provided.
         
-        
-        
+
+
 
     .. py:method:: get_by_name(experiment_name: str) -> GetExperimentResponse
 
@@ -169,7 +169,7 @@
           Name of the associated experiment.
         
         :returns: :class:`GetExperimentResponse`
-        
+
 
     .. py:method:: get_experiment(experiment_id: str) -> GetExperimentResponse
 
@@ -199,7 +199,7 @@
           ID of the associated experiment.
         
         :returns: :class:`GetExperimentResponse`
-        
+
 
     .. py:method:: get_history(metric_key: str [, max_results: Optional[int], page_token: Optional[str], run_id: Optional[str], run_uuid: Optional[str]]) -> Iterator[Metric]
 
@@ -221,7 +221,7 @@
           removed in a future MLflow version.
         
         :returns: Iterator over :class:`Metric`
-        
+
 
     .. py:method:: get_permission_levels(experiment_id: str) -> GetExperimentPermissionLevelsResponse
 
@@ -233,7 +233,7 @@
           The experiment for which to get or manage permissions.
         
         :returns: :class:`GetExperimentPermissionLevelsResponse`
-        
+
 
     .. py:method:: get_permissions(experiment_id: str) -> ExperimentPermissions
 
@@ -245,7 +245,7 @@
           The experiment for which to get or manage permissions.
         
         :returns: :class:`ExperimentPermissions`
-        
+
 
     .. py:method:: get_run(run_id: str [, run_uuid: Optional[str]]) -> GetRunResponse
 
@@ -263,7 +263,7 @@
           MLflow version.
         
         :returns: :class:`GetRunResponse`
-        
+
 
     .. py:method:: list_artifacts( [, page_token: Optional[str], path: Optional[str], run_id: Optional[str], run_uuid: Optional[str]]) -> Iterator[FileInfo]
 
@@ -289,7 +289,7 @@
           in a future MLflow version.
         
         :returns: Iterator over :class:`FileInfo`
-        
+
 
     .. py:method:: list_experiments( [, max_results: Optional[int], page_token: Optional[str], view_type: Optional[str]]) -> Iterator[Experiment]
 
@@ -319,7 +319,7 @@
           Qualifier for type of experiments to be returned. If unspecified, return only active experiments.
         
         :returns: Iterator over :class:`Experiment`
-        
+
 
     .. py:method:: log_batch( [, metrics: Optional[List[Metric]], params: Optional[List[Param]], run_id: Optional[str], tags: Optional[List[RunTag]]])
 
@@ -372,8 +372,8 @@
           Tags to log. A single request can contain up to 100 tags, and up to 1000 metrics, params, and tags
           in total.
         
-        
-        
+
+
 
     .. py:method:: log_inputs( [, datasets: Optional[List[DatasetInput]], run_id: Optional[str]])
 
@@ -386,8 +386,8 @@
         :param run_id: str (optional)
           ID of the run to log under
         
-        
-        
+
+
 
     .. py:method:: log_metric(key: str, value: float, timestamp: int [, run_id: Optional[str], run_uuid: Optional[str], step: Optional[int]])
 
@@ -411,8 +411,8 @@
         :param step: int (optional)
           Step at which to log the metric
         
-        
-        
+
+
 
     .. py:method:: log_model( [, model_json: Optional[str], run_id: Optional[str]])
 
@@ -425,8 +425,8 @@
         :param run_id: str (optional)
           ID of the run to log under
         
-        
-        
+
+
 
     .. py:method:: log_param(key: str, value: str [, run_id: Optional[str], run_uuid: Optional[str]])
 
@@ -446,8 +446,8 @@
           [Deprecated, use run_id instead] ID of the run under which to log the param. This field will be
           removed in a future MLflow version.
         
-        
-        
+
+
 
     .. py:method:: restore_experiment(experiment_id: str)
 
@@ -462,8 +462,8 @@
         :param experiment_id: str
           ID of the associated experiment.
         
-        
-        
+
+
 
     .. py:method:: restore_run(run_id: str)
 
@@ -474,8 +474,8 @@
         :param run_id: str
           ID of the run to restore.
         
-        
-        
+
+
 
     .. py:method:: restore_runs(experiment_id: str, min_timestamp_millis: int [, max_runs: Optional[int]]) -> RestoreRunsResponse
 
@@ -495,7 +495,7 @@
           value for max_runs is 10000.
         
         :returns: :class:`RestoreRunsResponse`
-        
+
 
     .. py:method:: search_experiments( [, filter: Optional[str], max_results: Optional[int], order_by: Optional[List[str]], page_token: Optional[str], view_type: Optional[SearchExperimentsViewType]]) -> Iterator[Experiment]
 
@@ -517,7 +517,7 @@
           Qualifier for type of experiments to be returned. If unspecified, return only active experiments.
         
         :returns: Iterator over :class:`Experiment`
-        
+
 
     .. py:method:: search_runs( [, experiment_ids: Optional[List[str]], filter: Optional[str], max_results: Optional[int], order_by: Optional[List[str]], page_token: Optional[str], run_view_type: Optional[SearchRunsRunViewType]]) -> Iterator[Run]
 
@@ -554,7 +554,7 @@
           Whether to display only active, only deleted, or all runs. Defaults to only active runs.
         
         :returns: Iterator over :class:`Run`
-        
+
 
     .. py:method:: set_experiment_tag(experiment_id: str, key: str, value: str)
 
@@ -571,8 +571,8 @@
           String value of the tag being logged. Maximum size depends on storage backend. All storage backends
           are guaranteed to support key values up to 5000 bytes in size.
         
-        
-        
+
+
 
     .. py:method:: set_permissions(experiment_id: str [, access_control_list: Optional[List[ExperimentAccessControlRequest]]]) -> ExperimentPermissions
 
@@ -586,7 +586,7 @@
         :param access_control_list: List[:class:`ExperimentAccessControlRequest`] (optional)
         
         :returns: :class:`ExperimentPermissions`
-        
+
 
     .. py:method:: set_tag(key: str, value: str [, run_id: Optional[str], run_uuid: Optional[str]])
 
@@ -606,8 +606,8 @@
           [Deprecated, use run_id instead] ID of the run under which to log the tag. This field will be
           removed in a future MLflow version.
         
-        
-        
+
+
 
     .. py:method:: update_experiment(experiment_id: str [, new_name: Optional[str]])
 
@@ -638,8 +638,8 @@
         :param new_name: str (optional)
           If provided, the experiment's name is changed to the new name. The new name must be unique.
         
-        
-        
+
+
 
     .. py:method:: update_permissions(experiment_id: str [, access_control_list: Optional[List[ExperimentAccessControlRequest]]]) -> ExperimentPermissions
 
@@ -652,7 +652,7 @@
         :param access_control_list: List[:class:`ExperimentAccessControlRequest`] (optional)
         
         :returns: :class:`ExperimentPermissions`
-        
+
 
     .. py:method:: update_run( [, end_time: Optional[int], run_id: Optional[str], run_uuid: Optional[str], status: Optional[UpdateRunStatus]]) -> UpdateRunResponse
 
@@ -694,4 +694,3 @@
           Updated status of the run.
         
         :returns: :class:`UpdateRunResponse`
-        

--- a/docs/workspace/ml/model_registry.rst
+++ b/docs/workspace/ml/model_registry.rst
@@ -38,7 +38,7 @@
           User-provided comment on the action.
         
         :returns: :class:`ApproveTransitionRequestResponse`
-        
+
 
     .. py:method:: create_comment(name: str, version: str, comment: str) -> CreateCommentResponse
 
@@ -77,7 +77,7 @@
           User-provided comment on the action.
         
         :returns: :class:`CreateCommentResponse`
-        
+
 
     .. py:method:: create_model(name: str [, description: Optional[str], tags: Optional[List[ModelTag]]]) -> CreateModelResponse
 
@@ -108,7 +108,7 @@
           Additional metadata for registered model.
         
         :returns: :class:`CreateModelResponse`
-        
+
 
     .. py:method:: create_model_version(name: str, source: str [, description: Optional[str], run_id: Optional[str], run_link: Optional[str], tags: Optional[List[ModelVersionTag]]]) -> CreateModelVersionResponse
 
@@ -147,7 +147,7 @@
           Additional metadata for model version.
         
         :returns: :class:`CreateModelVersionResponse`
-        
+
 
     .. py:method:: create_transition_request(name: str, version: str, stage: Stage [, comment: Optional[str]]) -> CreateTransitionRequestResponse
 
@@ -173,7 +173,7 @@
           User-provided comment on the action.
         
         :returns: :class:`CreateTransitionRequestResponse`
-        
+
 
     .. py:method:: create_webhook(events: List[RegistryWebhookEvent] [, description: Optional[str], http_url_spec: Optional[HttpUrlSpec], job_spec: Optional[JobSpec], model_name: Optional[str], status: Optional[RegistryWebhookStatus]]) -> CreateWebhookResponse
 
@@ -247,7 +247,7 @@
           event.
         
         :returns: :class:`CreateWebhookResponse`
-        
+
 
     .. py:method:: delete_comment(id: str)
 
@@ -257,8 +257,8 @@
         
         :param id: str
         
-        
-        
+
+
 
     .. py:method:: delete_model(name: str)
 
@@ -269,8 +269,8 @@
         :param name: str
           Registered model unique name identifier.
         
-        
-        
+
+
 
     .. py:method:: delete_model_tag(name: str, key: str)
 
@@ -284,8 +284,8 @@
           Name of the tag. The name must be an exact match; wild-card deletion is not supported. Maximum size
           is 250 bytes.
         
-        
-        
+
+
 
     .. py:method:: delete_model_version(name: str, version: str)
 
@@ -298,8 +298,8 @@
         :param version: str
           Model version number
         
-        
-        
+
+
 
     .. py:method:: delete_model_version_tag(name: str, version: str, key: str)
 
@@ -315,8 +315,8 @@
           Name of the tag. The name must be an exact match; wild-card deletion is not supported. Maximum size
           is 250 bytes.
         
-        
-        
+
+
 
     .. py:method:: delete_transition_request(name: str, version: str, stage: DeleteTransitionRequestStage, creator: str [, comment: Optional[str]])
 
@@ -344,8 +344,8 @@
         :param comment: str (optional)
           User-provided comment on the action.
         
-        
-        
+
+
 
     .. py:method:: delete_webhook( [, id: Optional[str]])
 
@@ -358,8 +358,8 @@
         :param id: str (optional)
           Webhook ID required to delete a registry webhook.
         
-        
-        
+
+
 
     .. py:method:: get_latest_versions(name: str [, stages: Optional[List[str]]]) -> Iterator[ModelVersion]
 
@@ -373,7 +373,7 @@
           List of stages.
         
         :returns: Iterator over :class:`ModelVersion`
-        
+
 
     .. py:method:: get_model(name: str) -> GetModelResponse
 
@@ -404,7 +404,7 @@
           Registered model unique name identifier.
         
         :returns: :class:`GetModelResponse`
-        
+
 
     .. py:method:: get_model_version(name: str, version: str) -> GetModelVersionResponse
 
@@ -418,7 +418,7 @@
           Model version number
         
         :returns: :class:`GetModelVersionResponse`
-        
+
 
     .. py:method:: get_model_version_download_uri(name: str, version: str) -> GetModelVersionDownloadUriResponse
 
@@ -432,7 +432,7 @@
           Model version number
         
         :returns: :class:`GetModelVersionDownloadUriResponse`
-        
+
 
     .. py:method:: get_permission_levels(registered_model_id: str) -> GetRegisteredModelPermissionLevelsResponse
 
@@ -444,7 +444,7 @@
           The registered model for which to get or manage permissions.
         
         :returns: :class:`GetRegisteredModelPermissionLevelsResponse`
-        
+
 
     .. py:method:: get_permissions(registered_model_id: str) -> RegisteredModelPermissions
 
@@ -457,7 +457,7 @@
           The registered model for which to get or manage permissions.
         
         :returns: :class:`RegisteredModelPermissions`
-        
+
 
     .. py:method:: list_models( [, max_results: Optional[int], page_token: Optional[str]]) -> Iterator[Model]
 
@@ -483,7 +483,7 @@
           Pagination token to go to the next page based on a previous query.
         
         :returns: Iterator over :class:`Model`
-        
+
 
     .. py:method:: list_transition_requests(name: str, version: str) -> Iterator[Activity]
 
@@ -497,7 +497,7 @@
           Version of the model.
         
         :returns: Iterator over :class:`Activity`
-        
+
 
     .. py:method:: list_webhooks( [, events: Optional[List[RegistryWebhookEvent]], model_name: Optional[str], page_token: Optional[str]]) -> Iterator[RegistryWebhook]
 
@@ -529,7 +529,7 @@
           Token indicating the page of artifact results to fetch
         
         :returns: Iterator over :class:`RegistryWebhook`
-        
+
 
     .. py:method:: reject_transition_request(name: str, version: str, stage: Stage [, comment: Optional[str]]) -> RejectTransitionRequestResponse
 
@@ -555,7 +555,7 @@
           User-provided comment on the action.
         
         :returns: :class:`RejectTransitionRequestResponse`
-        
+
 
     .. py:method:: rename_model(name: str [, new_name: Optional[str]]) -> RenameModelResponse
 
@@ -569,7 +569,7 @@
           If provided, updates the name for this `registered_model`.
         
         :returns: :class:`RenameModelResponse`
-        
+
 
     .. py:method:: search_model_versions( [, filter: Optional[str], max_results: Optional[int], order_by: Optional[List[str]], page_token: Optional[str]]) -> Iterator[ModelVersion]
 
@@ -590,7 +590,7 @@
           Pagination token to go to next page based on previous search query.
         
         :returns: Iterator over :class:`ModelVersion`
-        
+
 
     .. py:method:: search_models( [, filter: Optional[str], max_results: Optional[int], order_by: Optional[List[str]], page_token: Optional[str]]) -> Iterator[Model]
 
@@ -612,7 +612,7 @@
           Pagination token to go to the next page based on a previous search query.
         
         :returns: Iterator over :class:`Model`
-        
+
 
     .. py:method:: set_model_tag(name: str, key: str, value: str)
 
@@ -630,8 +630,8 @@
           String value of the tag being logged. Maximum size depends on storage backend. All storage backends
           are guaranteed to support key values up to 5000 bytes in size.
         
-        
-        
+
+
 
     .. py:method:: set_model_version_tag(name: str, version: str, key: str, value: str)
 
@@ -651,8 +651,8 @@
           String value of the tag being logged. Maximum size depends on storage backend. All storage backends
           are guaranteed to support key values up to 5000 bytes in size.
         
-        
-        
+
+
 
     .. py:method:: set_permissions(registered_model_id: str [, access_control_list: Optional[List[RegisteredModelAccessControlRequest]]]) -> RegisteredModelPermissions
 
@@ -666,7 +666,7 @@
         :param access_control_list: List[:class:`RegisteredModelAccessControlRequest`] (optional)
         
         :returns: :class:`RegisteredModelPermissions`
-        
+
 
     .. py:method:: test_registry_webhook(id: str [, event: Optional[RegistryWebhookEvent]]) -> TestRegistryWebhookResponse
 
@@ -683,7 +683,7 @@
           test trigger uses a randomly chosen event associated with the webhook.
         
         :returns: :class:`TestRegistryWebhookResponse`
-        
+
 
     .. py:method:: transition_stage(name: str, version: str, stage: Stage, archive_existing_versions: bool [, comment: Optional[str]]) -> TransitionStageResponse
 
@@ -714,7 +714,7 @@
           User-provided comment on the action.
         
         :returns: :class:`TransitionStageResponse`
-        
+
 
     .. py:method:: update_comment(id: str, comment: str) -> UpdateCommentResponse
 
@@ -752,7 +752,7 @@
           User-provided comment on the action.
         
         :returns: :class:`UpdateCommentResponse`
-        
+
 
     .. py:method:: update_model(name: str [, description: Optional[str]])
 
@@ -784,8 +784,8 @@
         :param description: str (optional)
           If provided, updates the description for this `registered_model`.
         
-        
-        
+
+
 
     .. py:method:: update_model_version(name: str, version: str [, description: Optional[str]])
 
@@ -819,8 +819,8 @@
         :param description: str (optional)
           If provided, updates the description for this `registered_model`.
         
-        
-        
+
+
 
     .. py:method:: update_permissions(registered_model_id: str [, access_control_list: Optional[List[RegisteredModelAccessControlRequest]]]) -> RegisteredModelPermissions
 
@@ -834,7 +834,7 @@
         :param access_control_list: List[:class:`RegisteredModelAccessControlRequest`] (optional)
         
         :returns: :class:`RegisteredModelPermissions`
-        
+
 
     .. py:method:: update_webhook(id: str [, description: Optional[str], events: Optional[List[RegistryWebhookEvent]], http_url_spec: Optional[HttpUrlSpec], job_spec: Optional[JobSpec], status: Optional[RegistryWebhookStatus]])
 
@@ -909,5 +909,4 @@
           * `TEST_MODE`: Webhook can be triggered through the test endpoint, but is not triggered on a real
           event.
         
-        
-        
+

--- a/docs/workspace/pipelines/pipelines.rst
+++ b/docs/workspace/pipelines/pipelines.rst
@@ -109,7 +109,7 @@
           Which pipeline trigger to use. Deprecated: Use `continuous` instead.
         
         :returns: :class:`CreatePipelineResponse`
-        
+
 
     .. py:method:: delete(pipeline_id: str)
 
@@ -119,8 +119,8 @@
         
         :param pipeline_id: str
         
-        
-        
+
+
 
     .. py:method:: get(pipeline_id: str) -> GetPipelineResponse
 
@@ -162,7 +162,7 @@
         :param pipeline_id: str
         
         :returns: :class:`GetPipelineResponse`
-        
+
 
     .. py:method:: get_permission_levels(pipeline_id: str) -> GetPipelinePermissionLevelsResponse
 
@@ -174,7 +174,7 @@
           The pipeline for which to get or manage permissions.
         
         :returns: :class:`GetPipelinePermissionLevelsResponse`
-        
+
 
     .. py:method:: get_permissions(pipeline_id: str) -> PipelinePermissions
 
@@ -186,7 +186,7 @@
           The pipeline for which to get or manage permissions.
         
         :returns: :class:`PipelinePermissions`
-        
+
 
     .. py:method:: get_update(pipeline_id: str, update_id: str) -> GetUpdateResponse
 
@@ -200,7 +200,7 @@
           The ID of the update.
         
         :returns: :class:`GetUpdateResponse`
-        
+
 
     .. py:method:: list_pipeline_events(pipeline_id: str [, filter: Optional[str], max_results: Optional[int], order_by: Optional[List[str]], page_token: Optional[str]]) -> Iterator[PipelineEvent]
 
@@ -262,7 +262,7 @@
           this field is set.
         
         :returns: Iterator over :class:`PipelineEvent`
-        
+
 
     .. py:method:: list_pipelines( [, filter: Optional[str], max_results: Optional[int], order_by: Optional[List[str]], page_token: Optional[str]]) -> Iterator[PipelineStateInfo]
 
@@ -302,7 +302,7 @@
           Page token returned by previous call
         
         :returns: Iterator over :class:`PipelineStateInfo`
-        
+
 
     .. py:method:: list_updates(pipeline_id: str [, max_results: Optional[int], page_token: Optional[str], until_update_id: Optional[str]]) -> ListUpdatesResponse
 
@@ -320,7 +320,7 @@
           If present, returns updates until and including this update_id.
         
         :returns: :class:`ListUpdatesResponse`
-        
+
 
     .. py:method:: set_permissions(pipeline_id: str [, access_control_list: Optional[List[PipelineAccessControlRequest]]]) -> PipelinePermissions
 
@@ -334,7 +334,7 @@
         :param access_control_list: List[:class:`PipelineAccessControlRequest`] (optional)
         
         :returns: :class:`PipelinePermissions`
-        
+
 
     .. py:method:: start_update(pipeline_id: str [, cause: Optional[StartUpdateCause], full_refresh: Optional[bool], full_refresh_selection: Optional[List[str]], refresh_selection: Optional[List[str]], validate_only: Optional[bool]]) -> StartUpdateResponse
 
@@ -360,7 +360,7 @@
           or publish any datasets.
         
         :returns: :class:`StartUpdateResponse`
-        
+
 
     .. py:method:: stop(pipeline_id: str) -> Wait[GetPipelineResponse]
 
@@ -374,7 +374,7 @@
         :returns:
           Long-running operation waiter for :class:`GetPipelineResponse`.
           See :method:wait_get_pipeline_idle for more details.
-        
+
 
     .. py:method:: stop_and_wait(pipeline_id: str, timeout: datetime.timedelta = 0:20:00) -> GetPipelineResponse
 
@@ -488,8 +488,8 @@
         :param trigger: :class:`PipelineTrigger` (optional)
           Which pipeline trigger to use. Deprecated: Use `continuous` instead.
         
-        
-        
+
+
 
     .. py:method:: update_permissions(pipeline_id: str [, access_control_list: Optional[List[PipelineAccessControlRequest]]]) -> PipelinePermissions
 
@@ -502,7 +502,7 @@
         :param access_control_list: List[:class:`PipelineAccessControlRequest`] (optional)
         
         :returns: :class:`PipelinePermissions`
-        
+
 
     .. py:method:: wait_get_pipeline_idle(pipeline_id: str, timeout: datetime.timedelta = 0:20:00, callback: Optional[Callable[[GetPipelineResponse], None]]) -> GetPipelineResponse
 

--- a/docs/workspace/provisioning/credentials.rst
+++ b/docs/workspace/provisioning/credentials.rst
@@ -52,7 +52,7 @@
         :param aws_credentials: :class:`CreateCredentialAwsCredentials`
         
         :returns: :class:`Credential`
-        
+
 
     .. py:method:: delete(credentials_id: str)
 
@@ -64,8 +64,8 @@
         :param credentials_id: str
           Databricks Account API credential configuration ID
         
-        
-        
+
+
 
     .. py:method:: get(credentials_id: str) -> Credential
 
@@ -100,7 +100,7 @@
           Databricks Account API credential configuration ID
         
         :returns: :class:`Credential`
-        
+
 
     .. py:method:: list() -> Iterator[Credential]
 
@@ -120,4 +120,3 @@
         Gets all Databricks credential configurations associated with an account specified by ID.
         
         :returns: Iterator over :class:`Credential`
-        

--- a/docs/workspace/serving/serving_endpoints.rst
+++ b/docs/workspace/serving/serving_endpoints.rst
@@ -27,7 +27,7 @@
           The name of the served model that build logs will be retrieved for. This field is required.
         
         :returns: :class:`BuildLogsResponse`
-        
+
 
     .. py:method:: create(name: str, config: EndpointCoreConfigInput [, ai_gateway: Optional[AiGatewayConfig], rate_limits: Optional[List[RateLimit]], route_optimized: Optional[bool], tags: Optional[List[EndpointTag]]]) -> Wait[ServingEndpointDetailed]
 
@@ -52,7 +52,7 @@
         :returns:
           Long-running operation waiter for :class:`ServingEndpointDetailed`.
           See :method:wait_get_serving_endpoint_not_updating for more details.
-        
+
 
     .. py:method:: create_and_wait(name: str, config: EndpointCoreConfigInput [, ai_gateway: Optional[AiGatewayConfig], rate_limits: Optional[List[RateLimit]], route_optimized: Optional[bool], tags: Optional[List[EndpointTag]], timeout: datetime.timedelta = 0:20:00]) -> ServingEndpointDetailed
 
@@ -64,8 +64,8 @@
         :param name: str
           The name of the serving endpoint. This field is required.
         
-        
-        
+
+
 
     .. py:method:: export_metrics(name: str) -> ExportMetricsResponse
 
@@ -78,7 +78,7 @@
           The name of the serving endpoint to retrieve metrics for. This field is required.
         
         :returns: :class:`ExportMetricsResponse`
-        
+
 
     .. py:method:: get(name: str) -> ServingEndpointDetailed
 
@@ -90,7 +90,7 @@
           The name of the serving endpoint. This field is required.
         
         :returns: :class:`ServingEndpointDetailed`
-        
+
 
     .. py:method:: get_langchain_chat_open_ai_client(model)
 
@@ -108,8 +108,8 @@
         :param name: str
           The name of the serving endpoint that the served model belongs to. This field is required.
         
-        
-        
+
+
 
     .. py:method:: get_permission_levels(serving_endpoint_id: str) -> GetServingEndpointPermissionLevelsResponse
 
@@ -121,7 +121,7 @@
           The serving endpoint for which to get or manage permissions.
         
         :returns: :class:`GetServingEndpointPermissionLevelsResponse`
-        
+
 
     .. py:method:: get_permissions(serving_endpoint_id: str) -> ServingEndpointPermissions
 
@@ -134,14 +134,14 @@
           The serving endpoint for which to get or manage permissions.
         
         :returns: :class:`ServingEndpointPermissions`
-        
+
 
     .. py:method:: list() -> Iterator[ServingEndpoint]
 
         Get all serving endpoints.
         
         :returns: Iterator over :class:`ServingEndpoint`
-        
+
 
     .. py:method:: logs(name: str, served_model_name: str) -> ServerLogsResponse
 
@@ -155,7 +155,7 @@
           The name of the served model that logs will be retrieved for. This field is required.
         
         :returns: :class:`ServerLogsResponse`
-        
+
 
     .. py:method:: patch(name: str [, add_tags: Optional[List[EndpointTag]], delete_tags: Optional[List[str]]]) -> Iterator[EndpointTag]
 
@@ -171,7 +171,7 @@
           List of tag keys to delete
         
         :returns: Iterator over :class:`EndpointTag`
-        
+
 
     .. py:method:: put(name: str [, rate_limits: Optional[List[RateLimit]]]) -> PutResponse
 
@@ -186,7 +186,7 @@
           The list of endpoint rate limits.
         
         :returns: :class:`PutResponse`
-        
+
 
     .. py:method:: put_ai_gateway(name: str [, guardrails: Optional[AiGatewayGuardrails], inference_table_config: Optional[AiGatewayInferenceTableConfig], rate_limits: Optional[List[AiGatewayRateLimit]], usage_tracking_config: Optional[AiGatewayUsageTrackingConfig]]) -> PutAiGatewayResponse
 
@@ -209,7 +209,7 @@
           operational usage on endpoints and their associated costs.
         
         :returns: :class:`PutAiGatewayResponse`
-        
+
 
     .. py:method:: query(name: str [, dataframe_records: Optional[List[Any]], dataframe_split: Optional[DataframeSplitInput], extra_params: Optional[Dict[str, str]], input: Optional[Any], inputs: Optional[Any], instances: Optional[List[Any]], max_tokens: Optional[int], messages: Optional[List[ChatMessage]], n: Optional[int], prompt: Optional[Any], stop: Optional[List[str]], stream: Optional[bool], temperature: Optional[float]]) -> QueryEndpointResponse
 
@@ -260,7 +260,7 @@
           other chat/completions query fields.
         
         :returns: :class:`QueryEndpointResponse`
-        
+
 
     .. py:method:: set_permissions(serving_endpoint_id: str [, access_control_list: Optional[List[ServingEndpointAccessControlRequest]]]) -> ServingEndpointPermissions
 
@@ -274,7 +274,7 @@
         :param access_control_list: List[:class:`ServingEndpointAccessControlRequest`] (optional)
         
         :returns: :class:`ServingEndpointPermissions`
-        
+
 
     .. py:method:: update_config(name: str [, auto_capture_config: Optional[AutoCaptureConfigInput], served_entities: Optional[List[ServedEntityInput]], served_models: Optional[List[ServedModelInput]], traffic_config: Optional[TrafficConfig]]) -> Wait[ServingEndpointDetailed]
 
@@ -300,7 +300,7 @@
         :returns:
           Long-running operation waiter for :class:`ServingEndpointDetailed`.
           See :method:wait_get_serving_endpoint_not_updating for more details.
-        
+
 
     .. py:method:: update_config_and_wait(name: str [, auto_capture_config: Optional[AutoCaptureConfigInput], served_entities: Optional[List[ServedEntityInput]], served_models: Optional[List[ServedModelInput]], traffic_config: Optional[TrafficConfig], timeout: datetime.timedelta = 0:20:00]) -> ServingEndpointDetailed
 
@@ -317,6 +317,6 @@
         :param access_control_list: List[:class:`ServingEndpointAccessControlRequest`] (optional)
         
         :returns: :class:`ServingEndpointPermissions`
-        
+
 
     .. py:method:: wait_get_serving_endpoint_not_updating(name: str, timeout: datetime.timedelta = 0:20:00, callback: Optional[Callable[[ServingEndpointDetailed], None]]) -> ServingEndpointDetailed

--- a/docs/workspace/serving/serving_endpoints_data_plane.rst
+++ b/docs/workspace/serving/serving_endpoints_data_plane.rst
@@ -56,4 +56,3 @@
           other chat/completions query fields.
         
         :returns: :class:`QueryEndpointResponse`
-        

--- a/docs/workspace/settings/aibi_dashboard_embedding_access_policy.rst
+++ b/docs/workspace/settings/aibi_dashboard_embedding_access_policy.rst
@@ -21,7 +21,7 @@
           request, and pass it with the DELETE request to identify the rule set version you are deleting.
         
         :returns: :class:`DeleteAibiDashboardEmbeddingAccessPolicySettingResponse`
-        
+
 
     .. py:method:: get( [, etag: Optional[str]]) -> AibiDashboardEmbeddingAccessPolicySetting
 
@@ -38,7 +38,7 @@
           request, and pass it with the DELETE request to identify the rule set version you are deleting.
         
         :returns: :class:`AibiDashboardEmbeddingAccessPolicySetting`
-        
+
 
     .. py:method:: update(allow_missing: bool, setting: AibiDashboardEmbeddingAccessPolicySetting, field_mask: str) -> AibiDashboardEmbeddingAccessPolicySetting
 
@@ -55,4 +55,3 @@
           multiple fields in the field mask, use comma as the separator (no space).
         
         :returns: :class:`AibiDashboardEmbeddingAccessPolicySetting`
-        

--- a/docs/workspace/settings/aibi_dashboard_embedding_approved_domains.rst
+++ b/docs/workspace/settings/aibi_dashboard_embedding_approved_domains.rst
@@ -22,7 +22,7 @@
           request, and pass it with the DELETE request to identify the rule set version you are deleting.
         
         :returns: :class:`DeleteAibiDashboardEmbeddingApprovedDomainsSettingResponse`
-        
+
 
     .. py:method:: get( [, etag: Optional[str]]) -> AibiDashboardEmbeddingApprovedDomainsSetting
 
@@ -38,7 +38,7 @@
           request, and pass it with the DELETE request to identify the rule set version you are deleting.
         
         :returns: :class:`AibiDashboardEmbeddingApprovedDomainsSetting`
-        
+
 
     .. py:method:: update(allow_missing: bool, setting: AibiDashboardEmbeddingApprovedDomainsSetting, field_mask: str) -> AibiDashboardEmbeddingApprovedDomainsSetting
 
@@ -56,4 +56,3 @@
           multiple fields in the field mask, use comma as the separator (no space).
         
         :returns: :class:`AibiDashboardEmbeddingApprovedDomainsSetting`
-        

--- a/docs/workspace/settings/automatic_cluster_update.rst
+++ b/docs/workspace/settings/automatic_cluster_update.rst
@@ -21,7 +21,7 @@
           request, and pass it with the DELETE request to identify the rule set version you are deleting.
         
         :returns: :class:`AutomaticClusterUpdateSetting`
-        
+
 
     .. py:method:: update(allow_missing: bool, setting: AutomaticClusterUpdateSetting, field_mask: str) -> AutomaticClusterUpdateSetting
 
@@ -41,4 +41,3 @@
           multiple fields in the field mask, use comma as the separator (no space).
         
         :returns: :class:`AutomaticClusterUpdateSetting`
-        

--- a/docs/workspace/settings/compliance_security_profile.rst
+++ b/docs/workspace/settings/compliance_security_profile.rst
@@ -23,7 +23,7 @@
           request, and pass it with the DELETE request to identify the rule set version you are deleting.
         
         :returns: :class:`ComplianceSecurityProfileSetting`
-        
+
 
     .. py:method:: update(allow_missing: bool, setting: ComplianceSecurityProfileSetting, field_mask: str) -> ComplianceSecurityProfileSetting
 
@@ -43,4 +43,3 @@
           multiple fields in the field mask, use comma as the separator (no space).
         
         :returns: :class:`ComplianceSecurityProfileSetting`
-        

--- a/docs/workspace/settings/credentials_manager.rst
+++ b/docs/workspace/settings/credentials_manager.rst
@@ -22,4 +22,3 @@
           Array of scopes for the token request.
         
         :returns: :class:`ExchangeTokenResponse`
-        

--- a/docs/workspace/settings/default_namespace.rst
+++ b/docs/workspace/settings/default_namespace.rst
@@ -32,7 +32,7 @@
           request, and pass it with the DELETE request to identify the rule set version you are deleting.
         
         :returns: :class:`DeleteDefaultNamespaceSettingResponse`
-        
+
 
     .. py:method:: get( [, etag: Optional[str]]) -> DefaultNamespaceSetting
 
@@ -48,7 +48,7 @@
           request, and pass it with the DELETE request to identify the rule set version you are deleting.
         
         :returns: :class:`DefaultNamespaceSetting`
-        
+
 
     .. py:method:: update(allow_missing: bool, setting: DefaultNamespaceSetting, field_mask: str) -> DefaultNamespaceSetting
 
@@ -77,4 +77,3 @@
           multiple fields in the field mask, use comma as the separator (no space).
         
         :returns: :class:`DefaultNamespaceSetting`
-        

--- a/docs/workspace/settings/disable_legacy_access.rst
+++ b/docs/workspace/settings/disable_legacy_access.rst
@@ -25,7 +25,7 @@
           request, and pass it with the DELETE request to identify the rule set version you are deleting.
         
         :returns: :class:`DeleteDisableLegacyAccessResponse`
-        
+
 
     .. py:method:: get( [, etag: Optional[str]]) -> DisableLegacyAccess
 
@@ -41,7 +41,7 @@
           request, and pass it with the DELETE request to identify the rule set version you are deleting.
         
         :returns: :class:`DisableLegacyAccess`
-        
+
 
     .. py:method:: update(allow_missing: bool, setting: DisableLegacyAccess, field_mask: str) -> DisableLegacyAccess
 
@@ -58,4 +58,3 @@
           multiple fields in the field mask, use comma as the separator (no space).
         
         :returns: :class:`DisableLegacyAccess`
-        

--- a/docs/workspace/settings/disable_legacy_dbfs.rst
+++ b/docs/workspace/settings/disable_legacy_dbfs.rst
@@ -21,7 +21,7 @@
           request, and pass it with the DELETE request to identify the rule set version you are deleting.
         
         :returns: :class:`DeleteDisableLegacyDbfsResponse`
-        
+
 
     .. py:method:: get( [, etag: Optional[str]]) -> DisableLegacyDbfs
 
@@ -37,7 +37,7 @@
           request, and pass it with the DELETE request to identify the rule set version you are deleting.
         
         :returns: :class:`DisableLegacyDbfs`
-        
+
 
     .. py:method:: update(allow_missing: bool, setting: DisableLegacyDbfs, field_mask: str) -> DisableLegacyDbfs
 
@@ -54,4 +54,3 @@
           multiple fields in the field mask, use comma as the separator (no space).
         
         :returns: :class:`DisableLegacyDbfs`
-        

--- a/docs/workspace/settings/enhanced_security_monitoring.rst
+++ b/docs/workspace/settings/enhanced_security_monitoring.rst
@@ -25,7 +25,7 @@
           request, and pass it with the DELETE request to identify the rule set version you are deleting.
         
         :returns: :class:`EnhancedSecurityMonitoringSetting`
-        
+
 
     .. py:method:: update(allow_missing: bool, setting: EnhancedSecurityMonitoringSetting, field_mask: str) -> EnhancedSecurityMonitoringSetting
 
@@ -45,4 +45,3 @@
           multiple fields in the field mask, use comma as the separator (no space).
         
         :returns: :class:`EnhancedSecurityMonitoringSetting`
-        

--- a/docs/workspace/settings/ip_access_lists.rst
+++ b/docs/workspace/settings/ip_access_lists.rst
@@ -70,7 +70,7 @@
         :param ip_addresses: List[str] (optional)
         
         :returns: :class:`CreateIpAccessListResponse`
-        
+
 
     .. py:method:: delete(ip_access_list_id: str)
 
@@ -81,8 +81,8 @@
         :param ip_access_list_id: str
           The ID for the corresponding IP access list
         
-        
-        
+
+
 
     .. py:method:: get(ip_access_list_id: str) -> FetchIpAccessListResponse
 
@@ -115,7 +115,7 @@
           The ID for the corresponding IP access list
         
         :returns: :class:`FetchIpAccessListResponse`
-        
+
 
     .. py:method:: list() -> Iterator[IpAccessListInfo]
 
@@ -135,7 +135,7 @@
         Gets all IP access lists for the specified workspace.
         
         :returns: Iterator over :class:`IpAccessListInfo`
-        
+
 
     .. py:method:: replace(ip_access_list_id: str, label: str, list_type: ListType, enabled: bool [, ip_addresses: Optional[List[str]]])
 
@@ -190,8 +190,8 @@
           Specifies whether this IP access list is enabled.
         :param ip_addresses: List[str] (optional)
         
-        
-        
+
+
 
     .. py:method:: update(ip_access_list_id: str [, enabled: Optional[bool], ip_addresses: Optional[List[str]], label: Optional[str], list_type: Optional[ListType]])
 
@@ -225,5 +225,4 @@
           * `ALLOW`: An allow list. Include this IP or range. * `BLOCK`: A block list. Exclude this IP or
           range. IP addresses in the block list are excluded even if they are included in an allow list.
         
-        
-        
+

--- a/docs/workspace/settings/notification_destinations.rst
+++ b/docs/workspace/settings/notification_destinations.rst
@@ -21,7 +21,7 @@
           The display name for the notification destination.
         
         :returns: :class:`NotificationDestination`
-        
+
 
     .. py:method:: delete(id: str)
 
@@ -31,8 +31,8 @@
         
         :param id: str
         
-        
-        
+
+
 
     .. py:method:: get(id: str) -> NotificationDestination
 
@@ -43,7 +43,7 @@
         :param id: str
         
         :returns: :class:`NotificationDestination`
-        
+
 
     .. py:method:: list( [, page_size: Optional[int], page_token: Optional[str]]) -> Iterator[ListNotificationDestinationsResult]
 
@@ -55,7 +55,7 @@
         :param page_token: str (optional)
         
         :returns: Iterator over :class:`ListNotificationDestinationsResult`
-        
+
 
     .. py:method:: update(id: str [, config: Optional[Config], display_name: Optional[str]]) -> NotificationDestination
 
@@ -72,4 +72,3 @@
           The display name for the notification destination.
         
         :returns: :class:`NotificationDestination`
-        

--- a/docs/workspace/settings/restrict_workspace_admins.rst
+++ b/docs/workspace/settings/restrict_workspace_admins.rst
@@ -31,7 +31,7 @@
           request, and pass it with the DELETE request to identify the rule set version you are deleting.
         
         :returns: :class:`DeleteRestrictWorkspaceAdminsSettingResponse`
-        
+
 
     .. py:method:: get( [, etag: Optional[str]]) -> RestrictWorkspaceAdminsSetting
 
@@ -47,7 +47,7 @@
           request, and pass it with the DELETE request to identify the rule set version you are deleting.
         
         :returns: :class:`RestrictWorkspaceAdminsSetting`
-        
+
 
     .. py:method:: update(allow_missing: bool, setting: RestrictWorkspaceAdminsSetting, field_mask: str) -> RestrictWorkspaceAdminsSetting
 
@@ -67,4 +67,3 @@
           multiple fields in the field mask, use comma as the separator (no space).
         
         :returns: :class:`RestrictWorkspaceAdminsSetting`
-        

--- a/docs/workspace/settings/token_management.rst
+++ b/docs/workspace/settings/token_management.rst
@@ -44,7 +44,7 @@
           The number of seconds before the token expires.
         
         :returns: :class:`CreateOboTokenResponse`
-        
+
 
     .. py:method:: delete(token_id: str)
 
@@ -55,8 +55,8 @@
         :param token_id: str
           The ID of the token to revoke.
         
-        
-        
+
+
 
     .. py:method:: get(token_id: str) -> GetTokenResponse
 
@@ -93,7 +93,7 @@
           The ID of the token to get.
         
         :returns: :class:`GetTokenResponse`
-        
+
 
     .. py:method:: get_permission_levels() -> GetTokenPermissionLevelsResponse
 
@@ -102,7 +102,7 @@
         Gets the permission levels that a user can have on an object.
         
         :returns: :class:`GetTokenPermissionLevelsResponse`
-        
+
 
     .. py:method:: get_permissions() -> TokenPermissions
 
@@ -111,7 +111,7 @@
         Gets the permissions of all tokens. Tokens can inherit permissions from their root object.
         
         :returns: :class:`TokenPermissions`
-        
+
 
     .. py:method:: list( [, created_by_id: Optional[int], created_by_username: Optional[str]]) -> Iterator[TokenInfo]
 
@@ -137,7 +137,7 @@
           Username of the user that created the token.
         
         :returns: Iterator over :class:`TokenInfo`
-        
+
 
     .. py:method:: set_permissions( [, access_control_list: Optional[List[TokenAccessControlRequest]]]) -> TokenPermissions
 
@@ -149,7 +149,7 @@
         :param access_control_list: List[:class:`TokenAccessControlRequest`] (optional)
         
         :returns: :class:`TokenPermissions`
-        
+
 
     .. py:method:: update_permissions( [, access_control_list: Optional[List[TokenAccessControlRequest]]]) -> TokenPermissions
 
@@ -160,4 +160,3 @@
         :param access_control_list: List[:class:`TokenAccessControlRequest`] (optional)
         
         :returns: :class:`TokenPermissions`
-        

--- a/docs/workspace/settings/tokens.rst
+++ b/docs/workspace/settings/tokens.rst
@@ -39,7 +39,7 @@
           If the lifetime is not specified, this token remains valid indefinitely.
         
         :returns: :class:`CreateTokenResponse`
-        
+
 
     .. py:method:: delete(token_id: str)
 
@@ -52,8 +52,8 @@
         :param token_id: str
           The ID of the token to be revoked.
         
-        
-        
+
+
 
     .. py:method:: list() -> Iterator[PublicTokenInfo]
 
@@ -73,4 +73,3 @@
         Lists all the valid tokens for a user-workspace pair.
         
         :returns: Iterator over :class:`PublicTokenInfo`
-        

--- a/docs/workspace/settings/workspace_conf.rst
+++ b/docs/workspace/settings/workspace_conf.rst
@@ -26,7 +26,7 @@
         :param keys: str
         
         :returns: Dict[str,str]
-        
+
 
     .. py:method:: set_status(contents: Dict[str, str])
 
@@ -35,5 +35,4 @@
         Sets the configuration status for a workspace, including enabling or disabling it.
         
         
-        
-        
+

--- a/docs/workspace/sharing/providers.rst
+++ b/docs/workspace/sharing/providers.rst
@@ -47,7 +47,7 @@
           This field is required when the __authentication_type__ is **TOKEN** or not provided.
         
         :returns: :class:`ProviderInfo`
-        
+
 
     .. py:method:: delete(name: str)
 
@@ -59,8 +59,8 @@
         :param name: str
           Name of the provider.
         
-        
-        
+
+
 
     .. py:method:: get(name: str) -> ProviderInfo
 
@@ -98,7 +98,7 @@
           Name of the provider.
         
         :returns: :class:`ProviderInfo`
-        
+
 
     .. py:method:: list( [, data_provider_global_metastore_id: Optional[str], max_results: Optional[int], page_token: Optional[str]]) -> Iterator[ProviderInfo]
 
@@ -135,7 +135,7 @@
           Opaque pagination token to go to next page based on previous query.
         
         :returns: Iterator over :class:`ProviderInfo`
-        
+
 
     .. py:method:: list_shares(name: str [, max_results: Optional[int], page_token: Optional[str]]) -> Iterator[ProviderShare]
 
@@ -184,7 +184,7 @@
           Opaque pagination token to go to next page based on previous query.
         
         :returns: Iterator over :class:`ProviderShare`
-        
+
 
     .. py:method:: update(name: str [, comment: Optional[str], new_name: Optional[str], owner: Optional[str], recipient_profile_str: Optional[str]]) -> ProviderInfo
 
@@ -231,4 +231,3 @@
           This field is required when the __authentication_type__ is **TOKEN** or not provided.
         
         :returns: :class:`ProviderInfo`
-        

--- a/docs/workspace/sharing/recipient_activation.rst
+++ b/docs/workspace/sharing/recipient_activation.rst
@@ -21,8 +21,8 @@
         :param activation_url: str
           The one time activation url. It also accepts activation token.
         
-        
-        
+
+
 
     .. py:method:: retrieve_token(activation_url: str) -> RetrieveTokenResponse
 
@@ -34,4 +34,3 @@
           The one time activation url. It also accepts activation token.
         
         :returns: :class:`RetrieveTokenResponse`
-        

--- a/docs/workspace/sharing/recipients.rst
+++ b/docs/workspace/sharing/recipients.rst
@@ -64,7 +64,7 @@
           __authentication_type__ is **DATABRICKS**.
         
         :returns: :class:`RecipientInfo`
-        
+
 
     .. py:method:: delete(name: str)
 
@@ -75,8 +75,8 @@
         :param name: str
           Name of the recipient.
         
-        
-        
+
+
 
     .. py:method:: get(name: str) -> RecipientInfo
 
@@ -108,7 +108,7 @@
           Name of the recipient.
         
         :returns: :class:`RecipientInfo`
-        
+
 
     .. py:method:: list( [, data_recipient_global_metastore_id: Optional[str], max_results: Optional[int], page_token: Optional[str]]) -> Iterator[RecipientInfo]
 
@@ -146,7 +146,7 @@
           Opaque pagination token to go to next page based on previous query.
         
         :returns: Iterator over :class:`RecipientInfo`
-        
+
 
     .. py:method:: rotate_token(name: str, existing_token_expire_in_seconds: int) -> RecipientInfo
 
@@ -181,7 +181,7 @@
           the existing token immediately, negative number will return an error.
         
         :returns: :class:`RecipientInfo`
-        
+
 
     .. py:method:: share_permissions(name: str [, max_results: Optional[int], page_token: Optional[str]]) -> GetRecipientSharePermissionsResponse
 
@@ -222,7 +222,7 @@
           Opaque pagination token to go to next page based on previous query.
         
         :returns: :class:`GetRecipientSharePermissionsResponse`
-        
+
 
     .. py:method:: update(name: str [, comment: Optional[str], expiration_time: Optional[int], ip_access_list: Optional[IpAccessList], new_name: Optional[str], owner: Optional[str], properties_kvpairs: Optional[SecurablePropertiesKvPairs]])
 
@@ -267,5 +267,4 @@
           specified properties will override the existing properties. To add and remove properties, one would
           need to perform a read-modify-write.
         
-        
-        
+

--- a/docs/workspace/sharing/shares.rst
+++ b/docs/workspace/sharing/shares.rst
@@ -40,7 +40,7 @@
           Storage root URL for the share.
         
         :returns: :class:`ShareInfo`
-        
+
 
     .. py:method:: delete(name: str)
 
@@ -51,8 +51,8 @@
         :param name: str
           The name of the share.
         
-        
-        
+
+
 
     .. py:method:: get(name: str [, include_shared_data: Optional[bool]]) -> ShareInfo
 
@@ -85,7 +85,7 @@
           Query for data to include in the share.
         
         :returns: :class:`ShareInfo`
-        
+
 
     .. py:method:: list( [, max_results: Optional[int], page_token: Optional[str]]) -> Iterator[ShareInfo]
 
@@ -118,7 +118,7 @@
           Opaque pagination token to go to next page based on previous query.
         
         :returns: Iterator over :class:`ShareInfo`
-        
+
 
     .. py:method:: share_permissions(name: str [, max_results: Optional[int], page_token: Optional[str]]) -> catalog.PermissionsList
 
@@ -141,7 +141,7 @@
           Opaque pagination token to go to next page based on previous query.
         
         :returns: :class:`PermissionsList`
-        
+
 
     .. py:method:: update(name: str [, comment: Optional[str], new_name: Optional[str], owner: Optional[str], storage_root: Optional[str], updates: Optional[List[SharedDataObjectUpdate]]]) -> ShareInfo
 
@@ -220,7 +220,7 @@
           Array of shared data object updates.
         
         :returns: :class:`ShareInfo`
-        
+
 
     .. py:method:: update_permissions(name: str [, changes: Optional[List[catalog.PermissionsChange]], max_results: Optional[int], page_token: Optional[str]])
 
@@ -247,5 +247,4 @@
         :param page_token: str (optional)
           Opaque pagination token to go to next page based on previous query.
         
-        
-        
+

--- a/docs/workspace/sql/alerts.rst
+++ b/docs/workspace/sql/alerts.rst
@@ -51,7 +51,7 @@
         :param alert: :class:`CreateAlertRequestAlert` (optional)
         
         :returns: :class:`Alert`
-        
+
 
     .. py:method:: delete(id: str)
 
@@ -63,8 +63,8 @@
         
         :param id: str
         
-        
-        
+
+
 
     .. py:method:: get(id: str) -> Alert
 
@@ -110,7 +110,7 @@
         :param id: str
         
         :returns: :class:`Alert`
-        
+
 
     .. py:method:: list( [, page_size: Optional[int], page_token: Optional[str]]) -> Iterator[ListAlertsResponseAlert]
 
@@ -135,7 +135,7 @@
         :param page_token: str (optional)
         
         :returns: Iterator over :class:`ListAlertsResponseAlert`
-        
+
 
     .. py:method:: update(id: str, update_mask: str [, alert: Optional[UpdateAlertRequestAlert]]) -> Alert
 
@@ -188,4 +188,3 @@
         :param alert: :class:`UpdateAlertRequestAlert` (optional)
         
         :returns: :class:`Alert`
-        

--- a/docs/workspace/sql/alerts_legacy.rst
+++ b/docs/workspace/sql/alerts_legacy.rst
@@ -39,7 +39,7 @@
           If `null`, alert will never be triggered again.
         
         :returns: :class:`LegacyAlert`
-        
+
 
     .. py:method:: delete(alert_id: str)
 
@@ -55,8 +55,8 @@
         
         :param alert_id: str
         
-        
-        
+
+
 
     .. py:method:: get(alert_id: str) -> LegacyAlert
 
@@ -72,7 +72,7 @@
         :param alert_id: str
         
         :returns: :class:`LegacyAlert`
-        
+
 
     .. py:method:: list() -> Iterator[LegacyAlert]
 
@@ -86,7 +86,7 @@
         [Learn more]: https://docs.databricks.com/en/sql/dbsql-api-latest.html
         
         :returns: Iterator over :class:`LegacyAlert`
-        
+
 
     .. py:method:: update(alert_id: str, name: str, options: AlertOptions, query_id: str [, rearm: Optional[int]])
 
@@ -110,5 +110,4 @@
           Number of seconds after being triggered before the alert rearms itself and can be triggered again.
           If `null`, alert will never be triggered again.
         
-        
-        
+

--- a/docs/workspace/sql/dashboard_widgets.rst
+++ b/docs/workspace/sql/dashboard_widgets.rst
@@ -23,7 +23,7 @@
           Query Vizualization ID returned by :method:queryvisualizations/create.
         
         :returns: :class:`Widget`
-        
+
 
     .. py:method:: delete(id: str)
 
@@ -32,8 +32,8 @@
         :param id: str
           Widget ID returned by :method:dashboardwidgets/create
         
-        
-        
+
+
 
     .. py:method:: update(id: str, dashboard_id: str, options: WidgetOptions, width: int [, text: Optional[str], visualization_id: Optional[str]]) -> Widget
 
@@ -53,4 +53,3 @@
           Query Vizualization ID returned by :method:queryvisualizations/create.
         
         :returns: :class:`Widget`
-        

--- a/docs/workspace/sql/dashboards.rst
+++ b/docs/workspace/sql/dashboards.rst
@@ -44,7 +44,7 @@
         :param tags: List[str] (optional)
         
         :returns: :class:`Dashboard`
-        
+
 
     .. py:method:: delete(dashboard_id: str)
 
@@ -73,8 +73,8 @@
         
         :param dashboard_id: str
         
-        
-        
+
+
 
     .. py:method:: get(dashboard_id: str) -> Dashboard
 
@@ -103,7 +103,7 @@
         :param dashboard_id: str
         
         :returns: :class:`Dashboard`
-        
+
 
     .. py:method:: list( [, order: Optional[ListOrder], page: Optional[int], page_size: Optional[int], q: Optional[str]]) -> Iterator[Dashboard]
 
@@ -136,7 +136,7 @@
           Full text search term.
         
         :returns: Iterator over :class:`Dashboard`
-        
+
 
     .. py:method:: restore(dashboard_id: str)
 
@@ -164,8 +164,8 @@
         
         :param dashboard_id: str
         
-        
-        
+
+
 
     .. py:method:: update(dashboard_id: str [, name: Optional[str], run_as_role: Optional[RunAsRole], tags: Optional[List[str]]]) -> Dashboard
 
@@ -185,4 +185,3 @@
         :param tags: List[str] (optional)
         
         :returns: :class:`Dashboard`
-        

--- a/docs/workspace/sql/data_sources.rst
+++ b/docs/workspace/sql/data_sources.rst
@@ -41,4 +41,3 @@
         [Learn more]: https://docs.databricks.com/en/sql/dbsql-api-latest.html
         
         :returns: Iterator over :class:`DataSource`
-        

--- a/docs/workspace/sql/dbsql_permissions.rst
+++ b/docs/workspace/sql/dbsql_permissions.rst
@@ -37,7 +37,7 @@
           Object ID. An ACL is returned for the object with this UUID.
         
         :returns: :class:`GetResponse`
-        
+
 
     .. py:method:: set(object_type: ObjectTypePlural, object_id: str [, access_control_list: Optional[List[AccessControl]]]) -> SetResponse
 
@@ -58,7 +58,7 @@
         :param access_control_list: List[:class:`AccessControl`] (optional)
         
         :returns: :class:`SetResponse`
-        
+
 
     .. py:method:: transfer_ownership(object_type: OwnableObjectType, object_id: TransferOwnershipObjectId [, new_owner: Optional[str]]) -> Success
 
@@ -79,4 +79,3 @@
           Email address for the new owner, who must exist in the workspace.
         
         :returns: :class:`Success`
-        

--- a/docs/workspace/sql/queries.rst
+++ b/docs/workspace/sql/queries.rst
@@ -39,7 +39,7 @@
         :param query: :class:`CreateQueryRequestQuery` (optional)
         
         :returns: :class:`Query`
-        
+
 
     .. py:method:: delete(id: str)
 
@@ -51,8 +51,8 @@
         
         :param id: str
         
-        
-        
+
+
 
     .. py:method:: get(id: str) -> Query
 
@@ -87,7 +87,7 @@
         :param id: str
         
         :returns: :class:`Query`
-        
+
 
     .. py:method:: list( [, page_size: Optional[int], page_token: Optional[str]]) -> Iterator[ListQueryObjectsResponseQuery]
 
@@ -100,7 +100,7 @@
         :param page_token: str (optional)
         
         :returns: Iterator over :class:`ListQueryObjectsResponseQuery`
-        
+
 
     .. py:method:: list_visualizations(id: str [, page_size: Optional[int], page_token: Optional[str]]) -> Iterator[Visualization]
 
@@ -113,7 +113,7 @@
         :param page_token: str (optional)
         
         :returns: Iterator over :class:`Visualization`
-        
+
 
     .. py:method:: update(id: str, update_mask: str [, query: Optional[UpdateQueryRequestQuery]]) -> Query
 
@@ -157,4 +157,3 @@
         :param query: :class:`UpdateQueryRequestQuery` (optional)
         
         :returns: :class:`Query`
-        

--- a/docs/workspace/sql/queries_legacy.rst
+++ b/docs/workspace/sql/queries_legacy.rst
@@ -54,7 +54,7 @@
         :param tags: List[str] (optional)
         
         :returns: :class:`LegacyQuery`
-        
+
 
     .. py:method:: delete(query_id: str)
 
@@ -70,8 +70,8 @@
         
         :param query_id: str
         
-        
-        
+
+
 
     .. py:method:: get(query_id: str) -> LegacyQuery
 
@@ -88,7 +88,7 @@
         :param query_id: str
         
         :returns: :class:`LegacyQuery`
-        
+
 
     .. py:method:: list( [, order: Optional[str], page: Optional[int], page_size: Optional[int], q: Optional[str]]) -> Iterator[LegacyQuery]
 
@@ -126,7 +126,7 @@
           Full text search term
         
         :returns: Iterator over :class:`LegacyQuery`
-        
+
 
     .. py:method:: restore(query_id: str)
 
@@ -142,8 +142,8 @@
         
         :param query_id: str
         
-        
-        
+
+
 
     .. py:method:: update(query_id: str [, data_source_id: Optional[str], description: Optional[str], name: Optional[str], options: Optional[Any], query: Optional[str], run_as_role: Optional[RunAsRole], tags: Optional[List[str]]]) -> LegacyQuery
 
@@ -180,4 +180,3 @@
         :param tags: List[str] (optional)
         
         :returns: :class:`LegacyQuery`
-        

--- a/docs/workspace/sql/query_history.rst
+++ b/docs/workspace/sql/query_history.rst
@@ -43,4 +43,3 @@
           %2B. This field is optional.
         
         :returns: :class:`ListQueriesResponse`
-        

--- a/docs/workspace/sql/query_visualizations.rst
+++ b/docs/workspace/sql/query_visualizations.rst
@@ -16,7 +16,7 @@
         :param visualization: :class:`CreateVisualizationRequestVisualization` (optional)
         
         :returns: :class:`Visualization`
-        
+
 
     .. py:method:: delete(id: str)
 
@@ -26,8 +26,8 @@
         
         :param id: str
         
-        
-        
+
+
 
     .. py:method:: update(id: str, update_mask: str [, visualization: Optional[UpdateVisualizationRequestVisualization]]) -> Visualization
 
@@ -43,4 +43,3 @@
         :param visualization: :class:`UpdateVisualizationRequestVisualization` (optional)
         
         :returns: :class:`Visualization`
-        

--- a/docs/workspace/sql/query_visualizations_legacy.rst
+++ b/docs/workspace/sql/query_visualizations_legacy.rst
@@ -36,7 +36,7 @@
           The name of the visualization that appears on dashboards and the query screen.
         
         :returns: :class:`LegacyVisualization`
-        
+
 
     .. py:method:: delete(id: str)
 
@@ -52,8 +52,8 @@
         :param id: str
           Widget ID returned by :method:queryvizualisations/create
         
-        
-        
+
+
 
     .. py:method:: update(id: str [, created_at: Optional[str], description: Optional[str], name: Optional[str], options: Optional[Any], query: Optional[LegacyQuery], type: Optional[str], updated_at: Optional[str]]) -> LegacyVisualization
 
@@ -82,4 +82,3 @@
         :param updated_at: str (optional)
         
         :returns: :class:`LegacyVisualization`
-        

--- a/docs/workspace/sql/statement_execution.rst
+++ b/docs/workspace/sql/statement_execution.rst
@@ -99,8 +99,8 @@
           The statement ID is returned upon successfully submitting a SQL statement, and is a required
           reference for all subsequent calls.
         
-        
-        
+
+
 
     .. py:method:: execute_statement(statement: str, warehouse_id: str [, byte_limit: Optional[int], catalog: Optional[str], disposition: Optional[Disposition], format: Optional[Format], on_wait_timeout: Optional[ExecuteStatementRequestOnWaitTimeout], parameters: Optional[List[StatementParameterListItem]], row_limit: Optional[int], schema: Optional[str], wait_timeout: Optional[str]]) -> StatementResponse
 
@@ -211,7 +211,7 @@
           timeout is reached.
         
         :returns: :class:`StatementResponse`
-        
+
 
     .. py:method:: get_statement(statement_id: str) -> StatementResponse
 
@@ -230,7 +230,7 @@
           reference for all subsequent calls.
         
         :returns: :class:`StatementResponse`
-        
+
 
     .. py:method:: get_statement_result_chunk_n(statement_id: str, chunk_index: int) -> ResultData
 
@@ -249,4 +249,3 @@
         :param chunk_index: int
         
         :returns: :class:`ResultData`
-        

--- a/docs/workspace/sql/warehouses.rst
+++ b/docs/workspace/sql/warehouses.rst
@@ -96,7 +96,7 @@
         :returns:
           Long-running operation waiter for :class:`GetWarehouseResponse`.
           See :method:wait_get_warehouse_running for more details.
-        
+
 
     .. py:method:: create_and_wait( [, auto_stop_mins: Optional[int], channel: Optional[Channel], cluster_size: Optional[str], creator_name: Optional[str], enable_photon: Optional[bool], enable_serverless_compute: Optional[bool], instance_profile_arn: Optional[str], max_num_clusters: Optional[int], min_num_clusters: Optional[int], name: Optional[str], spot_instance_policy: Optional[SpotInstancePolicy], tags: Optional[EndpointTags], warehouse_type: Optional[CreateWarehouseRequestWarehouseType], timeout: datetime.timedelta = 0:20:00]) -> GetWarehouseResponse
 
@@ -110,8 +110,8 @@
         :param id: str
           Required. Id of the SQL warehouse.
         
-        
-        
+
+
 
     .. py:method:: edit(id: str [, auto_stop_mins: Optional[int], channel: Optional[Channel], cluster_size: Optional[str], creator_name: Optional[str], enable_photon: Optional[bool], enable_serverless_compute: Optional[bool], instance_profile_arn: Optional[str], max_num_clusters: Optional[int], min_num_clusters: Optional[int], name: Optional[str], spot_instance_policy: Optional[SpotInstancePolicy], tags: Optional[EndpointTags], warehouse_type: Optional[EditWarehouseRequestWarehouseType]]) -> Wait[GetWarehouseResponse]
 
@@ -209,7 +209,7 @@
         :returns:
           Long-running operation waiter for :class:`GetWarehouseResponse`.
           See :method:wait_get_warehouse_running for more details.
-        
+
 
     .. py:method:: edit_and_wait(id: str [, auto_stop_mins: Optional[int], channel: Optional[Channel], cluster_size: Optional[str], creator_name: Optional[str], enable_photon: Optional[bool], enable_serverless_compute: Optional[bool], instance_profile_arn: Optional[str], max_num_clusters: Optional[int], min_num_clusters: Optional[int], name: Optional[str], spot_instance_policy: Optional[SpotInstancePolicy], tags: Optional[EndpointTags], warehouse_type: Optional[EditWarehouseRequestWarehouseType], timeout: datetime.timedelta = 0:20:00]) -> GetWarehouseResponse
 
@@ -250,7 +250,7 @@
           Required. Id of the SQL warehouse.
         
         :returns: :class:`GetWarehouseResponse`
-        
+
 
     .. py:method:: get_permission_levels(warehouse_id: str) -> GetWarehousePermissionLevelsResponse
 
@@ -262,7 +262,7 @@
           The SQL warehouse for which to get or manage permissions.
         
         :returns: :class:`GetWarehousePermissionLevelsResponse`
-        
+
 
     .. py:method:: get_permissions(warehouse_id: str) -> WarehousePermissions
 
@@ -275,7 +275,7 @@
           The SQL warehouse for which to get or manage permissions.
         
         :returns: :class:`WarehousePermissions`
-        
+
 
     .. py:method:: get_workspace_warehouse_config() -> GetWorkspaceWarehouseConfigResponse
 
@@ -284,7 +284,7 @@
         Gets the workspace level configuration that is shared by all SQL warehouses in a workspace.
         
         :returns: :class:`GetWorkspaceWarehouseConfigResponse`
-        
+
 
     .. py:method:: list( [, run_as_user_id: Optional[int]]) -> Iterator[EndpointInfo]
 
@@ -309,7 +309,7 @@
           from the session header is used.
         
         :returns: Iterator over :class:`EndpointInfo`
-        
+
 
     .. py:method:: set_permissions(warehouse_id: str [, access_control_list: Optional[List[WarehouseAccessControlRequest]]]) -> WarehousePermissions
 
@@ -323,7 +323,7 @@
         :param access_control_list: List[:class:`WarehouseAccessControlRequest`] (optional)
         
         :returns: :class:`WarehousePermissions`
-        
+
 
     .. py:method:: set_workspace_warehouse_config( [, channel: Optional[Channel], config_param: Optional[RepeatedEndpointConfPairs], data_access_config: Optional[List[EndpointConfPair]], enabled_warehouse_types: Optional[List[WarehouseTypePair]], global_param: Optional[RepeatedEndpointConfPairs], google_service_account: Optional[str], instance_profile_arn: Optional[str], security_policy: Optional[SetWorkspaceWarehouseConfigRequestSecurityPolicy], sql_configuration_parameters: Optional[RepeatedEndpointConfPairs]])
 
@@ -354,8 +354,8 @@
         :param sql_configuration_parameters: :class:`RepeatedEndpointConfPairs` (optional)
           SQL configuration parameters
         
-        
-        
+
+
 
     .. py:method:: start(id: str) -> Wait[GetWarehouseResponse]
 
@@ -369,7 +369,7 @@
         :returns:
           Long-running operation waiter for :class:`GetWarehouseResponse`.
           See :method:wait_get_warehouse_running for more details.
-        
+
 
     .. py:method:: start_and_wait(id: str, timeout: datetime.timedelta = 0:20:00) -> GetWarehouseResponse
 
@@ -386,7 +386,7 @@
         :returns:
           Long-running operation waiter for :class:`GetWarehouseResponse`.
           See :method:wait_get_warehouse_stopped for more details.
-        
+
 
     .. py:method:: stop_and_wait(id: str, timeout: datetime.timedelta = 0:20:00) -> GetWarehouseResponse
 
@@ -403,7 +403,7 @@
         :param access_control_list: List[:class:`WarehouseAccessControlRequest`] (optional)
         
         :returns: :class:`WarehousePermissions`
-        
+
 
     .. py:method:: wait_get_warehouse_running(id: str, timeout: datetime.timedelta = 0:20:00, callback: Optional[Callable[[GetWarehouseResponse], None]]) -> GetWarehouseResponse
 

--- a/docs/workspace/vectorsearch/vector_search_endpoints.rst
+++ b/docs/workspace/vectorsearch/vector_search_endpoints.rst
@@ -20,7 +20,7 @@
         :returns:
           Long-running operation waiter for :class:`EndpointInfo`.
           See :method:wait_get_endpoint_vector_search_endpoint_online for more details.
-        
+
 
     .. py:method:: create_endpoint_and_wait(name: str, endpoint_type: EndpointType, timeout: datetime.timedelta = 0:20:00) -> EndpointInfo
 
@@ -32,8 +32,8 @@
         :param endpoint_name: str
           Name of the endpoint
         
-        
-        
+
+
 
     .. py:method:: get_endpoint(endpoint_name: str) -> EndpointInfo
 
@@ -43,7 +43,7 @@
           Name of the endpoint
         
         :returns: :class:`EndpointInfo`
-        
+
 
     .. py:method:: list_endpoints( [, page_token: Optional[str]]) -> Iterator[EndpointInfo]
 
@@ -53,6 +53,6 @@
           Token for pagination
         
         :returns: Iterator over :class:`EndpointInfo`
-        
+
 
     .. py:method:: wait_get_endpoint_vector_search_endpoint_online(endpoint_name: str, timeout: datetime.timedelta = 0:20:00, callback: Optional[Callable[[EndpointInfo], None]]) -> EndpointInfo

--- a/docs/workspace/vectorsearch/vector_search_indexes.rst
+++ b/docs/workspace/vectorsearch/vector_search_indexes.rst
@@ -37,7 +37,7 @@
           Specification for Direct Vector Access Index. Required if `index_type` is `DIRECT_ACCESS`.
         
         :returns: :class:`CreateVectorIndexResponse`
-        
+
 
     .. py:method:: delete_data_vector_index(index_name: str, primary_keys: List[str]) -> DeleteDataVectorIndexResponse
 
@@ -51,7 +51,7 @@
           List of primary keys for the data to be deleted.
         
         :returns: :class:`DeleteDataVectorIndexResponse`
-        
+
 
     .. py:method:: delete_index(index_name: str)
 
@@ -62,8 +62,8 @@
         :param index_name: str
           Name of the index
         
-        
-        
+
+
 
     .. py:method:: get_index(index_name: str) -> VectorIndex
 
@@ -75,7 +75,7 @@
           Name of the index
         
         :returns: :class:`VectorIndex`
-        
+
 
     .. py:method:: list_indexes(endpoint_name: str [, page_token: Optional[str]]) -> Iterator[MiniVectorIndex]
 
@@ -89,7 +89,7 @@
           Token for pagination
         
         :returns: Iterator over :class:`MiniVectorIndex`
-        
+
 
     .. py:method:: query_index(index_name: str, columns: List[str] [, filters_json: Optional[str], num_results: Optional[int], query_text: Optional[str], query_type: Optional[str], query_vector: Optional[List[float]], score_threshold: Optional[float]]) -> QueryVectorIndexResponse
 
@@ -120,7 +120,7 @@
           Threshold for the approximate nearest neighbor search. Defaults to 0.0.
         
         :returns: :class:`QueryVectorIndexResponse`
-        
+
 
     .. py:method:: query_next_page(index_name: str [, endpoint_name: Optional[str], page_token: Optional[str]]) -> QueryVectorIndexResponse
 
@@ -137,7 +137,7 @@
           Page token returned from previous `QueryVectorIndex` or `QueryVectorIndexNextPage` API.
         
         :returns: :class:`QueryVectorIndexResponse`
-        
+
 
     .. py:method:: scan_index(index_name: str [, last_primary_key: Optional[str], num_results: Optional[int]]) -> ScanVectorIndexResponse
 
@@ -154,7 +154,7 @@
           Number of results to return. Defaults to 10.
         
         :returns: :class:`ScanVectorIndexResponse`
-        
+
 
     .. py:method:: sync_index(index_name: str)
 
@@ -165,8 +165,8 @@
         :param index_name: str
           Name of the vector index to synchronize. Must be a Delta Sync Index.
         
-        
-        
+
+
 
     .. py:method:: upsert_data_vector_index(index_name: str, inputs_json: str) -> UpsertDataVectorIndexResponse
 
@@ -180,4 +180,3 @@
           JSON string representing the data to be upserted.
         
         :returns: :class:`UpsertDataVectorIndexResponse`
-        

--- a/docs/workspace/workspace/git_credentials.rst
+++ b/docs/workspace/workspace/git_credentials.rst
@@ -49,7 +49,7 @@
           [Learn more]: https://docs.databricks.com/repos/get-access-tokens-from-git-provider.html
         
         :returns: :class:`CreateCredentialsResponse`
-        
+
 
     .. py:method:: delete(credential_id: int)
 
@@ -60,8 +60,8 @@
         :param credential_id: int
           The ID for the corresponding credential to access.
         
-        
-        
+
+
 
     .. py:method:: get(credential_id: int) -> GetCredentialsResponse
 
@@ -89,7 +89,7 @@
           The ID for the corresponding credential to access.
         
         :returns: :class:`GetCredentialsResponse`
-        
+
 
     .. py:method:: list() -> Iterator[CredentialInfo]
 
@@ -109,7 +109,7 @@
         Lists the calling user's Git credentials. One credential per user is supported.
         
         :returns: Iterator over :class:`CredentialInfo`
-        
+
 
     .. py:method:: update(credential_id: int, git_provider: str [, git_username: Optional[str], personal_access_token: Optional[str]])
 
@@ -156,5 +156,4 @@
           
           [Learn more]: https://docs.databricks.com/repos/get-access-tokens-from-git-provider.html
         
-        
-        
+

--- a/docs/workspace/workspace/repos.rst
+++ b/docs/workspace/workspace/repos.rst
@@ -53,7 +53,7 @@
           sparse checkout after the repo is created.
         
         :returns: :class:`CreateRepoResponse`
-        
+
 
     .. py:method:: delete(repo_id: int)
 
@@ -64,8 +64,8 @@
         :param repo_id: int
           The ID for the corresponding repo to delete.
         
-        
-        
+
+
 
     .. py:method:: get(repo_id: int) -> GetRepoResponse
 
@@ -97,7 +97,7 @@
           ID of the Git folder (repo) object in the workspace.
         
         :returns: :class:`GetRepoResponse`
-        
+
 
     .. py:method:: get_permission_levels(repo_id: str) -> GetRepoPermissionLevelsResponse
 
@@ -109,7 +109,7 @@
           The repo for which to get or manage permissions.
         
         :returns: :class:`GetRepoPermissionLevelsResponse`
-        
+
 
     .. py:method:: get_permissions(repo_id: str) -> RepoPermissions
 
@@ -121,7 +121,7 @@
           The repo for which to get or manage permissions.
         
         :returns: :class:`RepoPermissions`
-        
+
 
     .. py:method:: list( [, next_page_token: Optional[str], path_prefix: Optional[str]]) -> Iterator[RepoInfo]
 
@@ -151,7 +151,7 @@
           be served.
         
         :returns: Iterator over :class:`RepoInfo`
-        
+
 
     .. py:method:: set_permissions(repo_id: str [, access_control_list: Optional[List[RepoAccessControlRequest]]]) -> RepoPermissions
 
@@ -165,7 +165,7 @@
         :param access_control_list: List[:class:`RepoAccessControlRequest`] (optional)
         
         :returns: :class:`RepoPermissions`
-        
+
 
     .. py:method:: update(repo_id: int [, branch: Optional[str], sparse_checkout: Optional[SparseCheckoutUpdate], tag: Optional[str]])
 
@@ -206,8 +206,8 @@
           in a detached HEAD state. Before committing new changes, you must update the repo to a branch
           instead of the detached HEAD.
         
-        
-        
+
+
 
     .. py:method:: update_permissions(repo_id: str [, access_control_list: Optional[List[RepoAccessControlRequest]]]) -> RepoPermissions
 
@@ -220,4 +220,3 @@
         :param access_control_list: List[:class:`RepoAccessControlRequest`] (optional)
         
         :returns: :class:`RepoPermissions`
-        

--- a/docs/workspace/workspace/secrets.rst
+++ b/docs/workspace/workspace/secrets.rst
@@ -51,8 +51,8 @@
         :param scope_backend_type: :class:`ScopeBackendType` (optional)
           The backend type the scope will be created with. If not specified, will default to `DATABRICKS`
         
-        
-        
+
+
 
     .. py:method:: delete_acl(scope: str, principal: str)
 
@@ -69,8 +69,8 @@
         :param principal: str
           The principal to remove an existing ACL from.
         
-        
-        
+
+
 
     .. py:method:: delete_scope(scope: str)
 
@@ -84,8 +84,8 @@
         :param scope: str
           Name of the scope to delete.
         
-        
-        
+
+
 
     .. py:method:: delete_secret(scope: str, key: str)
 
@@ -102,8 +102,8 @@
         :param key: str
           Name of the secret to delete.
         
-        
-        
+
+
 
     .. py:method:: get_acl(scope: str, principal: str) -> AclItem
 
@@ -121,7 +121,7 @@
           The principal to fetch ACL information for.
         
         :returns: :class:`AclItem`
-        
+
 
     .. py:method:: get_secret(scope: str, key: str) -> GetSecretResponse
 
@@ -143,7 +143,7 @@
           The key to fetch secret for.
         
         :returns: :class:`GetSecretResponse`
-        
+
 
     .. py:method:: list_acls(scope: str) -> Iterator[AclItem]
 
@@ -181,7 +181,7 @@
           The name of the scope to fetch ACL information from.
         
         :returns: Iterator over :class:`AclItem`
-        
+
 
     .. py:method:: list_scopes() -> Iterator[SecretScope]
 
@@ -203,7 +203,7 @@
         Throws `PERMISSION_DENIED` if the user does not have permission to make this API call.
         
         :returns: Iterator over :class:`SecretScope`
-        
+
 
     .. py:method:: list_secrets(scope: str) -> Iterator[SecretMetadata]
 
@@ -243,7 +243,7 @@
           The name of the scope to list secrets within.
         
         :returns: Iterator over :class:`SecretMetadata`
-        
+
 
     .. py:method:: put_acl(scope: str, principal: str, permission: AclPermission)
 
@@ -308,8 +308,8 @@
         :param permission: :class:`AclPermission`
           The permission level applied to the principal.
         
-        
-        
+
+
 
     .. py:method:: put_secret(scope: str, key: str [, bytes_value: Optional[str], string_value: Optional[str]])
 
@@ -363,5 +363,4 @@
         :param string_value: str (optional)
           If specified, note that the value will be stored in UTF-8 (MB4) form.
         
-        
-        
+

--- a/docs/workspace/workspace/workspace.rst
+++ b/docs/workspace/workspace/workspace.rst
@@ -27,8 +27,8 @@
           note this deleting directory is not atomic. If it fails in the middle, some of objects under this
           directory may be deleted and cannot be undone.
         
-        
-        
+
+
 
     .. py:method:: download(path: str [, format: ExportFormat]) -> BinaryIO
 
@@ -56,14 +56,14 @@
 
         
         Downloads notebook or file from the workspace
-
+        
         :param path:     location of the file or notebook on workspace.
         :param format:   By default, `ExportFormat.SOURCE`. If using `ExportFormat.AUTO` the `path`
-                         is imported or exported as either a workspace file or a notebook, depending
-                         on an analysis of the `item`’s extension and the header content provided in
-                         the request.
+                 is imported or exported as either a workspace file or a notebook, depending
+                 on an analysis of the `item`’s extension and the header content provided in
+                 the request.
         :return:         file-like `io.BinaryIO` of the `path` contents.
-        
+
 
     .. py:method:: export(path: str [, format: Optional[ExportFormat]]) -> ExportResponse
 
@@ -108,7 +108,7 @@
           Directory exports will include notebooks and workspace files.
         
         :returns: :class:`ExportResponse`
-        
+
 
     .. py:method:: get_permission_levels(workspace_object_type: str, workspace_object_id: str) -> GetWorkspaceObjectPermissionLevelsResponse
 
@@ -122,7 +122,7 @@
           The workspace object for which to get or manage permissions.
         
         :returns: :class:`GetWorkspaceObjectPermissionLevelsResponse`
-        
+
 
     .. py:method:: get_permissions(workspace_object_type: str, workspace_object_id: str) -> WorkspaceObjectPermissions
 
@@ -137,7 +137,7 @@
           The workspace object for which to get or manage permissions.
         
         :returns: :class:`WorkspaceObjectPermissions`
-        
+
 
     .. py:method:: get_status(path: str) -> ObjectInfo
 
@@ -165,7 +165,7 @@
           The absolute path of the notebook or directory.
         
         :returns: :class:`ObjectInfo`
-        
+
 
     .. py:method:: import_(path: str [, content: Optional[str], format: Optional[ImportFormat], language: Optional[Language], overwrite: Optional[bool]])
 
@@ -223,8 +223,8 @@
           The flag that specifies whether to overwrite existing object. It is `false` by default. For `DBC`
           format, `overwrite` is not supported since it may contain a directory.
         
-        
-        
+
+
 
     .. py:method:: list(path: str [, notebooks_modified_after: int, recursive: bool = False]) -> ObjectInfo
 
@@ -243,12 +243,12 @@
             assert len(names) > 0
 
         List workspace objects
-
+        
         :param recursive: bool
             Optionally invoke recursive traversal
-
-        :returns: Iterator of workspaceObjectInfo
         
+        :returns: Iterator of workspaceObjectInfo
+
 
     .. py:method:: mkdirs(path: str)
 
@@ -265,8 +265,8 @@
           The absolute path of the directory. If the parent directories do not exist, it will also create
           them. If the directory already exists, this command will do nothing and succeed.
         
-        
-        
+
+
 
     .. py:method:: set_permissions(workspace_object_type: str, workspace_object_id: str [, access_control_list: Optional[List[WorkspaceObjectAccessControlRequest]]]) -> WorkspaceObjectPermissions
 
@@ -283,7 +283,7 @@
         :param access_control_list: List[:class:`WorkspaceObjectAccessControlRequest`] (optional)
         
         :returns: :class:`WorkspaceObjectPermissions`
-        
+
 
     .. py:method:: update_permissions(workspace_object_type: str, workspace_object_id: str [, access_control_list: Optional[List[WorkspaceObjectAccessControlRequest]]]) -> WorkspaceObjectPermissions
 
@@ -299,7 +299,7 @@
         :param access_control_list: List[:class:`WorkspaceObjectAccessControlRequest`] (optional)
         
         :returns: :class:`WorkspaceObjectPermissions`
-        
+
 
     .. py:method:: upload(path: str, content: bytes [, format: ImportFormat, language: Language, overwrite: bool = False])
 
@@ -327,17 +327,16 @@
         
         Uploads a workspace object (for example, a notebook or file) or the contents of an entire
         directory (`DBC` format).
-
+        
         Errors:
          * `RESOURCE_ALREADY_EXISTS`: if `path` already exists no `overwrite=True`.
          * `INVALID_PARAMETER_VALUE`: if `format` and `content` values are not compatible.
-
+        
         :param path:     target location of the file on workspace.
         :param content:  the contents as either raw binary data `bytes` or a file-like the file-like `io.BinaryIO` of the `path` contents.
         :param format:   By default, `ImportFormat.SOURCE`. If using `ImportFormat.AUTO` the `path`
-                         is imported or exported as either a workspace file or a notebook, depending
-                         on an analysis of the `item`’s extension and the header content provided in
-                         the request. In addition, if the `path` is imported as a notebook, then
-                         the `item`’s extension is automatically removed.
+                 is imported or exported as either a workspace file or a notebook, depending
+                 on an analysis of the `item`’s extension and the header content provided in
+                 the request. In addition, if the `path` is imported as a notebook, then
+                 the `item`’s extension is automatically removed.
         :param language: Only required if using `ExportFormat.SOURCE`.
-        


### PR DESCRIPTION
## What changes are proposed in this pull request?

Update Doc generation to fix formatting issue. In some computers, docstrings contain leading indentation, while in other it does not. This PR uses regex to consider both cases.

## How is this tested?

Regenerate in both computers
```
genkit generate-sdk --openapi-spec sha:a6a317df8327c9b1e5cb59a03a42ffa2aabeef6d
```