### PR TITLE
[Feature] Introduce new Credential Strategies for Agents

### DIFF
--- a/databricks/sdk/credentials_provider.py
+++ b/databricks/sdk/credentials_provider.py
@@ -314,11 +314,12 @@ def github_oidc_azure(cfg: 'Config') -> Optional[CredentialsProvider]:
         # detect Azure AD Tenant ID if it's not specified directly
         token_endpoint = cfg.oidc_endpoints.token_endpoint
         cfg.azure_tenant_id = token_endpoint.replace(aad_endpoint, '').split('/')[0]
-    inner = ClientCredentials(client_id=cfg.azure_client_id,
-                              client_secret="", # we have no (rotatable) secrets in OIDC flow
-                              token_url=f"{aad_endpoint}{cfg.azure_tenant_id}/oauth2/token",
-                              endpoint_params=params,
-                              use_params=True)
+    inner = ClientCredentials(
+        client_id=cfg.azure_client_id,
+        client_secret="", # we have no (rotatable) secrets in OIDC flow
+        token_url=f"{aad_endpoint}{cfg.azure_tenant_id}/oauth2/token",
+        endpoint_params=params,
+        use_params=True)
 
     def refreshed_headers() -> Dict[str, str]:
         token = inner.token()

--- a/databricks/sdk/credentials_provider.py
+++ b/databricks/sdk/credentials_provider.py
@@ -314,11 +314,12 @@ def github_oidc_azure(cfg: 'Config') -> Optional[CredentialsProvider]:
         # detect Azure AD Tenant ID if it's not specified directly
         token_endpoint = cfg.oidc_endpoints.token_endpoint
         cfg.azure_tenant_id = token_endpoint.replace(aad_endpoint, '').split('/')[0]
-    inner = ClientCredentials(client_id=cfg.azure_client_id,
-                              client_secret="", # we have no (rotatable) secrets in OIDC flow
-                              token_url=f"{aad_endpoint}{cfg.azure_tenant_id}/oauth2/token",
-                              endpoint_params=params,
-                              use_params=True)
+    inner = ClientCredentials(
+            client_id=cfg.azure_client_id,
+            client_secret="", # we have no (rotatable) secrets in OIDC flow
+            token_url=f"{aad_endpoint}{cfg.azure_tenant_id}/oauth2/token",
+            endpoint_params=params,
+            use_params=True)
 
     def refreshed_headers() -> Dict[str, str]:
         token = inner.token()

--- a/databricks/sdk/credentials_provider.py
+++ b/databricks/sdk/credentials_provider.py
@@ -315,11 +315,11 @@ def github_oidc_azure(cfg: 'Config') -> Optional[CredentialsProvider]:
         token_endpoint = cfg.oidc_endpoints.token_endpoint
         cfg.azure_tenant_id = token_endpoint.replace(aad_endpoint, '').split('/')[0]
     inner = ClientCredentials(
-            client_id=cfg.azure_client_id,
-            client_secret="", # we have no (rotatable) secrets in OIDC flow
-            token_url=f"{aad_endpoint}{cfg.azure_tenant_id}/oauth2/token",
-            endpoint_params=params,
-            use_params=True)
+        client_id=cfg.azure_client_id,
+        client_secret="", # we have no (rotatable) secrets in OIDC flow
+        token_url=f"{aad_endpoint}{cfg.azure_tenant_id}/oauth2/token",
+        endpoint_params=params,
+        use_params=True)
 
     def refreshed_headers() -> Dict[str, str]:
         token = inner.token()

--- a/databricks/sdk/credentials_provider.py
+++ b/databricks/sdk/credentials_provider.py
@@ -872,6 +872,14 @@ class DefaultCredentials:
 
 
 class ModelServingUserCredentials(CredentialsStrategy):
