### PR TITLE
[Fix] Properly pass query parameters in apps and oauth2

### DIFF
--- a/databricks/sdk/service/apps.py
+++ b/databricks/sdk/service/apps.py
@@ -981,6 +981,8 @@ class AppsAPI:
           See :method:wait_get_app_active for more details.
         """
         body = app.as_dict()
+        query = {}
+        if no_compute is not None: query['no_compute'] = no_compute
         headers = {'Accept': 'application/json', 'Content-Type': 'application/json', }
 
         op_response = self._api.do('POST', '/api/2.0/apps', query=query, body=body, headers=headers)

--- a/databricks/sdk/service/oauth2.py
+++ b/databricks/sdk/service/oauth2.py
@@ -950,6 +950,8 @@ class AccountFederationPolicyAPI:
         :returns: :class:`FederationPolicy`
         """
         body = policy.as_dict()
+        query = {}
+        if policy_id is not None: query['policy_id'] = policy_id
         headers = {'Accept': 'application/json', 'Content-Type': 'application/json', }
 
         res = self._api.do('POST',
@@ -1039,6 +1041,8 @@ class AccountFederationPolicyAPI:
         :returns: :class:`FederationPolicy`
         """
         body = policy.as_dict()
+        query = {}
+        if update_mask is not None: query['update_mask'] = update_mask
         headers = {'Accept': 'application/json', 'Content-Type': 'application/json', }
 
         res = self._api.do('PATCH',
@@ -1433,6 +1437,8 @@ class ServicePrincipalFederationPolicyAPI:
         :returns: :class:`FederationPolicy`
         """
         body = policy.as_dict()
+        query = {}
+        if policy_id is not None: query['policy_id'] = policy_id
         headers = {'Accept': 'application/json', 'Content-Type': 'application/json', }
 
         res = self._api.do(
@@ -1536,6 +1542,8 @@ class ServicePrincipalFederationPolicyAPI:
         :returns: :class:`FederationPolicy`
         """
         body = policy.as_dict()
+        query = {}
+        if update_mask is not None: query['update_mask'] = update_mask
         headers = {'Accept': 'application/json', 'Content-Type': 'application/json', }
 
         res = self._api.do(


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR properly passes query parameters in `apps` and `oauth2` API methods that are relying on inlined request bodies. 

## How is this tested?

This case is now properly tested by the SDK code generator. I've also verified that the API works as intended. 