### PR TITLE
[Internal] Add unit tests for external-browser authentication

### DIFF
--- a/databricks/sdk/credentials_provider.py
+++ b/databricks/sdk/credentials_provider.py
@@ -215,7 +215,6 @@ def external_browser(cfg: 'Config') -> Optional[CredentialsProvider]:
             # to detect if the token is expired and needs to be refreshed
             # by going through the OAuth login flow.
             credentials.token()
-            token_cache.save(credentials)
             return credentials(cfg)
         # TODO: We should ideally use more specific exceptions.
         except Exception as e:

--- a/databricks/sdk/credentials_provider.py
+++ b/databricks/sdk/credentials_provider.py
@@ -199,8 +199,8 @@ def external_browser(cfg: 'Config') -> Optional[CredentialsProvider]:
     if not client_id:
         client_id = 'databricks-cli'
 
-    # Load cached credentials from disk if they exist.
-    # Note that these are local to the Python SDK and not reused by other SDKs.
+    # Load cached credentials from disk if they exist. Note that these are 
+    # local to the Python SDK and not reused by other SDKs.
     oidc_endpoints = cfg.oidc_endpoints
     redirect_url = 'http://localhost:8020'
     token_cache = TokenCache(host=cfg.host,
@@ -210,10 +210,11 @@ def external_browser(cfg: 'Config') -> Optional[CredentialsProvider]:
                              redirect_url=redirect_url)
     credentials = token_cache.load()
     if credentials:
-        # Force a refresh in case the loaded credentials are expired.
-        # If the refresh fails, rather than throw exception we will initiate a new OAuth login flow.
         try:
-            credentials.token()
+            # Force a refresh in case the loaded credentials are expired.
+            # If the refresh fails, rather than throw exception we will 
+            # initiate a new OAuth login flow.
+            credentials.token()  # force a token refresh
             return credentials(cfg)
         # TODO: we should ideally use more specific exceptions.
         except Exception as e:

