### PR TITLE
[Internal] Fix `tests/integration/test_dbutils.py::test_secrets`

### DIFF
--- a/tests/integration/test_dbutils.py
+++ b/tests/integration/test_dbutils.py
@@ -192,20 +192,21 @@ def test_secrets(w, random):
 
     from databricks.sdk.runtime import dbutils
 
+    all_scopes = dbutils.secrets.listScopes()
+    assert random_scope in [scope.getName() for scope in all_scopes]
+
     all_secrets = {}
-    for secret_scope in dbutils.secrets.listScopes():
-        scope = secret_scope.name
-        for secret_metadata in dbutils.secrets.list(scope):
-            key = secret_metadata.key
-            try:
-                all_secrets[f'{scope}.{key}'] = dbutils.secrets.get(scope, key)
-            except DatabricksError as e:
-                if e.error_code == 'BAD_REQUEST':
-                    pytest.skip('dbconnect is not enabled on this workspace')
-                raise e
+    for secret_metadata in dbutils.secrets.list(random_scope):
+        key = secret_metadata.key
+        try:
+            all_secrets[key] = dbutils.secrets.get(random_scope, key)
+        except DatabricksError as e:
+            if e.error_code == 'BAD_REQUEST':
+                pytest.skip('dbconnect is not enabled on this workspace')
+            raise e
 
     logger.info(f'After loading secret: {random_value}')
     logging.getLogger('databricks.sdk').info(f'After loading secret: {random_value}')
 
-    assert all_secrets[f'{random_scope}.{key_for_string}'] == random_value
-    assert all_secrets[f'{random_scope}.{key_for_bytes}'] == random_value
+    assert all_secrets[key_for_string] == random_value
+    assert all_secrets[key_for_bytes] == random_value


### PR DESCRIPTION
## What changes are proposed in this pull request?
`tests/integration/test_dbutils.py::test_secrets` currently assumes that the principal running the test has access to all key vaults in our test workspace. This isn't necessarily the case. To alleviate this, rather than listing all secrets across all scopes, we just check that our scope is included in the list of secret scopes, and only list the secrets from our scope.

## How is this tested?

Integration tests will automatically run on this PR.