### PR TITLE
[Internal] Update Jobs list function to support paginated responses

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Documentation
 
 ### Internal Changes
+* Update Jobs ListJobs API to support paginated responses ([#896](https://github.com/databricks/databricks-sdk-py/pull/896))
 * Introduce automated tagging ([#888](https://github.com/databricks/databricks-sdk-py/pull/888))
 * Update Jobs GetJob API to support paginated responses ([#869](https://github.com/databricks/databricks-sdk-py/pull/869)).
 

--- a/databricks/sdk/mixins/jobs.py
+++ b/databricks/sdk/mixins/jobs.py
@@ -1,10 +1,63 @@
-from typing import Optional
+from typing import Iterator, Optional
 
 from databricks.sdk.service import jobs
-from databricks.sdk.service.jobs import Job
+from databricks.sdk.service.jobs import BaseJob, Job
 
 
 class JobsExt(jobs.JobsAPI):
+
+    def list(self,
+             *,
+             expand_tasks: Optional[bool] = None,
+             limit: Optional[int] = None,
+             name: Optional[str] = None,
+             offset: Optional[int] = None,
+             page_token: Optional[str] = None) -> Iterator[BaseJob]:
+        """List jobs.
+
+        Retrieves a list of jobs. If the job has multiple pages of tasks, job_clusters, parameters or environments,
+        it will paginate through all pages and aggregate the results.
+
+        :param expand_tasks: bool (optional)
+          Whether to include task and cluster details in the response. Note that in API 2.2, only the first
+          100 elements will be shown. Use :method:jobs/get to paginate through all tasks and clusters.
+        :param limit: int (optional)
+          The number of jobs to return. This value must be greater than 0 and less or equal to 100. The
+          default value is 20.
+        :param name: str (optional)
+          A filter on the list based on the exact (case insensitive) job name.
+        :param offset: int (optional)
+          The offset of the first job to return, relative to the most recently created job. Deprecated since
+          June 2023. Use `page_token` to iterate through the pages instead.
+        :param page_token: str (optional)
+          Use `next_page_token` or `prev_page_token` returned from the previous request to list the next or
+          previous page of jobs respectively.
+
+        :returns: Iterator over :class:`BaseJob`
+        """
+        # fetch jobs with limited elements in top level arrays
+        jobs_list = super().list(expand_tasks=expand_tasks,
+                                 limit=limit,
+                                 name=name,
+                                 offset=offset,
+                                 page_token=page_token)
+        if not expand_tasks:
+            yield from jobs_list
+
+        # fully fetch all top level arrays for each job in the list
+        for job in jobs_list:
+            if job.has_more:
+                job_from_get_call = self.get(job.job_id)
+                job.settings.tasks = job_from_get_call.settings.tasks
+                job.settings.job_clusters = job_from_get_call.settings.job_clusters
+                job.settings.parameters = job_from_get_call.settings.parameters
+                job.settings.environments = job_from_get_call.settings.environments
+            # Remove has_more fields for each job in the list.
+            # This field in Jobs API 2.2 is useful for pagination. It indicates if there are more than 100 tasks or job_clusters in the job.
+            # This function hides pagination details from the user. So the field does not play useful role here.
+            if hasattr(job, 'has_more'):
+                delattr(job, 'has_more')
+            yield job
 
     def get_run(self,
                 run_id: int,

--- a/tests/test_jobs_mixin.py
+++ b/tests/test_jobs_mixin.py
@@ -494,12 +494,15 @@ def test_list_jobs_with_many_tasks(config, requests_mock):
     getjob_400_page1 = {
         "job_id": 400,
         "settings": {
-            "tasks": [{
-                "task_key": "taskkey401"
-            }, {
-                "task_key":
-                "taskkey403" # jobs/get returns tasks in different order. jobs/get order is the ground truth
-            }],
+            "tasks": [
+                {
+                    "task_key": "taskkey401"
+                },
+                {
+                    "task_key":
+                    "taskkey403" # jobs/get returns tasks in different order. jobs/get order is the ground truth
+                }
+            ],
             "job_clusters": [cluster1.as_dict()]
         },
         "next_page_token": "tokenToSecondPage_400"

--- a/tests/test_jobs_mixin.py
+++ b/tests/test_jobs_mixin.py
@@ -10,6 +10,7 @@ def make_getrun_path_pattern(run_id: int, page_token: str) -> Pattern[str]:
         rf'{re.escape("http://localhost/api/")}2.\d{re.escape(f"/jobs/runs/get?page_token={page_token}&run_id={run_id}")}'
     )
 
+
 def make_getjob_path_pattern(job_id: int, page_token: Optional[str] = None) -> Pattern[str]:
     if page_token:
         return re.compile(
@@ -18,6 +19,7 @@ def make_getjob_path_pattern(job_id: int, page_token: Optional[str] = None) -> P
     else:
         return re.compile(
             rf'{re.escape("http://localhost/api/")}2.\d{re.escape(f"/jobs/get?job_id={job_id}")}')
+
 
 def make_listjobs_path_pattern(page_token: str) -> Pattern[str]:
     return re.compile(
@@ -270,6 +272,7 @@ def test_get_job_pagination_with_tasks(config, requests_mock):
         }
     }
 
+
 def test_list_jobs_without_task_expansion(config, requests_mock):
     listjobs_page1 = {
         "jobs": [{
@@ -343,6 +346,7 @@ def test_list_jobs_without_task_expansion(config, requests_mock):
     # only two requests should be made which are jobs/list requests
     assert requests_mock.call_count == 2
 
+
 def test_list_jobs_with_many_tasks(config, requests_mock):
     from databricks.sdk.service import compute, jobs
     cluster_spec = compute.ClusterSpec(spark_version="11.3.x-scala2.12",
@@ -393,7 +397,8 @@ def test_list_jobs_with_many_tasks(config, requests_mock):
                 }]
             }
         }],
-        "next_page_token": "tokenToSecondPage"
+        "next_page_token":
+        "tokenToSecondPage"
     }
     listjobs_page2 = {
         "jobs": [{


### PR DESCRIPTION
## What changes are proposed in this pull request?
Introduces logic in the extension for jobs ListJobs call. The extended logic accounts for the new response format of API 2.2. API 2.1 format returns all tasks and job_cluster for each job in the jobs list. API 2.2 format truncates tasks and job_cluster to 100 elements. The extended ListJobs logic calls GetJob for each job in the list to populate the full list of tasks and job_clusters.

The code consumes generator that is returned from `super().list` and it produces generator as well.

## How is this tested?
Unit tests and manual tests. Manual tests were done in two modes: using API 2.2 and using API 2.1. So this code is code is compatible with both API versions.

## Notes
Copy of this other PR
https://github.com/databricks/databricks-sdk-py/pull/889

The formatter is inconsistent and the original author could make it work.