--- a/tests/test_credentials_provider.py
+++ b/tests/test_credentials_provider.py
@@ -1,0 +1,147 @@
+import pytest
+
+from unittest.mock import Mock
+from databricks.sdk.credentials_provider import external_browser
+
+def test_external_browser_refresh_success(mocker):
+    """Tests successful refresh of existing credentials."""
+
+    # 1. Mock Config
+    mock_cfg = Mock()
+    mock_cfg.auth_type = 'external-browser'
+    mock_cfg.host = 'test-host'
+    mock_cfg.oidc_endpoints = {'token_endpoint': 'test-token-endpoint'}
+    mock_cfg.client_id = 'test-client-id'  # Or use azure_client_id
+    mock_cfg.client_secret = 'test-client-secret'  # Or use azure_client_secret
+
+    # 2. Mock TokenCache
+    mock_token_cache = Mock()
+    mock_session_credentials = Mock()
+    mock_session_credentials.token.return_value = "valid_token"  # Simulate successful refresh
+    mock_token_cache.load.return_value = mock_session_credentials
+
+    mock_credentials_provider = Mock()
+    mock_session_credentials.return_value = mock_credentials_provider
+
+    # 3. Patch TokenCache (no need to mock OAuthClient in this case)
+    mocker.patch('databricks.sdk.credentials_provider.TokenCache', return_value=mock_token_cache)
+
+    # 4. Call the function
+    result = external_browser(mock_cfg)
+
+    # 5. Assertions
+    mock_token_cache.load.assert_called_once()
+    mock_session_credentials.token.assert_called_once()  # Verify token refresh was attempted
+    assert result == mock_credentials_provider
+
+
+def test_external_browser_refresh_failure_new_oauth_flow(mocker):
+    """Tests failed refresh, triggering a new OAuth flow."""
+
+    # 1. Mock Config
+    mock_cfg = Mock()
+    mock_cfg.auth_type = 'external-browser'
+    mock_cfg.host = 'test-host'
+    mock_cfg.oidc_endpoints = {'token_endpoint': 'test-token-endpoint'}
+    mock_cfg.client_id = 'test-client-id'
+    mock_cfg.client_secret = 'test-client-secret'
+
+    # 2. Mock TokenCache
+    mock_token_cache = Mock()
+    mock_session_credentials = Mock()
+    mock_session_credentials.token.side_effect = Exception("Simulated refresh error")  # Simulate a failed refresh
+    mock_token_cache.load.return_value = mock_session_credentials
+
+    mock_credentials_provider = Mock()
+    mock_session_credentials.return_value = mock_credentials_provider
+
+    # 3. Mock OAuthClient
+    mock_oauth_client = Mock()
+    mock_consent = Mock()
+    mock_consent.launch_external_browser.return_value = mock_session_credentials  # Simulate successful OAuth flow
+    mock_oauth_client.initiate_consent.return_value = mock_consent
+
+    # 4. Patch TokenCache and OAuthClient
+    mocker.patch('databricks.sdk.credentials_provider.TokenCache', return_value=mock_token_cache)
+    mocker.patch('databricks.sdk.credentials_provider.OAuthClient', return_value=mock_oauth_client)
+
+    # 5. Call the function
+    result = external_browser(mock_cfg)
+
+    # 6. Assertions
+    mock_token_cache.load.assert_called_once()
+    mock_session_credentials.token.assert_called_once()  # Refresh attempt
+    mock_oauth_client.initiate_consent.assert_called_once()
+    mock_consent.launch_external_browser.assert_called_once()
+    mock_token_cache.save.assert_called_once_with(mock_session_credentials)
+    assert result == mock_credentials_provider
+
+
+def test_external_browser_no_cached_credentials(mocker):
+    """Tests the case where there are no cached credentials, initiating a new OAuth flow."""
+
+    # 1. Mock Config
+    mock_cfg = Mock()
+    mock_cfg.auth_type = 'external-browser'
+    mock_cfg.host = 'test-host'
+    mock_cfg.oidc_endpoints = {'token_endpoint': 'test-token-endpoint'}
+    mock_cfg.client_id = 'test-client-id'
+    mock_cfg.client_secret = 'test-client-secret'
+
+    # 2. Mock TokenCache
+    mock_token_cache = Mock()
+    mock_token_cache.load.return_value = None  # No cached credentials
+
+    mock_session_credentials = lambda c: "new_credentials"
+
+    # 3. Mock OAuthClient
+    mock_consent = Mock()
+    mock_consent.launch_external_browser.return_value = mock_session_credentials
+    mock_oauth_client = Mock()
+    mock_oauth_client.initiate_consent.return_value = mock_consent
+
+    # 4. Patch TokenCache and OAuthClient
+    mocker.patch('databricks.sdk.credentials_provider.TokenCache', return_value=mock_token_cache)
+    mocker.patch('databricks.sdk.credentials_provider.OAuthClient', return_value=mock_oauth_client)
+
+    # 5. Call the function
+    result = external_browser(mock_cfg)
+
+    # 6. Assertions
+    mock_token_cache.load.assert_called_once()
+    mock_oauth_client.initiate_consent.assert_called_once()
+    mock_consent.launch_external_browser.assert_called_once()
+    mock_token_cache.save.assert_called_once_with(mock_session_credentials)
+    assert result == "new_credentials"
+
+
+def test_external_browser_consent_fails(mocker):
+    """Tests the case where OAuth consent initiation fails."""
+
+    # 1. Mock Config
+    mock_cfg = Mock()
+    mock_cfg.auth_type = 'external-browser'
+    mock_cfg.host = 'test-host'
+    mock_cfg.oidc_endpoints = {'token_endpoint': 'test-token-endpoint'}
+    mock_cfg.client_id = 'test-client-id'
+    mock_cfg.client_secret = 'test-client-secret'
+
+    # 2. Mock TokenCache
+    mock_token_cache = Mock()
+    mock_token_cache.load.return_value = None  # No cached credentials
+
+    # 3. Mock OAuthClient
+    mock_oauth_client = Mock()
+    mock_oauth_client.initiate_consent.return_value = None  # Simulate consent failure
+
+    # 4. Patch TokenCache and OAuthClient
+    mocker.patch('databricks.sdk.credentials_provider.TokenCache', return_value=mock_token_cache)
+    mocker.patch('databricks.sdk.credentials_provider.OAuthClient', return_value=mock_oauth_client)
+
+    # 5. Call the function
+    result = external_browser(mock_cfg)
+
+    # 6. Assertions
+    mock_token_cache.load.assert_called_once()
+    mock_oauth_client.initiate_consent.assert_called_once()
+    assert result is None

--- a/tests/test_credentials_provider.py
+++ b/tests/test_credentials_provider.py
@@ -30,7 +30,6 @@ def test_external_browser_refresh_success(mocker):
     got_credentials_provider = external_browser(mock_cfg)
 
     mock_token_cache.load.assert_called_once()
-    mock_token_cache.save.assert_called_once_with(mock_session_credentials)
     mock_session_credentials.token.assert_called_once() # Verify token refresh was attempted
     assert got_credentials_provider == want_credentials_provider
 