+    """
+    This credential strategy is designed for authenticating the Databricks SDK in the model serving environment using user-specific rights. 
+    In the model serving environment, the strategy retrieves a downscoped user token from the thread-local variable. 
+    In any other environments, the class defaults to the DefaultCredentialStrategy. 
+    To use this credential strategy, instantiate the WorkspaceClient with the ModelServingUserCredentials strategy as follows:
+
+    invokers_client = WorkspaceClient(credential_strategy = ModelServingUserCredentials())
+    """
 
     def __init__(self):
         self.credential_type = ModelServingAuthProvider.USER_CREDENTIALS

--- a/tests/test_model_serving_auth.py
+++ b/tests/test_model_serving_auth.py
@@ -1,8 +1,11 @@
+import threading
 import time
 
 import pytest
 
 from databricks.sdk.core import Config
+from databricks.sdk.credentials_provider import (AgentEmbeddedCredentials,
+                                                 AgentUserCredentials)
 
 from .conftest import raises
 
@@ -24,7 +27,9 @@ default_auth_base_error_message = \
                           ([('IS_IN_DATABRICKS_MODEL_SERVING_ENV', 'true'),
                             ('DATABRICKS_MODEL_SERVING_HOST_URL', 'x')
                             ], ['DB_MODEL_SERVING_HOST_URL'], "tests/testdata/model-serving-test-token"), ])
-def test_model_serving_auth(env_values, del_env_values, oauth_file_name, monkeypatch, mocker):
+@pytest.mark.parametrize("use_credential_strategy", [True, False])
+def test_model_serving_auth(env_values, del_env_values, oauth_file_name, use_credential_strategy, monkeypatch,
+                            mocker):
     ## In mlflow we check for these two environment variables to return the correct config
     for (env_name, env_value) in env_values:
         monkeypatch.setenv(env_name, env_value)
@@ -37,26 +42,25 @@ def test_model_serving_auth(env_values, del_env_values, oauth_file_name, monkeyp
         "databricks.sdk.credentials_provider.ModelServingAuthProvider._MODEL_DEPENDENCY_OAUTH_TOKEN_FILE_PATH",
         oauth_file_name)
     mocker.patch('databricks.sdk.config.Config._known_file_config_loader')
-
-    cfg = Config()
-
-    assert cfg.auth_type == 'model-serving'
+    if use_credential_strategy:
+        cfg = Config(credentials_strategy=AgentEmbeddedCredentials())
+        assert cfg.auth_type == 'agent_embedded_credentials'
+    else:
+        cfg = Config()
+        assert cfg.auth_type == 'model-serving'
     headers = cfg.authenticate()
     assert (cfg.host == 'x')
     # Token defined in the test file
     assert headers.get("Authorization") == 'Bearer databricks_sdk_unit_test_token'
 
 
-@pytest.mark.parametrize(
-    "env_values, oauth_file_name",
-    [
-        ([], "invalid_file_name"), # Not in Model Serving and Invalid File Name
-        ([('IS_IN_DB_MODEL_SERVING_ENV', 'true')
-          ], "invalid_file_name"), # In Model Serving and Invalid File Name
-        ([('IS_IN_DATABRICKS_MODEL_SERVING_ENV', 'true')
-          ], "invalid_file_name"), # In Model Serving and Invalid File Name
-        ([], "tests/testdata/model-serving-test-token") # Not in Model Serving and Valid File Name
-    ])
+@pytest.mark.parametrize("env_values, oauth_file_name", [
+    ([], "invalid_file_name"), # Not in Model Serving and Invalid File Name
+    ([('IS_IN_DB_MODEL_SERVING_ENV', 'true')], "invalid_file_name"), # In Model Serving and Invalid File Name
+    ([('IS_IN_DATABRICKS_MODEL_SERVING_ENV', 'true')
+      ], "invalid_file_name"), # In Model Serving and Invalid File Name
+    ([], "tests/testdata/model-serving-test-token") # Not in Model Serving and Valid File Name
+])
 @raises(default_auth_base_error_message)
 def test_model_serving_auth_errors(env_values, oauth_file_name, monkeypatch):
     # Guarantee that the tests defaults to env variables rather than config file.
