### PR TITLE
[Internal] Add unit tests for retriable requests

### DIFF
--- a/tests/test_base_client.py
+++ b/tests/test_base_client.py
@@ -398,7 +398,6 @@ class MockSession:
         response._content = b''
         response.status_code = 429
         response.headers = {'Retry-After': '1'}
-        # response.reason = 'Too Many Requests'
         response.url = 'http://test.com/'
 
         response.request = PreparedRequest()


### PR DESCRIPTION
## What changes are proposed in this pull request?

Improving tests for retriable requests, ensuring we're covering retries from error response and connection exceptions.
Now we have one unified test which is parameterized by:
1) data passed to be uploaded
2) type of failure (retriable response or retriable exception)

## How is this tested?

This PR only changes tests.