### PR TITLE
[Internal] Add CICD environment to the User Agent

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -42,12 +42,16 @@ def test_extra_and_upstream_user_agent(monkeypatch):
         def system(self):
             return 'TestOS'
 
+    # Clear all environment variables and cached CICD provider.
+    for k in os.environ:
+        monkeypatch.delenv(k, raising=False)
+    useragent._cicd_provider = None
+
     monkeypatch.setattr(platform, 'python_version', lambda: '3.0.0')
     monkeypatch.setattr(platform, 'uname', MockUname)
     monkeypatch.setenv('DATABRICKS_SDK_UPSTREAM', "upstream-product")
     monkeypatch.setenv('DATABRICKS_SDK_UPSTREAM_VERSION', "0.0.1")
     monkeypatch.setenv('DATABRICKS_RUNTIME_VERSION', "13.1 anything/else")
-    monkeypatch.delenv('GITHUB_ACTIONS', raising=False)
 
     config = Config(host='http://localhost', username="something", password="something", product='test',
                     product_version='0.0.0') \

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -42,15 +42,12 @@ def test_extra_and_upstream_user_agent(monkeypatch):
         def system(self):
             return 'TestOS'
 
-    # Clear all environment variables.
-    for k in os.environ:
-        monkeypatch.delenv(k, raising=False)
-
     monkeypatch.setattr(platform, 'python_version', lambda: '3.0.0')
     monkeypatch.setattr(platform, 'uname', MockUname)
     monkeypatch.setenv('DATABRICKS_SDK_UPSTREAM', "upstream-product")
     monkeypatch.setenv('DATABRICKS_SDK_UPSTREAM_VERSION', "0.0.1")
     monkeypatch.setenv('DATABRICKS_RUNTIME_VERSION', "13.1 anything/else")
+    monkeypatch.delenv('GITHUB_ACTIONS', raising=False)
 
     config = Config(host='http://localhost', username="something", password="something", product='test',
                     product_version='0.0.0') \

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -33,7 +33,6 @@ def test_config_host_url_format_check(mocker, host, expected):
     mocker.patch('databricks.sdk.config.Config.init_auth')
     assert Config(host=host).host == expected
 
-
 def test_extra_and_upstream_user_agent(monkeypatch):
 
     class MockUname:
@@ -41,6 +40,10 @@ def test_extra_and_upstream_user_agent(monkeypatch):
         @property
         def system(self):
             return 'TestOS'
+
+    # Clear all environment variables.
+    for k in os.environ:
+        monkeypatch.delenv(k, raising=False)
 
     monkeypatch.setattr(platform, 'python_version', lambda: '3.0.0')
     monkeypatch.setattr(platform, 'uname', MockUname)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -33,6 +33,7 @@ def test_config_host_url_format_check(mocker, host, expected):
     mocker.patch('databricks.sdk.config.Config.init_auth')
     assert Config(host=host).host == expected
 
+
 def test_extra_and_upstream_user_agent(monkeypatch):
 
     class MockUname:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -178,6 +178,10 @@ def test_extra_and_upstream_user_agent(monkeypatch):
         def system(self):
             return 'TestOS'
 
+    # Clear all environment variables.
+    for k in os.environ:
+        monkeypatch.delenv(k, raising=False)
+
     monkeypatch.setattr(platform, 'python_version', lambda: '3.0.0')
     monkeypatch.setattr(platform, 'uname', MockUname)
     monkeypatch.setenv('DATABRICKS_SDK_UPSTREAM', "upstream-product")

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -8,7 +8,7 @@ from http.server import BaseHTTPRequestHandler
 
 import pytest
 