@@ -74,7 +78,8 @@ def test_model_serving_auth_errors(env_values, oauth_file_name, monkeypatch):
     Config()
 
 
-def test_model_serving_auth_refresh(monkeypatch, mocker):
+@pytest.mark.parametrize("use_credential_strategy", [True, False])
+def test_model_serving_auth_refresh(use_credential_strategy, monkeypatch, mocker):
     ## In mlflow we check for these two environment variables to return the correct config
     monkeypatch.setenv('IS_IN_DB_MODEL_SERVING_ENV', 'true')
     monkeypatch.setenv('DB_MODEL_SERVING_HOST_URL', 'x')
@@ -85,15 +90,18 @@ def test_model_serving_auth_refresh(monkeypatch, mocker):
         "tests/testdata/model-serving-test-token")
     mocker.patch('databricks.sdk.config.Config._known_file_config_loader')
 
-    cfg = Config()
-    assert cfg.auth_type == 'model-serving'
+    if use_credential_strategy:
+        cfg = Config(credentials_strategy=AgentEmbeddedCredentials())
+        assert cfg.auth_type == 'agent_embedded_credentials'
+    else:
+        cfg = Config()
+        assert cfg.auth_type == 'model-serving'
 
     current_time = time.time()
     headers = cfg.authenticate()
     assert (cfg.host == 'x')
     assert headers.get(
         "Authorization") == 'Bearer databricks_sdk_unit_test_token' # Token defined in the test file
