### PR TITLE
[Internal] Stop testing Python 3.7 on Ubuntu

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        pyVersion: [ '3.7', '3.8', '3.9', '3.10', '3.11', '3.12' ]
+        pyVersion: [ '3.8', '3.9', '3.10', '3.11', '3.12' ]
     with:
       os: ubuntu-latest
       pyVersion: ${{ matrix.pyVersion }}


### PR DESCRIPTION
## What changes are proposed in this pull request?

Python 3.7.x is essentially not supported;

- It has been removed from Windows 2019, Windows 2022, Ubuntu 20 and Ubuntu 22 images ([ref](https://github.com/actions/runner-images/issues/10893)).
- `unbuntu-latest` now points toward 24.04 which does not support Python 3.7.x ([ref](https://github.com/actions/runner-images/pull/11332))

 This PR updates our Ubuntu workflows to avoid this version.

## How is this tested?

N/A