-from databricks.sdk import WorkspaceClient, errors
+from databricks.sdk import WorkspaceClient, errors, useragent
 from databricks.sdk.core import ApiClient, Config, DatabricksError
 from databricks.sdk.credentials_provider import (CliTokenSource,
                                                  CredentialsProvider,
@@ -178,12 +178,16 @@ def test_extra_and_upstream_user_agent(monkeypatch):
         def system(self):
             return 'TestOS'
 
+    # Clear all environment variables and cached CICD provider.
+    for k in os.environ:
+        monkeypatch.delenv(k, raising=False)
+    useragent._cicd_provider = None
+
     monkeypatch.setattr(platform, 'python_version', lambda: '3.0.0')
     monkeypatch.setattr(platform, 'uname', MockUname)
     monkeypatch.setenv('DATABRICKS_SDK_UPSTREAM', "upstream-product")
     monkeypatch.setenv('DATABRICKS_SDK_UPSTREAM_VERSION', "0.0.1")
     monkeypatch.setenv('DATABRICKS_RUNTIME_VERSION', "13.1 anything/else")
-    monkeypatch.delenv('GITHUB_ACTIONS', raising=False)
 
     config = Config(host='http://localhost', username="something", password="something", product='test',
                     product_version='0.0.0') \

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -178,15 +178,12 @@ def test_extra_and_upstream_user_agent(monkeypatch):
         def system(self):
             return 'TestOS'
 
-    # Clear all environment variables.
-    for k in os.environ:
-        monkeypatch.delenv(k, raising=False)
-
     monkeypatch.setattr(platform, 'python_version', lambda: '3.0.0')
     monkeypatch.setattr(platform, 'uname', MockUname)
     monkeypatch.setenv('DATABRICKS_SDK_UPSTREAM', "upstream-product")
     monkeypatch.setenv('DATABRICKS_SDK_UPSTREAM_VERSION', "0.0.1")
     monkeypatch.setenv('DATABRICKS_RUNTIME_VERSION', "13.1 anything/else")
+    monkeypatch.delenv('GITHUB_ACTIONS', raising=False)
 
     config = Config(host='http://localhost', username="something", password="something", product='test',
                     product_version='0.0.0') \

--- a/tests/test_user_agent.py
+++ b/tests/test_user_agent.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 
 from databricks.sdk.version import __version__
@@ -40,3 +42,45 @@ def test_user_agent_with_partner(user_agent):
     user_agent.with_partner('differenttest')
     assert 'partner/test' in user_agent.to_string()
     assert 'partner/differenttest' in user_agent.to_string()
+
+
+@pytest.fixture(scope="session")
+def clear_cicd():
+    # Save and clear env vars.
+    original_env = os.environ
+    os.environ.clear()
+
+    # Clear cached CICD provider.
+    from databricks.sdk import useragent
+    useragent._cicd_provider = None
+
+    yield
+
+    # Restore env vars.
+    os.environ = original_env
+
+
+def test_user_agent_cicd_no_provider(clear_cicd):
+    from databricks.sdk import useragent
+    user_agent = useragent.to_string()
+
+    assert 'cicd' not in user_agent
+
+
+def test_user_agent_cicd_one_provider(clear_cicd):
+    os.environ['GITHUB_ACTIONS'] = 'true'
+
+    from databricks.sdk import useragent
+    user_agent = useragent.to_string()
+
+    assert 'cicd/github' in user_agent
+
+
+def test_user_agent_cicd_two_provider(clear_cicd):
+    os.environ['GITHUB_ACTIONS'] = 'true'
+    os.environ['GITLAB_CI'] = 'true'
+
+    from databricks.sdk import useragent
+    user_agent = useragent.to_string()
+
+    assert 'cicd/github' in user_agent

--- a/tests/test_user_agent.py
+++ b/tests/test_user_agent.py
@@ -44,10 +44,10 @@ def test_user_agent_with_partner(user_agent):
     assert 'partner/differenttest' in user_agent.to_string()
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="function")
 def clear_cicd():
     # Save and clear env vars.
-    original_env = os.environ
+    original_env = os.environ.copy()
     os.environ.clear()
 
     # Clear cached CICD provider.


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR adds CICD environment to the User Agent of each SDK outbound request. The implementation is similar to the one used in the Go SDK. 

## How is this tested?

Added unit tests. 