-
     # Simulate refreshing the token by patching to to a new file
     monkeypatch.setattr(
         "databricks.sdk.credentials_provider.ModelServingAuthProvider._MODEL_DEPENDENCY_OAUTH_TOKEN_FILE_PATH",
@@ -113,3 +121,64 @@ def test_model_serving_auth_refresh(monkeypatch, mocker):
     assert (cfg.host == 'x')
     # Read V2 now
     assert headers.get("Authorization") == 'Bearer databricks_sdk_unit_test_token_v2'
+
+
+def test_agent_user_credentials(monkeypatch, mocker):
+    monkeypatch.setenv('IS_IN_DB_MODEL_SERVING_ENV', 'true')
+    monkeypatch.setenv('DB_MODEL_SERVING_HOST_URL', 'x')
+    monkeypatch.setattr(
+        "databricks.sdk.credentials_provider.ModelServingAuthProvider._MODEL_DEPENDENCY_OAUTH_TOKEN_FILE_PATH",
+        "tests/testdata/model-serving-test-token")
+
+    invokers_token_val = "databricks_invokers_token"
+    current_thread = threading.current_thread()
+    thread_data = current_thread.__dict__
+    thread_data["invokers_token"] = invokers_token_val
+
+    cfg = Config(credentials_strategy=AgentUserCredentials())
+    assert cfg.auth_type == 'agent_user_credentials'
+
+    headers = cfg.authenticate()
+
+    assert (cfg.host == 'x')
+    assert headers.get("Authorization") == f'Bearer {invokers_token_val}'
+
+    # Test updates of invokers token
+    invokers_token_val = "databricks_invokers_token_v2"
+    current_thread = threading.current_thread()
+    thread_data = current_thread.__dict__
+    thread_data["invokers_token"] = invokers_token_val
+
+    headers = cfg.authenticate()
+    assert (cfg.host == 'x')
+    assert headers.get("Authorization") == f'Bearer {invokers_token_val}'
+
+
+# If this credential strategy is being used in a non model serving environments then use default credential strategy instead
+def test_agent_user_credentials_in_non_model_serving_environments(monkeypatch):
+
+    monkeypatch.setenv('DATABRICKS_HOST', 'x')
+    monkeypatch.setenv('DATABRICKS_TOKEN', 'token')
+
+    cfg = Config(credentials_strategy=AgentUserCredentials())
+    assert cfg.auth_type == 'pat' # Auth type is PAT as it is no longer in a model serving environment
+
+    headers = cfg.authenticate()
+
+    assert (cfg.host == 'https://x')
+    assert headers.get("Authorization") == f'Bearer token'
+
+
+# If this credential strategy is being used in a non model serving environments then use default credential strategy instead
+def test_agent_embedded_credentials_in_non_model_serving_environments(monkeypatch):
+
+    monkeypatch.setenv('DATABRICKS_HOST', 'x')
+    monkeypatch.setenv('DATABRICKS_TOKEN', 'token')
+
+    cfg = Config(credentials_strategy=AgentEmbeddedCredentials())
+    assert cfg.auth_type == 'pat' # Auth type is PAT as it is no longer in a model serving environment
+
+    headers = cfg.authenticate()
+
+    assert (cfg.host == 'https://x')
+    assert headers.get("Authorization") == f'Bearer token'

--- a/tests/test_model_serving_auth.py
+++ b/tests/test_model_serving_auth.py
@@ -48,13 +48,16 @@ def test_model_serving_auth(env_values, del_env_values, oauth_file_name, monkeyp
     assert headers.get("Authorization") == 'Bearer databricks_sdk_unit_test_token'
 
 
-@pytest.mark.parametrize("env_values, oauth_file_name", [
-    ([], "invalid_file_name"), # Not in Model Serving and Invalid File Name
-    ([('IS_IN_DB_MODEL_SERVING_ENV', 'true')], "invalid_file_name"), # In Model Serving and Invalid File Name
-    ([('IS_IN_DATABRICKS_MODEL_SERVING_ENV', 'true')
-      ], "invalid_file_name"), # In Model Serving and Invalid File Name
-    ([], "tests/testdata/model-serving-test-token") # Not in Model Serving and Valid File Name
-])
+@pytest.mark.parametrize(
+    "env_values, oauth_file_name",
+    [
+        ([], "invalid_file_name"), # Not in Model Serving and Invalid File Name
+        ([('IS_IN_DB_MODEL_SERVING_ENV', 'true')
+          ], "invalid_file_name"), # In Model Serving and Invalid File Name
+        ([('IS_IN_DATABRICKS_MODEL_SERVING_ENV', 'true')
+          ], "invalid_file_name"), # In Model Serving and Invalid File Name
+        ([], "tests/testdata/model-serving-test-token") # Not in Model Serving and Valid File Name
+    ])
 @raises(default_auth_base_error_message)
 def test_model_serving_auth_errors(env_values, oauth_file_name, monkeypatch):
     # Guarantee that the tests defaults to env variables rather than config file.


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR introduces two new credential strategies for Agents, (AgentEmbeddedCredentials, AgentUserCredentials). 

Agents currently use the databricks.sdk in order to interact with databricks resources. However the authentication method for these resources is a little unique where we store the token for the authentication in a Credential File on the Kubernetes Container. Therefore in the past we added the Model Serving Credential Strategy to the defaultCredentials list to read this file. 

Now we want to introduce a new authentication where the user's token is instead stored in a thread local variable. Agent users will initialize clients as follows:

```
from databricks.sdk.credentials_provider import ModelServingUserCredentials

invokers_client = WorkspaceClient(credential_strategy = ModelServingUserCredentials())
definers_client = WorkspaceClient()

```

Then the users can use the invoker_client to interact with resources with the invokers token or the definers_client to interact with resources using the old method of authentication. 

Additionally as the users will be using these clients to test their code locally in Databricks Notebooks, if the code is not being run on model serving environments, users need to be able to authenticate using the DefaultCredential strategies. 

More details: https://docs.google.com/document/d/14qLVjyxIAk581w287TWElstIeh8-DR30ab9Z6B_Vydg/edit?usp=sharing

## How is this tested?

Added unit tests