--- a/tests/test_credentials_provider.py
+++ b/tests/test_credentials_provider.py
@@ -1,44 +1,44 @@
-import pytest
-
 from unittest.mock import Mock
+
 from databricks.sdk.credentials_provider import external_browser
+
 
 def test_external_browser_refresh_success(mocker):
     """Tests successful refresh of existing credentials."""
 
-    # 1. Mock Config
+    # Mock Config.
     mock_cfg = Mock()
     mock_cfg.auth_type = 'external-browser'
     mock_cfg.host = 'test-host'
     mock_cfg.oidc_endpoints = {'token_endpoint': 'test-token-endpoint'}
-    mock_cfg.client_id = 'test-client-id'  # Or use azure_client_id
-    mock_cfg.client_secret = 'test-client-secret'  # Or use azure_client_secret
+    mock_cfg.client_id = 'test-client-id' # Or use azure_client_id
+    mock_cfg.client_secret = 'test-client-secret' # Or use azure_client_secret
 
-    # 2. Mock TokenCache
+    # Mock TokenCache.
     mock_token_cache = Mock()
     mock_session_credentials = Mock()
-    mock_session_credentials.token.return_value = "valid_token"  # Simulate successful refresh
+    mock_session_credentials.token.return_value = "valid_token" # Simulate successful refresh
     mock_token_cache.load.return_value = mock_session_credentials
 
-    mock_credentials_provider = Mock()
-    mock_session_credentials.return_value = mock_credentials_provider
+    # Mock SessionCredentials.
+    want_credentials_provider = lambda c: "new_credentials"
+    mock_session_credentials.return_value = want_credentials_provider
 
-    # 3. Patch TokenCache (no need to mock OAuthClient in this case)
+    # Inject the mock implementations.
     mocker.patch('databricks.sdk.credentials_provider.TokenCache', return_value=mock_token_cache)
 
-    # 4. Call the function
-    result = external_browser(mock_cfg)
+    got_credentials_provider = external_browser(mock_cfg)
 
-    # 5. Assertions
     mock_token_cache.load.assert_called_once()
-    mock_session_credentials.token.assert_called_once()  # Verify token refresh was attempted
-    assert result == mock_credentials_provider
+    mock_token_cache.save.assert_called_once_with(mock_session_credentials)
+    mock_session_credentials.token.assert_called_once() # Verify token refresh was attempted
+    assert got_credentials_provider == want_credentials_provider
 
 
 def test_external_browser_refresh_failure_new_oauth_flow(mocker):
     """Tests failed refresh, triggering a new OAuth flow."""
 
-    # 1. Mock Config
+    # Mock Config.
     mock_cfg = Mock()
     mock_cfg.auth_type = 'external-browser'
     mock_cfg.host = 'test-host'
@@ -46,41 +46,41 @@ def test_external_browser_refresh_failure_new_oauth_flow(mocker):
     mock_cfg.client_id = 'test-client-id'
     mock_cfg.client_secret = 'test-client-secret'
 
-    # 2. Mock TokenCache
+    # Mock TokenCache.
     mock_token_cache = Mock()
     mock_session_credentials = Mock()
-    mock_session_credentials.token.side_effect = Exception("Simulated refresh error")  # Simulate a failed refresh
+    mock_session_credentials.token.side_effect = Exception(
+        "Simulated refresh error") # Simulate a failed refresh
     mock_token_cache.load.return_value = mock_session_credentials
 
-    mock_credentials_provider = Mock()
-    mock_session_credentials.return_value = mock_credentials_provider
+    # Mock SessionCredentials.
+    want_credentials_provider = lambda c: "new_credentials"
+    mock_session_credentials.return_value = want_credentials_provider
 
-    # 3. Mock OAuthClient
+    # Mock OAuthClient.
     mock_oauth_client = Mock()
     mock_consent = Mock()
-    mock_consent.launch_external_browser.return_value = mock_session_credentials  # Simulate successful OAuth flow
+    mock_consent.launch_external_browser.return_value = mock_session_credentials
     mock_oauth_client.initiate_consent.return_value = mock_consent
 
-    # 4. Patch TokenCache and OAuthClient
+    # Inject the mock implementations.
     mocker.patch('databricks.sdk.credentials_provider.TokenCache', return_value=mock_token_cache)
     mocker.patch('databricks.sdk.credentials_provider.OAuthClient', return_value=mock_oauth_client)
 
-    # 5. Call the function
-    result = external_browser(mock_cfg)
+    got_credentials_provider = external_browser(mock_cfg)
 
-    # 6. Assertions
     mock_token_cache.load.assert_called_once()
-    mock_session_credentials.token.assert_called_once()  # Refresh attempt
+    mock_session_credentials.token.assert_called_once() # Refresh attempt
     mock_oauth_client.initiate_consent.assert_called_once()
     mock_consent.launch_external_browser.assert_called_once()
     mock_token_cache.save.assert_called_once_with(mock_session_credentials)
-    assert result == mock_credentials_provider
+    assert got_credentials_provider == want_credentials_provider
 
 
 def test_external_browser_no_cached_credentials(mocker):
     """Tests the case where there are no cached credentials, initiating a new OAuth flow."""
 
-    # 1. Mock Config
+    # Mock Config.
     mock_cfg = Mock()
     mock_cfg.auth_type = 'external-browser'
     mock_cfg.host = 'test-host'
@@ -88,37 +88,38 @@ def test_external_browser_no_cached_credentials(mocker):
     mock_cfg.client_id = 'test-client-id'
     mock_cfg.client_secret = 'test-client-secret'
 
-    # 2. Mock TokenCache
+    # Mock TokenCache.
     mock_token_cache = Mock()
-    mock_token_cache.load.return_value = None  # No cached credentials
+    mock_token_cache.load.return_value = None # No cached credentials
 
-    mock_session_credentials = lambda c: "new_credentials"
+    # Mock SessionCredentials.
+    mock_session_credentials = Mock()
+    want_credentials_provider = lambda c: "new_credentials"
+    mock_session_credentials.return_value = want_credentials_provider
 
-    # 3. Mock OAuthClient
+    # Mock OAuthClient.
     mock_consent = Mock()
     mock_consent.launch_external_browser.return_value = mock_session_credentials
     mock_oauth_client = Mock()
     mock_oauth_client.initiate_consent.return_value = mock_consent
 
-    # 4. Patch TokenCache and OAuthClient
+    # Inject the mock implementations.
     mocker.patch('databricks.sdk.credentials_provider.TokenCache', return_value=mock_token_cache)
     mocker.patch('databricks.sdk.credentials_provider.OAuthClient', return_value=mock_oauth_client)
 
-    # 5. Call the function
-    result = external_browser(mock_cfg)
+    got_credentials_provider = external_browser(mock_cfg)
 
-    # 6. Assertions
     mock_token_cache.load.assert_called_once()
     mock_oauth_client.initiate_consent.assert_called_once()
     mock_consent.launch_external_browser.assert_called_once()
     mock_token_cache.save.assert_called_once_with(mock_session_credentials)
-    assert result == "new_credentials"
+    assert got_credentials_provider == want_credentials_provider
 
 
 def test_external_browser_consent_fails(mocker):
     """Tests the case where OAuth consent initiation fails."""
 
-    # 1. Mock Config
+    # Mock Config.
     mock_cfg = Mock()
     mock_cfg.auth_type = 'external-browser'
     mock_cfg.host = 'test-host'
@@ -126,22 +127,20 @@ def test_external_browser_consent_fails(mocker):
     mock_cfg.client_id = 'test-client-id'
     mock_cfg.client_secret = 'test-client-secret'
 
-    # 2. Mock TokenCache
+    # Mock TokenCache.
     mock_token_cache = Mock()
-    mock_token_cache.load.return_value = None  # No cached credentials
+    mock_token_cache.load.return_value = None # No cached credentials
 
-    # 3. Mock OAuthClient
+    # Mock OAuthClient.
     mock_oauth_client = Mock()
-    mock_oauth_client.initiate_consent.return_value = None  # Simulate consent failure
+    mock_oauth_client.initiate_consent.return_value = None # Simulate consent failure
 
-    # 4. Patch TokenCache and OAuthClient
+    # Inject the mock implementations.
     mocker.patch('databricks.sdk.credentials_provider.TokenCache', return_value=mock_token_cache)
     mocker.patch('databricks.sdk.credentials_provider.OAuthClient', return_value=mock_oauth_client)
 
-    # 5. Call the function
-    result = external_browser(mock_cfg)
+    got_credentials_provider = external_browser(mock_cfg)
 
-    # 6. Assertions
     mock_token_cache.load.assert_called_once()
     mock_oauth_client.initiate_consent.assert_called_once()
-    assert result is None
+    assert got_credentials_provider is None


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR is a noop that adds unit tests for the "external-browser" credential strategy.

## How is this tested?

This PR adds the unit test. Though, these are a little brittle and likely deserve using a stronger typing model in the future. 