### PR TITLE
[Internal] Replace incorrect `any` type hints with `Any`

### DIFF
--- a/databricks/sdk/__init__.py
+++ b/databricks/sdk/__init__.py
@@ -5,7 +5,8 @@ from typing import Optional
 
 import databricks.sdk.core as client
 import databricks.sdk.dbutils as dbutils
-from databricks.sdk import azure, service
+import databricks.sdk.service as service
+from databricks.sdk import azure
 from databricks.sdk.credentials_provider import CredentialsStrategy
 from databricks.sdk.mixins.compute import ClustersExt
 from databricks.sdk.mixins.files import DbfsExt, FilesExt

--- a/databricks/sdk/service/apps.py
+++ b/databricks/sdk/service/apps.py
@@ -8,7 +8,7 @@ import time
 from dataclasses import dataclass
 from datetime import timedelta
 from enum import Enum
-from typing import Callable, Dict, Iterator, List, Optional
+from typing import Any, Callable, Dict, Iterator, List, Optional
 
 from ..errors import OperationFailed
 from ._internal import Wait, _enum, _from_dict, _repeated_dict
@@ -150,7 +150,7 @@ class App:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> App:
+    def from_dict(cls, d: Dict[str, Any]) -> App:
         """Deserializes the App from a dictionary."""
         return cls(
             active_deployment=_from_dict(d, "active_deployment", AppDeployment),
@@ -214,7 +214,7 @@ class AppAccessControlRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> AppAccessControlRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> AppAccessControlRequest:
         """Deserializes the AppAccessControlRequest from a dictionary."""
         return cls(
             group_name=d.get("group_name", None),
@@ -272,7 +272,7 @@ class AppAccessControlResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> AppAccessControlResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> AppAccessControlResponse:
         """Deserializes the AppAccessControlResponse from a dictionary."""
         return cls(
             all_permissions=_repeated_dict(d, "all_permissions", AppPermission),
@@ -356,7 +356,7 @@ class AppDeployment:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> AppDeployment:
+    def from_dict(cls, d: Dict[str, Any]) -> AppDeployment:
         """Deserializes the AppDeployment from a dictionary."""
         return cls(
             create_time=d.get("create_time", None),
@@ -390,7 +390,7 @@ class AppDeploymentArtifacts:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> AppDeploymentArtifacts:
+    def from_dict(cls, d: Dict[str, Any]) -> AppDeploymentArtifacts:
         """Deserializes the AppDeploymentArtifacts from a dictionary."""
         return cls(source_code_path=d.get("source_code_path", None))
 
@@ -436,7 +436,7 @@ class AppDeploymentStatus:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> AppDeploymentStatus:
+    def from_dict(cls, d: Dict[str, Any]) -> AppDeploymentStatus:
         """Deserializes the AppDeploymentStatus from a dictionary."""
         return cls(message=d.get("message", None), state=_enum(d, "state", AppDeploymentState))
 
@@ -473,7 +473,7 @@ class AppPermission:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> AppPermission:
+    def from_dict(cls, d: Dict[str, Any]) -> AppPermission:
         """Deserializes the AppPermission from a dictionary."""
         return cls(
             inherited=d.get("inherited", None),
@@ -520,7 +520,7 @@ class AppPermissions:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> AppPermissions:
+    def from_dict(cls, d: Dict[str, Any]) -> AppPermissions:
         """Deserializes the AppPermissions from a dictionary."""
         return cls(
             access_control_list=_repeated_dict(d, "access_control_list", AppAccessControlResponse),
@@ -555,7 +555,7 @@ class AppPermissionsDescription:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> AppPermissionsDescription:
+    def from_dict(cls, d: Dict[str, Any]) -> AppPermissionsDescription:
         """Deserializes the AppPermissionsDescription from a dictionary."""
         return cls(
             description=d.get("description", None), permission_level=_enum(d, "permission_level", AppPermissionLevel)
@@ -588,7 +588,7 @@ class AppPermissionsRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> AppPermissionsRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> AppPermissionsRequest:
         """Deserializes the AppPermissionsRequest from a dictionary."""
         return cls(
             access_control_list=_repeated_dict(d, "access_control_list", AppAccessControlRequest),
@@ -647,7 +647,7 @@ class AppResource:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> AppResource:
+    def from_dict(cls, d: Dict[str, Any]) -> AppResource:
         """Deserializes the AppResource from a dictionary."""
         return cls(
             description=d.get("description", None),
@@ -687,7 +687,7 @@ class AppResourceJob:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> AppResourceJob:
+    def from_dict(cls, d: Dict[str, Any]) -> AppResourceJob:
         """Deserializes the AppResourceJob from a dictionary."""
         return cls(id=d.get("id", None), permission=_enum(d, "permission", AppResourceJobJobPermission))
 
@@ -735,7 +735,7 @@ class AppResourceSecret:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> AppResourceSecret:
+    def from_dict(cls, d: Dict[str, Any]) -> AppResourceSecret:
         """Deserializes the AppResourceSecret from a dictionary."""
         return cls(
             key=d.get("key", None),
@@ -780,7 +780,7 @@ class AppResourceServingEndpoint:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> AppResourceServingEndpoint:
+    def from_dict(cls, d: Dict[str, Any]) -> AppResourceServingEndpoint:
         """Deserializes the AppResourceServingEndpoint from a dictionary."""
         return cls(
             name=d.get("name", None),
@@ -823,7 +823,7 @@ class AppResourceSqlWarehouse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> AppResourceSqlWarehouse:
+    def from_dict(cls, d: Dict[str, Any]) -> AppResourceSqlWarehouse:
         """Deserializes the AppResourceSqlWarehouse from a dictionary."""
         return cls(
             id=d.get("id", None), permission=_enum(d, "permission", AppResourceSqlWarehouseSqlWarehousePermission)
@@ -872,7 +872,7 @@ class ApplicationStatus:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ApplicationStatus:
+    def from_dict(cls, d: Dict[str, Any]) -> ApplicationStatus:
         """Deserializes the ApplicationStatus from a dictionary."""
         return cls(message=d.get("message", None), state=_enum(d, "state", ApplicationState))
 
@@ -915,7 +915,7 @@ class ComputeStatus:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ComputeStatus:
+    def from_dict(cls, d: Dict[str, Any]) -> ComputeStatus:
         """Deserializes the ComputeStatus from a dictionary."""
         return cls(message=d.get("message", None), state=_enum(d, "state", ComputeState))
 
@@ -940,7 +940,7 @@ class GetAppPermissionLevelsResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GetAppPermissionLevelsResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> GetAppPermissionLevelsResponse:
         """Deserializes the GetAppPermissionLevelsResponse from a dictionary."""
         return cls(permission_levels=_repeated_dict(d, "permission_levels", AppPermissionsDescription))
 
@@ -972,7 +972,7 @@ class ListAppDeploymentsResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListAppDeploymentsResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ListAppDeploymentsResponse:
         """Deserializes the ListAppDeploymentsResponse from a dictionary."""
         return cls(
             app_deployments=_repeated_dict(d, "app_deployments", AppDeployment),
@@ -1006,7 +1006,7 @@ class ListAppsResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListAppsResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ListAppsResponse:
         """Deserializes the ListAppsResponse from a dictionary."""
         return cls(apps=_repeated_dict(d, "apps", App), next_page_token=d.get("next_page_token", None))
 

--- a/databricks/sdk/service/billing.py
+++ b/databricks/sdk/service/billing.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from enum import Enum
-from typing import BinaryIO, Dict, Iterator, List, Optional
+from typing import Any, BinaryIO, Dict, Iterator, List, Optional
 
 from ._internal import _enum, _from_dict, _repeated_dict
 
@@ -51,7 +51,7 @@ class ActionConfiguration:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ActionConfiguration:
+    def from_dict(cls, d: Dict[str, Any]) -> ActionConfiguration:
         """Deserializes the ActionConfiguration from a dictionary."""
         return cls(
             action_configuration_id=d.get("action_configuration_id", None),
@@ -123,7 +123,7 @@ class AlertConfiguration:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> AlertConfiguration:
+    def from_dict(cls, d: Dict[str, Any]) -> AlertConfiguration:
         """Deserializes the AlertConfiguration from a dictionary."""
         return cls(
             action_configurations=_repeated_dict(d, "action_configurations", ActionConfiguration),
@@ -215,7 +215,7 @@ class BudgetConfiguration:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> BudgetConfiguration:
+    def from_dict(cls, d: Dict[str, Any]) -> BudgetConfiguration:
         """Deserializes the BudgetConfiguration from a dictionary."""
         return cls(
             account_id=d.get("account_id", None),
@@ -257,7 +257,7 @@ class BudgetConfigurationFilter:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> BudgetConfigurationFilter:
+    def from_dict(cls, d: Dict[str, Any]) -> BudgetConfigurationFilter:
         """Deserializes the BudgetConfigurationFilter from a dictionary."""
         return cls(
             tags=_repeated_dict(d, "tags", BudgetConfigurationFilterTagClause),
@@ -290,7 +290,7 @@ class BudgetConfigurationFilterClause:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> BudgetConfigurationFilterClause:
+    def from_dict(cls, d: Dict[str, Any]) -> BudgetConfigurationFilterClause:
         """Deserializes the BudgetConfigurationFilterClause from a dictionary."""
         return cls(operator=_enum(d, "operator", BudgetConfigurationFilterOperator), values=d.get("values", None))
 
@@ -325,7 +325,7 @@ class BudgetConfigurationFilterTagClause:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> BudgetConfigurationFilterTagClause:
+    def from_dict(cls, d: Dict[str, Any]) -> BudgetConfigurationFilterTagClause:
         """Deserializes the BudgetConfigurationFilterTagClause from a dictionary."""
         return cls(key=d.get("key", None), value=_from_dict(d, "value", BudgetConfigurationFilterClause))
 
@@ -355,7 +355,7 @@ class BudgetConfigurationFilterWorkspaceIdClause:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> BudgetConfigurationFilterWorkspaceIdClause:
+    def from_dict(cls, d: Dict[str, Any]) -> BudgetConfigurationFilterWorkspaceIdClause:
         """Deserializes the BudgetConfigurationFilterWorkspaceIdClause from a dictionary."""
         return cls(operator=_enum(d, "operator", BudgetConfigurationFilterOperator), values=d.get("values", None))
 
@@ -397,7 +397,7 @@ class BudgetPolicy:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> BudgetPolicy:
+    def from_dict(cls, d: Dict[str, Any]) -> BudgetPolicy:
         """Deserializes the BudgetPolicy from a dictionary."""
         return cls(
             custom_tags=_repeated_dict(d, "custom_tags", compute.CustomPolicyTag),
@@ -434,7 +434,7 @@ class CreateBillingUsageDashboardRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateBillingUsageDashboardRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateBillingUsageDashboardRequest:
         """Deserializes the CreateBillingUsageDashboardRequest from a dictionary."""
         return cls(
             dashboard_type=_enum(d, "dashboard_type", UsageDashboardType), workspace_id=d.get("workspace_id", None)
@@ -461,7 +461,7 @@ class CreateBillingUsageDashboardResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateBillingUsageDashboardResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateBillingUsageDashboardResponse:
         """Deserializes the CreateBillingUsageDashboardResponse from a dictionary."""
         return cls(dashboard_id=d.get("dashboard_id", None))
 
@@ -510,7 +510,7 @@ class CreateBudgetConfigurationBudget:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateBudgetConfigurationBudget:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateBudgetConfigurationBudget:
         """Deserializes the CreateBudgetConfigurationBudget from a dictionary."""
         return cls(
             account_id=d.get("account_id", None),
@@ -549,7 +549,7 @@ class CreateBudgetConfigurationBudgetActionConfigurations:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateBudgetConfigurationBudgetActionConfigurations:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateBudgetConfigurationBudgetActionConfigurations:
         """Deserializes the CreateBudgetConfigurationBudgetActionConfigurations from a dictionary."""
         return cls(action_type=_enum(d, "action_type", ActionConfigurationType), target=d.get("target", None))
 
@@ -605,7 +605,7 @@ class CreateBudgetConfigurationBudgetAlertConfigurations:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateBudgetConfigurationBudgetAlertConfigurations:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateBudgetConfigurationBudgetAlertConfigurations:
         """Deserializes the CreateBudgetConfigurationBudgetAlertConfigurations from a dictionary."""
         return cls(
             action_configurations=_repeated_dict(
@@ -638,7 +638,7 @@ class CreateBudgetConfigurationRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateBudgetConfigurationRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateBudgetConfigurationRequest:
         """Deserializes the CreateBudgetConfigurationRequest from a dictionary."""
         return cls(budget=_from_dict(d, "budget", CreateBudgetConfigurationBudget))
 
@@ -663,7 +663,7 @@ class CreateBudgetConfigurationResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateBudgetConfigurationResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateBudgetConfigurationResponse:
         """Deserializes the CreateBudgetConfigurationResponse from a dictionary."""
         return cls(budget=_from_dict(d, "budget", BudgetConfiguration))
 
@@ -706,7 +706,7 @@ class CreateBudgetPolicyRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateBudgetPolicyRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateBudgetPolicyRequest:
         """Deserializes the CreateBudgetPolicyRequest from a dictionary."""
         return cls(
             custom_tags=_repeated_dict(d, "custom_tags", compute.CustomPolicyTag),
@@ -833,7 +833,7 @@ class CreateLogDeliveryConfigurationParams:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateLogDeliveryConfigurationParams:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateLogDeliveryConfigurationParams:
         """Deserializes the CreateLogDeliveryConfigurationParams from a dictionary."""
         return cls(
             config_name=d.get("config_name", None),
@@ -861,7 +861,7 @@ class DeleteBudgetConfigurationResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DeleteBudgetConfigurationResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> DeleteBudgetConfigurationResponse:
         """Deserializes the DeleteBudgetConfigurationResponse from a dictionary."""
         return cls()
 
@@ -879,7 +879,7 @@ class DeleteResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DeleteResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> DeleteResponse:
         """Deserializes the DeleteResponse from a dictionary."""
         return cls()
 
@@ -919,7 +919,7 @@ class DownloadResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DownloadResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> DownloadResponse:
         """Deserializes the DownloadResponse from a dictionary."""
         return cls(contents=d.get("contents", None))
 
@@ -961,7 +961,7 @@ class Filter:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> Filter:
+    def from_dict(cls, d: Dict[str, Any]) -> Filter:
         """Deserializes the Filter from a dictionary."""
         return cls(
             creator_user_id=d.get("creator_user_id", None),
@@ -997,7 +997,7 @@ class GetBillingUsageDashboardResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GetBillingUsageDashboardResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> GetBillingUsageDashboardResponse:
         """Deserializes the GetBillingUsageDashboardResponse from a dictionary."""
         return cls(dashboard_id=d.get("dashboard_id", None), dashboard_url=d.get("dashboard_url", None))
 
@@ -1021,7 +1021,7 @@ class GetBudgetConfigurationResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GetBudgetConfigurationResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> GetBudgetConfigurationResponse:
         """Deserializes the GetBudgetConfigurationResponse from a dictionary."""
         return cls(budget=_from_dict(d, "budget", BudgetConfiguration))
 
@@ -1042,7 +1042,7 @@ class LimitConfig:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> LimitConfig:
+    def from_dict(cls, d: Dict[str, Any]) -> LimitConfig:
         """Deserializes the LimitConfig from a dictionary."""
         return cls()
 
@@ -1074,7 +1074,7 @@ class ListBudgetConfigurationsResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListBudgetConfigurationsResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ListBudgetConfigurationsResponse:
         """Deserializes the ListBudgetConfigurationsResponse from a dictionary."""
         return cls(
             budgets=_repeated_dict(d, "budgets", BudgetConfiguration), next_page_token=d.get("next_page_token", None)
@@ -1118,7 +1118,7 @@ class ListBudgetPoliciesResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListBudgetPoliciesResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ListBudgetPoliciesResponse:
         """Deserializes the ListBudgetPoliciesResponse from a dictionary."""
         return cls(
             next_page_token=d.get("next_page_token", None),
@@ -1290,7 +1290,7 @@ class LogDeliveryConfiguration:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> LogDeliveryConfiguration:
+    def from_dict(cls, d: Dict[str, Any]) -> LogDeliveryConfiguration:
         """Deserializes the LogDeliveryConfiguration from a dictionary."""
         return cls(
             account_id=d.get("account_id", None),
@@ -1360,7 +1360,7 @@ class LogDeliveryStatus:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> LogDeliveryStatus:
+    def from_dict(cls, d: Dict[str, Any]) -> LogDeliveryStatus:
         """Deserializes the LogDeliveryStatus from a dictionary."""
         return cls(
             last_attempt_time=d.get("last_attempt_time", None),
@@ -1417,7 +1417,7 @@ class PatchStatusResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> PatchStatusResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> PatchStatusResponse:
         """Deserializes the PatchStatusResponse from a dictionary."""
         return cls()
 
@@ -1449,7 +1449,7 @@ class SortSpec:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> SortSpec:
+    def from_dict(cls, d: Dict[str, Any]) -> SortSpec:
         """Deserializes the SortSpec from a dictionary."""
         return cls(descending=d.get("descending", None), field=_enum(d, "field", SortSpecField))
 
@@ -1510,7 +1510,7 @@ class UpdateBudgetConfigurationBudget:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateBudgetConfigurationBudget:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateBudgetConfigurationBudget:
         """Deserializes the UpdateBudgetConfigurationBudget from a dictionary."""
         return cls(
             account_id=d.get("account_id", None),
@@ -1548,7 +1548,7 @@ class UpdateBudgetConfigurationRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateBudgetConfigurationRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateBudgetConfigurationRequest:
         """Deserializes the UpdateBudgetConfigurationRequest from a dictionary."""
         return cls(budget=_from_dict(d, "budget", UpdateBudgetConfigurationBudget), budget_id=d.get("budget_id", None))
 
@@ -1573,7 +1573,7 @@ class UpdateBudgetConfigurationResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateBudgetConfigurationResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateBudgetConfigurationResponse:
         """Deserializes the UpdateBudgetConfigurationResponse from a dictionary."""
         return cls(budget=_from_dict(d, "budget", BudgetConfiguration))
 
@@ -1608,7 +1608,7 @@ class UpdateLogDeliveryConfigurationStatusRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateLogDeliveryConfigurationStatusRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateLogDeliveryConfigurationStatusRequest:
         """Deserializes the UpdateLogDeliveryConfigurationStatusRequest from a dictionary."""
         return cls(
             log_delivery_configuration_id=d.get("log_delivery_configuration_id", None),
@@ -1641,7 +1641,7 @@ class WrappedCreateLogDeliveryConfiguration:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> WrappedCreateLogDeliveryConfiguration:
+    def from_dict(cls, d: Dict[str, Any]) -> WrappedCreateLogDeliveryConfiguration:
         """Deserializes the WrappedCreateLogDeliveryConfiguration from a dictionary."""
         return cls(
             log_delivery_configuration=_from_dict(d, "log_delivery_configuration", CreateLogDeliveryConfigurationParams)
@@ -1667,7 +1667,7 @@ class WrappedLogDeliveryConfiguration:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> WrappedLogDeliveryConfiguration:
+    def from_dict(cls, d: Dict[str, Any]) -> WrappedLogDeliveryConfiguration:
         """Deserializes the WrappedLogDeliveryConfiguration from a dictionary."""
         return cls(log_delivery_configuration=_from_dict(d, "log_delivery_configuration", LogDeliveryConfiguration))
 
@@ -1691,7 +1691,7 @@ class WrappedLogDeliveryConfigurations:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> WrappedLogDeliveryConfigurations:
+    def from_dict(cls, d: Dict[str, Any]) -> WrappedLogDeliveryConfigurations:
         """Deserializes the WrappedLogDeliveryConfigurations from a dictionary."""
         return cls(
             log_delivery_configurations=_repeated_dict(d, "log_delivery_configurations", LogDeliveryConfiguration)

--- a/databricks/sdk/service/catalog.py
+++ b/databricks/sdk/service/catalog.py
@@ -8,7 +8,7 @@ import time
 from dataclasses import dataclass
 from datetime import timedelta
 from enum import Enum
-from typing import Callable, Dict, Iterator, List, Optional
+from typing import Any, Callable, Dict, Iterator, List, Optional
 
 from ..errors import OperationFailed
 from ._internal import Wait, _enum, _from_dict, _repeated_dict, _repeated_enum
@@ -38,7 +38,7 @@ class AccountsCreateMetastore:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> AccountsCreateMetastore:
+    def from_dict(cls, d: Dict[str, Any]) -> AccountsCreateMetastore:
         """Deserializes the AccountsCreateMetastore from a dictionary."""
         return cls(metastore_info=_from_dict(d, "metastore_info", CreateMetastore))
 
@@ -76,7 +76,7 @@ class AccountsCreateMetastoreAssignment:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> AccountsCreateMetastoreAssignment:
+    def from_dict(cls, d: Dict[str, Any]) -> AccountsCreateMetastoreAssignment:
         """Deserializes the AccountsCreateMetastoreAssignment from a dictionary."""
         return cls(
             metastore_assignment=_from_dict(d, "metastore_assignment", CreateMetastoreAssignment),
@@ -111,7 +111,7 @@ class AccountsCreateStorageCredential:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> AccountsCreateStorageCredential:
+    def from_dict(cls, d: Dict[str, Any]) -> AccountsCreateStorageCredential:
         """Deserializes the AccountsCreateStorageCredential from a dictionary."""
         return cls(
             credential_info=_from_dict(d, "credential_info", CreateStorageCredential),
@@ -138,7 +138,7 @@ class AccountsMetastoreAssignment:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> AccountsMetastoreAssignment:
+    def from_dict(cls, d: Dict[str, Any]) -> AccountsMetastoreAssignment:
         """Deserializes the AccountsMetastoreAssignment from a dictionary."""
         return cls(metastore_assignment=_from_dict(d, "metastore_assignment", MetastoreAssignment))
 
@@ -162,7 +162,7 @@ class AccountsMetastoreInfo:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> AccountsMetastoreInfo:
+    def from_dict(cls, d: Dict[str, Any]) -> AccountsMetastoreInfo:
         """Deserializes the AccountsMetastoreInfo from a dictionary."""
         return cls(metastore_info=_from_dict(d, "metastore_info", MetastoreInfo))
 
@@ -186,7 +186,7 @@ class AccountsStorageCredentialInfo:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> AccountsStorageCredentialInfo:
+    def from_dict(cls, d: Dict[str, Any]) -> AccountsStorageCredentialInfo:
         """Deserializes the AccountsStorageCredentialInfo from a dictionary."""
         return cls(credential_info=_from_dict(d, "credential_info", StorageCredentialInfo))
 
@@ -217,7 +217,7 @@ class AccountsUpdateMetastore:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> AccountsUpdateMetastore:
+    def from_dict(cls, d: Dict[str, Any]) -> AccountsUpdateMetastore:
         """Deserializes the AccountsUpdateMetastore from a dictionary."""
         return cls(
             metastore_id=d.get("metastore_id", None), metastore_info=_from_dict(d, "metastore_info", UpdateMetastore)
@@ -257,7 +257,7 @@ class AccountsUpdateMetastoreAssignment:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> AccountsUpdateMetastoreAssignment:
+    def from_dict(cls, d: Dict[str, Any]) -> AccountsUpdateMetastoreAssignment:
         """Deserializes the AccountsUpdateMetastoreAssignment from a dictionary."""
         return cls(
             metastore_assignment=_from_dict(d, "metastore_assignment", UpdateMetastoreAssignment),
@@ -299,7 +299,7 @@ class AccountsUpdateStorageCredential:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> AccountsUpdateStorageCredential:
+    def from_dict(cls, d: Dict[str, Any]) -> AccountsUpdateStorageCredential:
         """Deserializes the AccountsUpdateStorageCredential from a dictionary."""
         return cls(
             credential_info=_from_dict(d, "credential_info", UpdateStorageCredential),
@@ -349,7 +349,7 @@ class ArtifactAllowlistInfo:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ArtifactAllowlistInfo:
+    def from_dict(cls, d: Dict[str, Any]) -> ArtifactAllowlistInfo:
         """Deserializes the ArtifactAllowlistInfo from a dictionary."""
         return cls(
             artifact_matchers=_repeated_dict(d, "artifact_matchers", ArtifactMatcher),
@@ -386,7 +386,7 @@ class ArtifactMatcher:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ArtifactMatcher:
+    def from_dict(cls, d: Dict[str, Any]) -> ArtifactMatcher:
         """Deserializes the ArtifactMatcher from a dictionary."""
         return cls(artifact=d.get("artifact", None), match_type=_enum(d, "match_type", MatchType))
 
@@ -412,7 +412,7 @@ class AssignResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> AssignResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> AssignResponse:
         """Deserializes the AssignResponse from a dictionary."""
         return cls()
 
@@ -462,7 +462,7 @@ class AwsCredentials:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> AwsCredentials:
+    def from_dict(cls, d: Dict[str, Any]) -> AwsCredentials:
         """Deserializes the AwsCredentials from a dictionary."""
         return cls(
             access_key_id=d.get("access_key_id", None),
@@ -509,7 +509,7 @@ class AwsIamRole:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> AwsIamRole:
+    def from_dict(cls, d: Dict[str, Any]) -> AwsIamRole:
         """Deserializes the AwsIamRole from a dictionary."""
         return cls(
             external_id=d.get("external_id", None),
@@ -538,7 +538,7 @@ class AwsIamRoleRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> AwsIamRoleRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> AwsIamRoleRequest:
         """Deserializes the AwsIamRoleRequest from a dictionary."""
         return cls(role_arn=d.get("role_arn", None))
 
@@ -578,7 +578,7 @@ class AwsIamRoleResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> AwsIamRoleResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> AwsIamRoleResponse:
         """Deserializes the AwsIamRoleResponse from a dictionary."""
         return cls(
             external_id=d.get("external_id", None),
@@ -612,7 +612,7 @@ class AzureActiveDirectoryToken:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> AzureActiveDirectoryToken:
+    def from_dict(cls, d: Dict[str, Any]) -> AzureActiveDirectoryToken:
         """Deserializes the AzureActiveDirectoryToken from a dictionary."""
         return cls(aad_token=d.get("aad_token", None))
 
@@ -660,7 +660,7 @@ class AzureManagedIdentity:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> AzureManagedIdentity:
+    def from_dict(cls, d: Dict[str, Any]) -> AzureManagedIdentity:
         """Deserializes the AzureManagedIdentity from a dictionary."""
         return cls(
             access_connector_id=d.get("access_connector_id", None),
@@ -701,7 +701,7 @@ class AzureManagedIdentityRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> AzureManagedIdentityRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> AzureManagedIdentityRequest:
         """Deserializes the AzureManagedIdentityRequest from a dictionary."""
         return cls(
             access_connector_id=d.get("access_connector_id", None),
@@ -748,7 +748,7 @@ class AzureManagedIdentityResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> AzureManagedIdentityResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> AzureManagedIdentityResponse:
         """Deserializes the AzureManagedIdentityResponse from a dictionary."""
         return cls(
             access_connector_id=d.get("access_connector_id", None),
@@ -793,7 +793,7 @@ class AzureServicePrincipal:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> AzureServicePrincipal:
+    def from_dict(cls, d: Dict[str, Any]) -> AzureServicePrincipal:
         """Deserializes the AzureServicePrincipal from a dictionary."""
         return cls(
             application_id=d.get("application_id", None),
@@ -825,7 +825,7 @@ class AzureUserDelegationSas:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> AzureUserDelegationSas:
+    def from_dict(cls, d: Dict[str, Any]) -> AzureUserDelegationSas:
         """Deserializes the AzureUserDelegationSas from a dictionary."""
         return cls(sas_token=d.get("sas_token", None))
 
@@ -843,7 +843,7 @@ class CancelRefreshResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CancelRefreshResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> CancelRefreshResponse:
         """Deserializes the CancelRefreshResponse from a dictionary."""
         return cls()
 
@@ -1023,7 +1023,7 @@ class CatalogInfo:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CatalogInfo:
+    def from_dict(cls, d: Dict[str, Any]) -> CatalogInfo:
         """Deserializes the CatalogInfo from a dictionary."""
         return cls(
             browse_only=d.get("browse_only", None),
@@ -1103,7 +1103,7 @@ class CloudflareApiToken:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CloudflareApiToken:
+    def from_dict(cls, d: Dict[str, Any]) -> CloudflareApiToken:
         """Deserializes the CloudflareApiToken from a dictionary."""
         return cls(
             access_key_id=d.get("access_key_id", None),
@@ -1207,7 +1207,7 @@ class ColumnInfo:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ColumnInfo:
+    def from_dict(cls, d: Dict[str, Any]) -> ColumnInfo:
         """Deserializes the ColumnInfo from a dictionary."""
         return cls(
             comment=d.get("comment", None),
@@ -1254,7 +1254,7 @@ class ColumnMask:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ColumnMask:
+    def from_dict(cls, d: Dict[str, Any]) -> ColumnMask:
         """Deserializes the ColumnMask from a dictionary."""
         return cls(function_name=d.get("function_name", None), using_column_names=d.get("using_column_names", None))
 
@@ -1423,7 +1423,7 @@ class ConnectionInfo:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ConnectionInfo:
+    def from_dict(cls, d: Dict[str, Any]) -> ConnectionInfo:
         """Deserializes the ConnectionInfo from a dictionary."""
         return cls(
             comment=d.get("comment", None),
@@ -1502,7 +1502,7 @@ class ContinuousUpdateStatus:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ContinuousUpdateStatus:
+    def from_dict(cls, d: Dict[str, Any]) -> ContinuousUpdateStatus:
         """Deserializes the ContinuousUpdateStatus from a dictionary."""
         return cls(
             initial_pipeline_sync_progress=_from_dict(d, "initial_pipeline_sync_progress", PipelineProgress),
@@ -1582,7 +1582,7 @@ class CreateCatalog:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateCatalog:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateCatalog:
         """Deserializes the CreateCatalog from a dictionary."""
         return cls(
             comment=d.get("comment", None),
@@ -1651,7 +1651,7 @@ class CreateConnection:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateConnection:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateConnection:
         """Deserializes the CreateConnection from a dictionary."""
         return cls(
             comment=d.get("comment", None),
@@ -1741,7 +1741,7 @@ class CreateCredentialRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateCredentialRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateCredentialRequest:
         """Deserializes the CreateCredentialRequest from a dictionary."""
         return cls(
             aws_iam_role=_from_dict(d, "aws_iam_role", AwsIamRole),
@@ -1834,7 +1834,7 @@ class CreateExternalLocation:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateExternalLocation:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateExternalLocation:
         """Deserializes the CreateExternalLocation from a dictionary."""
         return cls(
             access_point=d.get("access_point", None),
@@ -2011,7 +2011,7 @@ class CreateFunction:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateFunction:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateFunction:
         """Deserializes the CreateFunction from a dictionary."""
         return cls(
             catalog_name=d.get("catalog_name", None),
@@ -2064,7 +2064,7 @@ class CreateFunctionRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateFunctionRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateFunctionRequest:
         """Deserializes the CreateFunctionRequest from a dictionary."""
         return cls(function_info=_from_dict(d, "function_info", CreateFunction))
 
@@ -2129,7 +2129,7 @@ class CreateMetastore:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateMetastore:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateMetastore:
         """Deserializes the CreateMetastore from a dictionary."""
         return cls(name=d.get("name", None), region=d.get("region", None), storage_root=d.get("storage_root", None))
 
@@ -2169,7 +2169,7 @@ class CreateMetastoreAssignment:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateMetastoreAssignment:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateMetastoreAssignment:
         """Deserializes the CreateMetastoreAssignment from a dictionary."""
         return cls(
             default_catalog_name=d.get("default_catalog_name", None),
@@ -2295,7 +2295,7 @@ class CreateMonitor:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateMonitor:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateMonitor:
         """Deserializes the CreateMonitor from a dictionary."""
         return cls(
             assets_dir=d.get("assets_dir", None),
@@ -2363,7 +2363,7 @@ class CreateRegisteredModelRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateRegisteredModelRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateRegisteredModelRequest:
         """Deserializes the CreateRegisteredModelRequest from a dictionary."""
         return cls(
             catalog_name=d.get("catalog_name", None),
@@ -2387,7 +2387,7 @@ class CreateResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateResponse:
         """Deserializes the CreateResponse from a dictionary."""
         return cls()
 
@@ -2440,7 +2440,7 @@ class CreateSchema:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateSchema:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateSchema:
         """Deserializes the CreateSchema from a dictionary."""
         return cls(
             catalog_name=d.get("catalog_name", None),
@@ -2527,7 +2527,7 @@ class CreateStorageCredential:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateStorageCredential:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateStorageCredential:
         """Deserializes the CreateStorageCredential from a dictionary."""
         return cls(
             aws_iam_role=_from_dict(d, "aws_iam_role", AwsIamRoleRequest),
@@ -2572,7 +2572,7 @@ class CreateTableConstraint:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateTableConstraint:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateTableConstraint:
         """Deserializes the CreateTableConstraint from a dictionary."""
         return cls(constraint=_from_dict(d, "constraint", TableConstraint), full_name_arg=d.get("full_name_arg", None))
 
@@ -2631,7 +2631,7 @@ class CreateVolumeRequestContent:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateVolumeRequestContent:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateVolumeRequestContent:
         """Deserializes the CreateVolumeRequestContent from a dictionary."""
         return cls(
             catalog_name=d.get("catalog_name", None),
@@ -2785,7 +2785,7 @@ class CredentialInfo:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CredentialInfo:
+    def from_dict(cls, d: Dict[str, Any]) -> CredentialInfo:
         """Deserializes the CredentialInfo from a dictionary."""
         return cls(
             aws_iam_role=_from_dict(d, "aws_iam_role", AwsIamRole),
@@ -2849,7 +2849,7 @@ class CredentialValidationResult:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CredentialValidationResult:
+    def from_dict(cls, d: Dict[str, Any]) -> CredentialValidationResult:
         """Deserializes the CredentialValidationResult from a dictionary."""
         return cls(message=d.get("message", None), result=_enum(d, "result", ValidateCredentialResult))
 
@@ -2876,7 +2876,7 @@ class CurrentWorkspaceBindings:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CurrentWorkspaceBindings:
+    def from_dict(cls, d: Dict[str, Any]) -> CurrentWorkspaceBindings:
         """Deserializes the CurrentWorkspaceBindings from a dictionary."""
         return cls(workspaces=d.get("workspaces", None))
 
@@ -2947,7 +2947,7 @@ class DatabricksGcpServiceAccount:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DatabricksGcpServiceAccount:
+    def from_dict(cls, d: Dict[str, Any]) -> DatabricksGcpServiceAccount:
         """Deserializes the DatabricksGcpServiceAccount from a dictionary."""
         return cls(
             credential_id=d.get("credential_id", None),
@@ -2969,7 +2969,7 @@ class DatabricksGcpServiceAccountRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DatabricksGcpServiceAccountRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> DatabricksGcpServiceAccountRequest:
         """Deserializes the DatabricksGcpServiceAccountRequest from a dictionary."""
         return cls()
 
@@ -3001,7 +3001,7 @@ class DatabricksGcpServiceAccountResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DatabricksGcpServiceAccountResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> DatabricksGcpServiceAccountResponse:
         """Deserializes the DatabricksGcpServiceAccountResponse from a dictionary."""
         return cls(credential_id=d.get("credential_id", None), email=d.get("email", None))
 
@@ -3019,7 +3019,7 @@ class DeleteAliasResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DeleteAliasResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> DeleteAliasResponse:
         """Deserializes the DeleteAliasResponse from a dictionary."""
         return cls()
 
@@ -3037,7 +3037,7 @@ class DeleteCredentialResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DeleteCredentialResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> DeleteCredentialResponse:
         """Deserializes the DeleteCredentialResponse from a dictionary."""
         return cls()
 
@@ -3055,7 +3055,7 @@ class DeleteResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DeleteResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> DeleteResponse:
         """Deserializes the DeleteResponse from a dictionary."""
         return cls()
 
@@ -3083,7 +3083,7 @@ class DeltaRuntimePropertiesKvPairs:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DeltaRuntimePropertiesKvPairs:
+    def from_dict(cls, d: Dict[str, Any]) -> DeltaRuntimePropertiesKvPairs:
         """Deserializes the DeltaRuntimePropertiesKvPairs from a dictionary."""
         return cls(delta_runtime_properties=d.get("delta_runtime_properties", None))
 
@@ -3118,7 +3118,7 @@ class Dependency:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> Dependency:
+    def from_dict(cls, d: Dict[str, Any]) -> Dependency:
         """Deserializes the Dependency from a dictionary."""
         return cls(
             function=_from_dict(d, "function", FunctionDependency), table=_from_dict(d, "table", TableDependency)
@@ -3147,7 +3147,7 @@ class DependencyList:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DependencyList:
+    def from_dict(cls, d: Dict[str, Any]) -> DependencyList:
         """Deserializes the DependencyList from a dictionary."""
         return cls(dependencies=_repeated_dict(d, "dependencies", Dependency))
 
@@ -3165,7 +3165,7 @@ class DisableResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DisableResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> DisableResponse:
         """Deserializes the DisableResponse from a dictionary."""
         return cls()
 
@@ -3190,7 +3190,7 @@ class EffectivePermissionsList:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> EffectivePermissionsList:
+    def from_dict(cls, d: Dict[str, Any]) -> EffectivePermissionsList:
         """Deserializes the EffectivePermissionsList from a dictionary."""
         return cls(privilege_assignments=_repeated_dict(d, "privilege_assignments", EffectivePrivilegeAssignment))
 
@@ -3231,7 +3231,7 @@ class EffectivePredictiveOptimizationFlag:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> EffectivePredictiveOptimizationFlag:
+    def from_dict(cls, d: Dict[str, Any]) -> EffectivePredictiveOptimizationFlag:
         """Deserializes the EffectivePredictiveOptimizationFlag from a dictionary."""
         return cls(
             inherited_from_name=d.get("inherited_from_name", None),
@@ -3284,7 +3284,7 @@ class EffectivePrivilege:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> EffectivePrivilege:
+    def from_dict(cls, d: Dict[str, Any]) -> EffectivePrivilege:
         """Deserializes the EffectivePrivilege from a dictionary."""
         return cls(
             inherited_from_name=d.get("inherited_from_name", None),
@@ -3320,7 +3320,7 @@ class EffectivePrivilegeAssignment:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> EffectivePrivilegeAssignment:
+    def from_dict(cls, d: Dict[str, Any]) -> EffectivePrivilegeAssignment:
         """Deserializes the EffectivePrivilegeAssignment from a dictionary."""
         return cls(principal=d.get("principal", None), privileges=_repeated_dict(d, "privileges", EffectivePrivilege))
 
@@ -3346,7 +3346,7 @@ class EnableResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> EnableResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> EnableResponse:
         """Deserializes the EnableResponse from a dictionary."""
         return cls()
 
@@ -3373,7 +3373,7 @@ class EncryptionDetails:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> EncryptionDetails:
+    def from_dict(cls, d: Dict[str, Any]) -> EncryptionDetails:
         """Deserializes the EncryptionDetails from a dictionary."""
         return cls(sse_encryption_details=_from_dict(d, "sse_encryption_details", SseEncryptionDetails))
 
@@ -3512,7 +3512,7 @@ class ExternalLocationInfo:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ExternalLocationInfo:
+    def from_dict(cls, d: Dict[str, Any]) -> ExternalLocationInfo:
         """Deserializes the ExternalLocationInfo from a dictionary."""
         return cls(
             access_point=d.get("access_point", None),
@@ -3568,7 +3568,7 @@ class FailedStatus:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> FailedStatus:
+    def from_dict(cls, d: Dict[str, Any]) -> FailedStatus:
         """Deserializes the FailedStatus from a dictionary."""
         return cls(
             last_processed_commit_version=d.get("last_processed_commit_version", None),
@@ -3617,7 +3617,7 @@ class ForeignKeyConstraint:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ForeignKeyConstraint:
+    def from_dict(cls, d: Dict[str, Any]) -> ForeignKeyConstraint:
         """Deserializes the ForeignKeyConstraint from a dictionary."""
         return cls(
             child_columns=d.get("child_columns", None),
@@ -3650,7 +3650,7 @@ class FunctionDependency:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> FunctionDependency:
+    def from_dict(cls, d: Dict[str, Any]) -> FunctionDependency:
         """Deserializes the FunctionDependency from a dictionary."""
         return cls(function_full_name=d.get("function_full_name", None))
 
@@ -3881,7 +3881,7 @@ class FunctionInfo:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> FunctionInfo:
+    def from_dict(cls, d: Dict[str, Any]) -> FunctionInfo:
         """Deserializes the FunctionInfo from a dictionary."""
         return cls(
             browse_only=d.get("browse_only", None),
@@ -4043,7 +4043,7 @@ class FunctionParameterInfo:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> FunctionParameterInfo:
+    def from_dict(cls, d: Dict[str, Any]) -> FunctionParameterInfo:
         """Deserializes the FunctionParameterInfo from a dictionary."""
         return cls(
             comment=d.get("comment", None),
@@ -4081,7 +4081,7 @@ class FunctionParameterInfos:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> FunctionParameterInfos:
+    def from_dict(cls, d: Dict[str, Any]) -> FunctionParameterInfos:
         """Deserializes the FunctionParameterInfos from a dictionary."""
         return cls(parameters=_repeated_dict(d, "parameters", FunctionParameterInfo))
 
@@ -4121,7 +4121,7 @@ class GcpOauthToken:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GcpOauthToken:
+    def from_dict(cls, d: Dict[str, Any]) -> GcpOauthToken:
         """Deserializes the GcpOauthToken from a dictionary."""
         return cls(oauth_token=d.get("oauth_token", None))
 
@@ -4150,7 +4150,7 @@ class GenerateTemporaryServiceCredentialAzureOptions:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GenerateTemporaryServiceCredentialAzureOptions:
+    def from_dict(cls, d: Dict[str, Any]) -> GenerateTemporaryServiceCredentialAzureOptions:
         """Deserializes the GenerateTemporaryServiceCredentialAzureOptions from a dictionary."""
         return cls(resources=d.get("resources", None))
 
@@ -4179,7 +4179,7 @@ class GenerateTemporaryServiceCredentialGcpOptions:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GenerateTemporaryServiceCredentialGcpOptions:
+    def from_dict(cls, d: Dict[str, Any]) -> GenerateTemporaryServiceCredentialGcpOptions:
         """Deserializes the GenerateTemporaryServiceCredentialGcpOptions from a dictionary."""
         return cls(scopes=d.get("scopes", None))
 
@@ -4218,7 +4218,7 @@ class GenerateTemporaryServiceCredentialRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GenerateTemporaryServiceCredentialRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> GenerateTemporaryServiceCredentialRequest:
         """Deserializes the GenerateTemporaryServiceCredentialRequest from a dictionary."""
         return cls(
             azure_options=_from_dict(d, "azure_options", GenerateTemporaryServiceCredentialAzureOptions),
@@ -4256,7 +4256,7 @@ class GenerateTemporaryTableCredentialRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GenerateTemporaryTableCredentialRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> GenerateTemporaryTableCredentialRequest:
         """Deserializes the GenerateTemporaryTableCredentialRequest from a dictionary."""
         return cls(operation=_enum(d, "operation", TableOperation), table_id=d.get("table_id", None))
 
@@ -4330,7 +4330,7 @@ class GenerateTemporaryTableCredentialResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GenerateTemporaryTableCredentialResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> GenerateTemporaryTableCredentialResponse:
         """Deserializes the GenerateTemporaryTableCredentialResponse from a dictionary."""
         return cls(
             aws_temp_credentials=_from_dict(d, "aws_temp_credentials", AwsCredentials),
@@ -4502,7 +4502,7 @@ class GetMetastoreSummaryResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GetMetastoreSummaryResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> GetMetastoreSummaryResponse:
         """Deserializes the GetMetastoreSummaryResponse from a dictionary."""
         return cls(
             cloud=d.get("cloud", None),
@@ -4556,7 +4556,7 @@ class GetQuotaResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GetQuotaResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> GetQuotaResponse:
         """Deserializes the GetQuotaResponse from a dictionary."""
         return cls(quota_info=_from_dict(d, "quota_info", QuotaInfo))
 
@@ -4588,7 +4588,7 @@ class ListAccountMetastoreAssignmentsResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListAccountMetastoreAssignmentsResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ListAccountMetastoreAssignmentsResponse:
         """Deserializes the ListAccountMetastoreAssignmentsResponse from a dictionary."""
         return cls(workspace_ids=d.get("workspace_ids", None))
 
@@ -4613,7 +4613,7 @@ class ListAccountStorageCredentialsResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListAccountStorageCredentialsResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ListAccountStorageCredentialsResponse:
         """Deserializes the ListAccountStorageCredentialsResponse from a dictionary."""
         return cls(storage_credentials=_repeated_dict(d, "storage_credentials", StorageCredentialInfo))
 
@@ -4646,7 +4646,7 @@ class ListCatalogsResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListCatalogsResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ListCatalogsResponse:
         """Deserializes the ListCatalogsResponse from a dictionary."""
         return cls(catalogs=_repeated_dict(d, "catalogs", CatalogInfo), next_page_token=d.get("next_page_token", None))
 
@@ -4679,7 +4679,7 @@ class ListConnectionsResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListConnectionsResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ListConnectionsResponse:
         """Deserializes the ListConnectionsResponse from a dictionary."""
         return cls(
             connections=_repeated_dict(d, "connections", ConnectionInfo), next_page_token=d.get("next_page_token", None)
@@ -4713,7 +4713,7 @@ class ListCredentialsResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListCredentialsResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ListCredentialsResponse:
         """Deserializes the ListCredentialsResponse from a dictionary."""
         return cls(
             credentials=_repeated_dict(d, "credentials", CredentialInfo), next_page_token=d.get("next_page_token", None)
@@ -4748,7 +4748,7 @@ class ListExternalLocationsResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListExternalLocationsResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ListExternalLocationsResponse:
         """Deserializes the ListExternalLocationsResponse from a dictionary."""
         return cls(
             external_locations=_repeated_dict(d, "external_locations", ExternalLocationInfo),
@@ -4784,7 +4784,7 @@ class ListFunctionsResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListFunctionsResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ListFunctionsResponse:
         """Deserializes the ListFunctionsResponse from a dictionary."""
         return cls(
             functions=_repeated_dict(d, "functions", FunctionInfo), next_page_token=d.get("next_page_token", None)
@@ -4811,7 +4811,7 @@ class ListMetastoresResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListMetastoresResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ListMetastoresResponse:
         """Deserializes the ListMetastoresResponse from a dictionary."""
         return cls(metastores=_repeated_dict(d, "metastores", MetastoreInfo))
 
@@ -4843,7 +4843,7 @@ class ListModelVersionsResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListModelVersionsResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ListModelVersionsResponse:
         """Deserializes the ListModelVersionsResponse from a dictionary."""
         return cls(
             model_versions=_repeated_dict(d, "model_versions", ModelVersionInfo),
@@ -4879,7 +4879,7 @@ class ListQuotasResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListQuotasResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ListQuotasResponse:
         """Deserializes the ListQuotasResponse from a dictionary."""
         return cls(next_page_token=d.get("next_page_token", None), quotas=_repeated_dict(d, "quotas", QuotaInfo))
 
@@ -4911,7 +4911,7 @@ class ListRegisteredModelsResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListRegisteredModelsResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ListRegisteredModelsResponse:
         """Deserializes the ListRegisteredModelsResponse from a dictionary."""
         return cls(
             next_page_token=d.get("next_page_token", None),
@@ -4947,7 +4947,7 @@ class ListSchemasResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListSchemasResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ListSchemasResponse:
         """Deserializes the ListSchemasResponse from a dictionary."""
         return cls(next_page_token=d.get("next_page_token", None), schemas=_repeated_dict(d, "schemas", SchemaInfo))
 
@@ -4979,7 +4979,7 @@ class ListStorageCredentialsResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListStorageCredentialsResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ListStorageCredentialsResponse:
         """Deserializes the ListStorageCredentialsResponse from a dictionary."""
         return cls(
             next_page_token=d.get("next_page_token", None),
@@ -5015,7 +5015,7 @@ class ListSystemSchemasResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListSystemSchemasResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ListSystemSchemasResponse:
         """Deserializes the ListSystemSchemasResponse from a dictionary."""
         return cls(
             next_page_token=d.get("next_page_token", None), schemas=_repeated_dict(d, "schemas", SystemSchemaInfo)
@@ -5050,7 +5050,7 @@ class ListTableSummariesResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListTableSummariesResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ListTableSummariesResponse:
         """Deserializes the ListTableSummariesResponse from a dictionary."""
         return cls(next_page_token=d.get("next_page_token", None), tables=_repeated_dict(d, "tables", TableSummary))
 
@@ -5083,7 +5083,7 @@ class ListTablesResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListTablesResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ListTablesResponse:
         """Deserializes the ListTablesResponse from a dictionary."""
         return cls(next_page_token=d.get("next_page_token", None), tables=_repeated_dict(d, "tables", TableInfo))
 
@@ -5116,7 +5116,7 @@ class ListVolumesResponseContent:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListVolumesResponseContent:
+    def from_dict(cls, d: Dict[str, Any]) -> ListVolumesResponseContent:
         """Deserializes the ListVolumesResponseContent from a dictionary."""
         return cls(next_page_token=d.get("next_page_token", None), volumes=_repeated_dict(d, "volumes", VolumeInfo))
 
@@ -5161,7 +5161,7 @@ class MetastoreAssignment:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> MetastoreAssignment:
+    def from_dict(cls, d: Dict[str, Any]) -> MetastoreAssignment:
         """Deserializes the MetastoreAssignment from a dictionary."""
         return cls(
             default_catalog_name=d.get("default_catalog_name", None),
@@ -5321,7 +5321,7 @@ class MetastoreInfo:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> MetastoreInfo:
+    def from_dict(cls, d: Dict[str, Any]) -> MetastoreInfo:
         """Deserializes the MetastoreInfo from a dictionary."""
         return cls(
             cloud=d.get("cloud", None),
@@ -5504,7 +5504,7 @@ class ModelVersionInfo:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ModelVersionInfo:
+    def from_dict(cls, d: Dict[str, Any]) -> ModelVersionInfo:
         """Deserializes the ModelVersionInfo from a dictionary."""
         return cls(
             aliases=_repeated_dict(d, "aliases", RegisteredModelAlias),
@@ -5575,7 +5575,7 @@ class MonitorCronSchedule:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> MonitorCronSchedule:
+    def from_dict(cls, d: Dict[str, Any]) -> MonitorCronSchedule:
         """Deserializes the MonitorCronSchedule from a dictionary."""
         return cls(
             pause_status=_enum(d, "pause_status", MonitorCronSchedulePauseStatus),
@@ -5611,7 +5611,7 @@ class MonitorDataClassificationConfig:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> MonitorDataClassificationConfig:
+    def from_dict(cls, d: Dict[str, Any]) -> MonitorDataClassificationConfig:
         """Deserializes the MonitorDataClassificationConfig from a dictionary."""
         return cls(enabled=d.get("enabled", None))
 
@@ -5637,7 +5637,7 @@ class MonitorDestination:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> MonitorDestination:
+    def from_dict(cls, d: Dict[str, Any]) -> MonitorDestination:
         """Deserializes the MonitorDestination from a dictionary."""
         return cls(email_addresses=d.get("email_addresses", None))
 
@@ -5714,7 +5714,7 @@ class MonitorInferenceLog:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> MonitorInferenceLog:
+    def from_dict(cls, d: Dict[str, Any]) -> MonitorInferenceLog:
         """Deserializes the MonitorInferenceLog from a dictionary."""
         return cls(
             granularities=d.get("granularities", None),
@@ -5882,7 +5882,7 @@ class MonitorInfo:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> MonitorInfo:
+    def from_dict(cls, d: Dict[str, Any]) -> MonitorInfo:
         """Deserializes the MonitorInfo from a dictionary."""
         return cls(
             assets_dir=d.get("assets_dir", None),
@@ -5974,7 +5974,7 @@ class MonitorMetric:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> MonitorMetric:
+    def from_dict(cls, d: Dict[str, Any]) -> MonitorMetric:
         """Deserializes the MonitorMetric from a dictionary."""
         return cls(
             definition=d.get("definition", None),
@@ -6026,7 +6026,7 @@ class MonitorNotifications:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> MonitorNotifications:
+    def from_dict(cls, d: Dict[str, Any]) -> MonitorNotifications:
         """Deserializes the MonitorNotifications from a dictionary."""
         return cls(
             on_failure=_from_dict(d, "on_failure", MonitorDestination),
@@ -6089,7 +6089,7 @@ class MonitorRefreshInfo:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> MonitorRefreshInfo:
+    def from_dict(cls, d: Dict[str, Any]) -> MonitorRefreshInfo:
         """Deserializes the MonitorRefreshInfo from a dictionary."""
         return cls(
             end_time_ms=d.get("end_time_ms", None),
@@ -6138,7 +6138,7 @@ class MonitorRefreshListResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> MonitorRefreshListResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> MonitorRefreshListResponse:
         """Deserializes the MonitorRefreshListResponse from a dictionary."""
         return cls(refreshes=_repeated_dict(d, "refreshes", MonitorRefreshInfo))
 
@@ -6156,7 +6156,7 @@ class MonitorSnapshot:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> MonitorSnapshot:
+    def from_dict(cls, d: Dict[str, Any]) -> MonitorSnapshot:
         """Deserializes the MonitorSnapshot from a dictionary."""
         return cls()
 
@@ -6194,7 +6194,7 @@ class MonitorTimeSeries:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> MonitorTimeSeries:
+    def from_dict(cls, d: Dict[str, Any]) -> MonitorTimeSeries:
         """Deserializes the MonitorTimeSeries from a dictionary."""
         return cls(granularities=d.get("granularities", None), timestamp_col=d.get("timestamp_col", None))
 
@@ -6219,7 +6219,7 @@ class NamedTableConstraint:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> NamedTableConstraint:
+    def from_dict(cls, d: Dict[str, Any]) -> NamedTableConstraint:
         """Deserializes the NamedTableConstraint from a dictionary."""
         return cls(name=d.get("name", None))
 
@@ -6276,7 +6276,7 @@ class OnlineTable:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> OnlineTable:
+    def from_dict(cls, d: Dict[str, Any]) -> OnlineTable:
         """Deserializes the OnlineTable from a dictionary."""
         return cls(
             name=d.get("name", None),
@@ -6357,7 +6357,7 @@ class OnlineTableSpec:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> OnlineTableSpec:
+    def from_dict(cls, d: Dict[str, Any]) -> OnlineTableSpec:
         """Deserializes the OnlineTableSpec from a dictionary."""
         return cls(
             perform_full_copy=d.get("perform_full_copy", None),
@@ -6383,7 +6383,7 @@ class OnlineTableSpecContinuousSchedulingPolicy:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> OnlineTableSpecContinuousSchedulingPolicy:
+    def from_dict(cls, d: Dict[str, Any]) -> OnlineTableSpecContinuousSchedulingPolicy:
         """Deserializes the OnlineTableSpecContinuousSchedulingPolicy from a dictionary."""
         return cls()
 
@@ -6401,7 +6401,7 @@ class OnlineTableSpecTriggeredSchedulingPolicy:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> OnlineTableSpecTriggeredSchedulingPolicy:
+    def from_dict(cls, d: Dict[str, Any]) -> OnlineTableSpecTriggeredSchedulingPolicy:
         """Deserializes the OnlineTableSpecTriggeredSchedulingPolicy from a dictionary."""
         return cls()
 
@@ -6483,7 +6483,7 @@ class OnlineTableStatus:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> OnlineTableStatus:
+    def from_dict(cls, d: Dict[str, Any]) -> OnlineTableStatus:
         """Deserializes the OnlineTableStatus from a dictionary."""
         return cls(
             continuous_update_status=_from_dict(d, "continuous_update_status", ContinuousUpdateStatus),
@@ -6529,7 +6529,7 @@ class PermissionsChange:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> PermissionsChange:
+    def from_dict(cls, d: Dict[str, Any]) -> PermissionsChange:
         """Deserializes the PermissionsChange from a dictionary."""
         return cls(
             add=_repeated_enum(d, "add", Privilege),
@@ -6558,7 +6558,7 @@ class PermissionsList:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> PermissionsList:
+    def from_dict(cls, d: Dict[str, Any]) -> PermissionsList:
         """Deserializes the PermissionsList from a dictionary."""
         return cls(privilege_assignments=_repeated_dict(d, "privilege_assignments", PrivilegeAssignment))
 
@@ -6614,7 +6614,7 @@ class PipelineProgress:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> PipelineProgress:
+    def from_dict(cls, d: Dict[str, Any]) -> PipelineProgress:
         """Deserializes the PipelineProgress from a dictionary."""
         return cls(
             estimated_completion_time_seconds=d.get("estimated_completion_time_seconds", None),
@@ -6652,7 +6652,7 @@ class PrimaryKeyConstraint:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> PrimaryKeyConstraint:
+    def from_dict(cls, d: Dict[str, Any]) -> PrimaryKeyConstraint:
         """Deserializes the PrimaryKeyConstraint from a dictionary."""
         return cls(child_columns=d.get("child_columns", None), name=d.get("name", None))
 
@@ -6733,7 +6733,7 @@ class PrivilegeAssignment:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> PrivilegeAssignment:
+    def from_dict(cls, d: Dict[str, Any]) -> PrivilegeAssignment:
         """Deserializes the PrivilegeAssignment from a dictionary."""
         return cls(principal=d.get("principal", None), privileges=_repeated_enum(d, "privileges", Privilege))
 
@@ -6762,7 +6762,7 @@ class ProvisioningInfo:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ProvisioningInfo:
+    def from_dict(cls, d: Dict[str, Any]) -> ProvisioningInfo:
         """Deserializes the ProvisioningInfo from a dictionary."""
         return cls(state=_enum(d, "state", ProvisioningInfoState))
 
@@ -6801,7 +6801,7 @@ class ProvisioningStatus:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ProvisioningStatus:
+    def from_dict(cls, d: Dict[str, Any]) -> ProvisioningStatus:
         """Deserializes the ProvisioningStatus from a dictionary."""
         return cls(initial_pipeline_sync_progress=_from_dict(d, "initial_pipeline_sync_progress", PipelineProgress))
 
@@ -6861,7 +6861,7 @@ class QuotaInfo:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> QuotaInfo:
+    def from_dict(cls, d: Dict[str, Any]) -> QuotaInfo:
         """Deserializes the QuotaInfo from a dictionary."""
         return cls(
             last_refreshed_at=d.get("last_refreshed_at", None),
@@ -6910,7 +6910,7 @@ class R2Credentials:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> R2Credentials:
+    def from_dict(cls, d: Dict[str, Any]) -> R2Credentials:
         """Deserializes the R2Credentials from a dictionary."""
         return cls(
             access_key_id=d.get("access_key_id", None),
@@ -6947,7 +6947,7 @@ class RegenerateDashboardRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> RegenerateDashboardRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> RegenerateDashboardRequest:
         """Deserializes the RegenerateDashboardRequest from a dictionary."""
         return cls(table_name=d.get("table_name", None), warehouse_id=d.get("warehouse_id", None))
 
@@ -6979,7 +6979,7 @@ class RegenerateDashboardResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> RegenerateDashboardResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> RegenerateDashboardResponse:
         """Deserializes the RegenerateDashboardResponse from a dictionary."""
         return cls(dashboard_id=d.get("dashboard_id", None), parent_folder=d.get("parent_folder", None))
 
@@ -7013,7 +7013,7 @@ class RegisteredModelAlias:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> RegisteredModelAlias:
+    def from_dict(cls, d: Dict[str, Any]) -> RegisteredModelAlias:
         """Deserializes the RegisteredModelAlias from a dictionary."""
         return cls(alias_name=d.get("alias_name", None), version_num=d.get("version_num", None))
 
@@ -7130,7 +7130,7 @@ class RegisteredModelInfo:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> RegisteredModelInfo:
+    def from_dict(cls, d: Dict[str, Any]) -> RegisteredModelInfo:
         """Deserializes the RegisteredModelInfo from a dictionary."""
         return cls(
             aliases=_repeated_dict(d, "aliases", RegisteredModelAlias),
@@ -7289,7 +7289,7 @@ class SchemaInfo:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> SchemaInfo:
+    def from_dict(cls, d: Dict[str, Any]) -> SchemaInfo:
         """Deserializes the SchemaInfo from a dictionary."""
         return cls(
             browse_only=d.get("browse_only", None),
@@ -7368,7 +7368,7 @@ class SetArtifactAllowlist:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> SetArtifactAllowlist:
+    def from_dict(cls, d: Dict[str, Any]) -> SetArtifactAllowlist:
         """Deserializes the SetArtifactAllowlist from a dictionary."""
         return cls(
             artifact_matchers=_repeated_dict(d, "artifact_matchers", ArtifactMatcher),
@@ -7410,7 +7410,7 @@ class SetRegisteredModelAliasRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> SetRegisteredModelAliasRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> SetRegisteredModelAliasRequest:
         """Deserializes the SetRegisteredModelAliasRequest from a dictionary."""
         return cls(
             alias=d.get("alias", None), full_name=d.get("full_name", None), version_num=d.get("version_num", None)
@@ -7446,7 +7446,7 @@ class SseEncryptionDetails:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> SseEncryptionDetails:
+    def from_dict(cls, d: Dict[str, Any]) -> SseEncryptionDetails:
         """Deserializes the SseEncryptionDetails from a dictionary."""
         return cls(
             algorithm=_enum(d, "algorithm", SseEncryptionDetailsAlgorithm),
@@ -7599,7 +7599,7 @@ class StorageCredentialInfo:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> StorageCredentialInfo:
+    def from_dict(cls, d: Dict[str, Any]) -> StorageCredentialInfo:
         """Deserializes the StorageCredentialInfo from a dictionary."""
         return cls(
             aws_iam_role=_from_dict(d, "aws_iam_role", AwsIamRoleResponse),
@@ -7653,7 +7653,7 @@ class SystemSchemaInfo:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> SystemSchemaInfo:
+    def from_dict(cls, d: Dict[str, Any]) -> SystemSchemaInfo:
         """Deserializes the SystemSchemaInfo from a dictionary."""
         return cls(schema=d.get("schema", None), state=_enum(d, "state", SystemSchemaInfoState))
 
@@ -7703,7 +7703,7 @@ class TableConstraint:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> TableConstraint:
+    def from_dict(cls, d: Dict[str, Any]) -> TableConstraint:
         """Deserializes the TableConstraint from a dictionary."""
         return cls(
             foreign_key_constraint=_from_dict(d, "foreign_key_constraint", ForeignKeyConstraint),
@@ -7735,7 +7735,7 @@ class TableDependency:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> TableDependency:
+    def from_dict(cls, d: Dict[str, Any]) -> TableDependency:
         """Deserializes the TableDependency from a dictionary."""
         return cls(table_full_name=d.get("table_full_name", None))
 
@@ -7760,7 +7760,7 @@ class TableExistsResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> TableExistsResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> TableExistsResponse:
         """Deserializes the TableExistsResponse from a dictionary."""
         return cls(table_exists=d.get("table_exists", None))
 
@@ -8006,7 +8006,7 @@ class TableInfo:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> TableInfo:
+    def from_dict(cls, d: Dict[str, Any]) -> TableInfo:
         """Deserializes the TableInfo from a dictionary."""
         return cls(
             access_point=d.get("access_point", None),
@@ -8082,7 +8082,7 @@ class TableRowFilter:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> TableRowFilter:
+    def from_dict(cls, d: Dict[str, Any]) -> TableRowFilter:
         """Deserializes the TableRowFilter from a dictionary."""
         return cls(function_name=d.get("function_name", None), input_column_names=d.get("input_column_names", None))
 
@@ -8113,7 +8113,7 @@ class TableSummary:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> TableSummary:
+    def from_dict(cls, d: Dict[str, Any]) -> TableSummary:
         """Deserializes the TableSummary from a dictionary."""
         return cls(full_name=d.get("full_name", None), table_type=_enum(d, "table_type", TableType))
 
@@ -8176,7 +8176,7 @@ class TemporaryCredentials:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> TemporaryCredentials:
+    def from_dict(cls, d: Dict[str, Any]) -> TemporaryCredentials:
         """Deserializes the TemporaryCredentials from a dictionary."""
         return cls(
             aws_temp_credentials=_from_dict(d, "aws_temp_credentials", AwsCredentials),
@@ -8225,7 +8225,7 @@ class TriggeredUpdateStatus:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> TriggeredUpdateStatus:
+    def from_dict(cls, d: Dict[str, Any]) -> TriggeredUpdateStatus:
         """Deserializes the TriggeredUpdateStatus from a dictionary."""
         return cls(
             last_processed_commit_version=d.get("last_processed_commit_version", None),
@@ -8247,7 +8247,7 @@ class UnassignResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UnassignResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> UnassignResponse:
         """Deserializes the UnassignResponse from a dictionary."""
         return cls()
 
@@ -8265,7 +8265,7 @@ class UpdateAssignmentResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateAssignmentResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateAssignmentResponse:
         """Deserializes the UpdateAssignmentResponse from a dictionary."""
         return cls()
 
@@ -8347,7 +8347,7 @@ class UpdateCatalog:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateCatalog:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateCatalog:
         """Deserializes the UpdateCatalog from a dictionary."""
         return cls(
             comment=d.get("comment", None),
@@ -8402,7 +8402,7 @@ class UpdateConnection:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateConnection:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateConnection:
         """Deserializes the UpdateConnection from a dictionary."""
         return cls(
             name=d.get("name", None),
@@ -8511,7 +8511,7 @@ class UpdateCredentialRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateCredentialRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateCredentialRequest:
         """Deserializes the UpdateCredentialRequest from a dictionary."""
         return cls(
             aws_iam_role=_from_dict(d, "aws_iam_role", AwsIamRole),
@@ -8634,7 +8634,7 @@ class UpdateExternalLocation:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateExternalLocation:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateExternalLocation:
         """Deserializes the UpdateExternalLocation from a dictionary."""
         return cls(
             access_point=d.get("access_point", None),
@@ -8681,7 +8681,7 @@ class UpdateFunction:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateFunction:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateFunction:
         """Deserializes the UpdateFunction from a dictionary."""
         return cls(name=d.get("name", None), owner=d.get("owner", None))
 
@@ -8760,7 +8760,7 @@ class UpdateMetastore:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateMetastore:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateMetastore:
         """Deserializes the UpdateMetastore from a dictionary."""
         return cls(
             delta_sharing_organization_name=d.get("delta_sharing_organization_name", None),
@@ -8811,7 +8811,7 @@ class UpdateMetastoreAssignment:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateMetastoreAssignment:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateMetastoreAssignment:
         """Deserializes the UpdateMetastoreAssignment from a dictionary."""
         return cls(
             default_catalog_name=d.get("default_catalog_name", None),
@@ -8861,7 +8861,7 @@ class UpdateModelVersionRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateModelVersionRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateModelVersionRequest:
         """Deserializes the UpdateModelVersionRequest from a dictionary."""
         return cls(comment=d.get("comment", None), full_name=d.get("full_name", None), version=d.get("version", None))
 
@@ -8969,7 +8969,7 @@ class UpdateMonitor:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateMonitor:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateMonitor:
         """Deserializes the UpdateMonitor from a dictionary."""
         return cls(
             baseline_table_name=d.get("baseline_table_name", None),
@@ -9021,7 +9021,7 @@ class UpdatePermissions:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdatePermissions:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdatePermissions:
         """Deserializes the UpdatePermissions from a dictionary."""
         return cls(
             changes=_repeated_dict(d, "changes", PermissionsChange),
@@ -9071,7 +9071,7 @@ class UpdateRegisteredModelRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateRegisteredModelRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateRegisteredModelRequest:
         """Deserializes the UpdateRegisteredModelRequest from a dictionary."""
         return cls(
             comment=d.get("comment", None),
@@ -9094,7 +9094,7 @@ class UpdateResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateResponse:
         """Deserializes the UpdateResponse from a dictionary."""
         return cls()
 
@@ -9154,7 +9154,7 @@ class UpdateSchema:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateSchema:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateSchema:
         """Deserializes the UpdateSchema from a dictionary."""
         return cls(
             comment=d.get("comment", None),
@@ -9269,7 +9269,7 @@ class UpdateStorageCredential:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateStorageCredential:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateStorageCredential:
         """Deserializes the UpdateStorageCredential from a dictionary."""
         return cls(
             aws_iam_role=_from_dict(d, "aws_iam_role", AwsIamRoleRequest),
@@ -9331,7 +9331,7 @@ class UpdateVolumeRequestContent:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateVolumeRequestContent:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateVolumeRequestContent:
         """Deserializes the UpdateVolumeRequestContent from a dictionary."""
         return cls(
             comment=d.get("comment", None),
@@ -9375,7 +9375,7 @@ class UpdateWorkspaceBindings:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateWorkspaceBindings:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateWorkspaceBindings:
         """Deserializes the UpdateWorkspaceBindings from a dictionary."""
         return cls(
             assign_workspaces=d.get("assign_workspaces", None),
@@ -9425,7 +9425,7 @@ class UpdateWorkspaceBindingsParameters:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateWorkspaceBindingsParameters:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateWorkspaceBindingsParameters:
         """Deserializes the UpdateWorkspaceBindingsParameters from a dictionary."""
         return cls(
             add=_repeated_dict(d, "add", WorkspaceBinding),
@@ -9499,7 +9499,7 @@ class ValidateCredentialRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ValidateCredentialRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> ValidateCredentialRequest:
         """Deserializes the ValidateCredentialRequest from a dictionary."""
         return cls(
             aws_iam_role=_from_dict(d, "aws_iam_role", AwsIamRole),
@@ -9540,7 +9540,7 @@ class ValidateCredentialResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ValidateCredentialResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ValidateCredentialResponse:
         """Deserializes the ValidateCredentialResponse from a dictionary."""
         return cls(is_dir=d.get("isDir", None), results=_repeated_dict(d, "results", CredentialValidationResult))
 
@@ -9629,7 +9629,7 @@ class ValidateStorageCredential:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ValidateStorageCredential:
+    def from_dict(cls, d: Dict[str, Any]) -> ValidateStorageCredential:
         """Deserializes the ValidateStorageCredential from a dictionary."""
         return cls(
             aws_iam_role=_from_dict(d, "aws_iam_role", AwsIamRoleRequest),
@@ -9673,7 +9673,7 @@ class ValidateStorageCredentialResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ValidateStorageCredentialResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ValidateStorageCredentialResponse:
         """Deserializes the ValidateStorageCredentialResponse from a dictionary."""
         return cls(is_dir=d.get("isDir", None), results=_repeated_dict(d, "results", ValidationResult))
 
@@ -9712,7 +9712,7 @@ class ValidationResult:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ValidationResult:
+    def from_dict(cls, d: Dict[str, Any]) -> ValidationResult:
         """Deserializes the ValidationResult from a dictionary."""
         return cls(
             message=d.get("message", None),
@@ -9869,7 +9869,7 @@ class VolumeInfo:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> VolumeInfo:
+    def from_dict(cls, d: Dict[str, Any]) -> VolumeInfo:
         """Deserializes the VolumeInfo from a dictionary."""
         return cls(
             access_point=d.get("access_point", None),
@@ -9923,7 +9923,7 @@ class WorkspaceBinding:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> WorkspaceBinding:
+    def from_dict(cls, d: Dict[str, Any]) -> WorkspaceBinding:
         """Deserializes the WorkspaceBinding from a dictionary."""
         return cls(
             binding_type=_enum(d, "binding_type", WorkspaceBindingBindingType), workspace_id=d.get("workspace_id", None)
@@ -9966,7 +9966,7 @@ class WorkspaceBindingsResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> WorkspaceBindingsResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> WorkspaceBindingsResponse:
         """Deserializes the WorkspaceBindingsResponse from a dictionary."""
         return cls(
             bindings=_repeated_dict(d, "bindings", WorkspaceBinding), next_page_token=d.get("next_page_token", None)

--- a/databricks/sdk/service/cleanrooms.py
+++ b/databricks/sdk/service/cleanrooms.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from enum import Enum
-from typing import Dict, Iterator, List, Optional
+from typing import Any, Dict, Iterator, List, Optional
 
 from ._internal import _enum, _from_dict, _repeated_dict
 
@@ -106,7 +106,7 @@ class CleanRoom:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CleanRoom:
+    def from_dict(cls, d: Dict[str, Any]) -> CleanRoom:
         """Deserializes the CleanRoom from a dictionary."""
         return cls(
             access_restricted=_enum(d, "access_restricted", CleanRoomAccessRestricted),
@@ -248,7 +248,7 @@ class CleanRoomAsset:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CleanRoomAsset:
+    def from_dict(cls, d: Dict[str, Any]) -> CleanRoomAsset:
         """Deserializes the CleanRoomAsset from a dictionary."""
         return cls(
             added_at=d.get("added_at", None),
@@ -298,7 +298,7 @@ class CleanRoomAssetForeignTable:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CleanRoomAssetForeignTable:
+    def from_dict(cls, d: Dict[str, Any]) -> CleanRoomAssetForeignTable:
         """Deserializes the CleanRoomAssetForeignTable from a dictionary."""
         return cls(columns=_repeated_dict(d, "columns", catalog.ColumnInfo))
 
@@ -324,7 +324,7 @@ class CleanRoomAssetForeignTableLocalDetails:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CleanRoomAssetForeignTableLocalDetails:
+    def from_dict(cls, d: Dict[str, Any]) -> CleanRoomAssetForeignTableLocalDetails:
         """Deserializes the CleanRoomAssetForeignTableLocalDetails from a dictionary."""
         return cls(local_name=d.get("local_name", None))
 
@@ -357,7 +357,7 @@ class CleanRoomAssetNotebook:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CleanRoomAssetNotebook:
+    def from_dict(cls, d: Dict[str, Any]) -> CleanRoomAssetNotebook:
         """Deserializes the CleanRoomAssetNotebook from a dictionary."""
         return cls(etag=d.get("etag", None), notebook_content=d.get("notebook_content", None))
 
@@ -389,7 +389,7 @@ class CleanRoomAssetTable:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CleanRoomAssetTable:
+    def from_dict(cls, d: Dict[str, Any]) -> CleanRoomAssetTable:
         """Deserializes the CleanRoomAssetTable from a dictionary."""
         return cls(columns=_repeated_dict(d, "columns", catalog.ColumnInfo))
 
@@ -422,7 +422,7 @@ class CleanRoomAssetTableLocalDetails:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CleanRoomAssetTableLocalDetails:
+    def from_dict(cls, d: Dict[str, Any]) -> CleanRoomAssetTableLocalDetails:
         """Deserializes the CleanRoomAssetTableLocalDetails from a dictionary."""
         return cls(
             local_name=d.get("local_name", None),
@@ -450,7 +450,7 @@ class CleanRoomAssetView:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CleanRoomAssetView:
+    def from_dict(cls, d: Dict[str, Any]) -> CleanRoomAssetView:
         """Deserializes the CleanRoomAssetView from a dictionary."""
         return cls(columns=_repeated_dict(d, "columns", catalog.ColumnInfo))
 
@@ -476,7 +476,7 @@ class CleanRoomAssetViewLocalDetails:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CleanRoomAssetViewLocalDetails:
+    def from_dict(cls, d: Dict[str, Any]) -> CleanRoomAssetViewLocalDetails:
         """Deserializes the CleanRoomAssetViewLocalDetails from a dictionary."""
         return cls(local_name=d.get("local_name", None))
 
@@ -502,7 +502,7 @@ class CleanRoomAssetVolumeLocalDetails:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CleanRoomAssetVolumeLocalDetails:
+    def from_dict(cls, d: Dict[str, Any]) -> CleanRoomAssetVolumeLocalDetails:
         """Deserializes the CleanRoomAssetVolumeLocalDetails from a dictionary."""
         return cls(local_name=d.get("local_name", None))
 
@@ -576,7 +576,7 @@ class CleanRoomCollaborator:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CleanRoomCollaborator:
+    def from_dict(cls, d: Dict[str, Any]) -> CleanRoomCollaborator:
         """Deserializes the CleanRoomCollaborator from a dictionary."""
         return cls(
             collaborator_alias=d.get("collaborator_alias", None),
@@ -654,7 +654,7 @@ class CleanRoomNotebookTaskRun:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CleanRoomNotebookTaskRun:
+    def from_dict(cls, d: Dict[str, Any]) -> CleanRoomNotebookTaskRun:
         """Deserializes the CleanRoomNotebookTaskRun from a dictionary."""
         return cls(
             collaborator_job_run_info=_from_dict(d, "collaborator_job_run_info", CollaboratorJobRunInfo),
@@ -696,7 +696,7 @@ class CleanRoomOutputCatalog:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CleanRoomOutputCatalog:
+    def from_dict(cls, d: Dict[str, Any]) -> CleanRoomOutputCatalog:
         """Deserializes the CleanRoomOutputCatalog from a dictionary."""
         return cls(
             catalog_name=d.get("catalog_name", None),
@@ -780,7 +780,7 @@ class CleanRoomRemoteDetail:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CleanRoomRemoteDetail:
+    def from_dict(cls, d: Dict[str, Any]) -> CleanRoomRemoteDetail:
         """Deserializes the CleanRoomRemoteDetail from a dictionary."""
         return cls(
             central_clean_room_id=d.get("central_clean_room_id", None),
@@ -849,7 +849,7 @@ class CollaboratorJobRunInfo:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CollaboratorJobRunInfo:
+    def from_dict(cls, d: Dict[str, Any]) -> CollaboratorJobRunInfo:
         """Deserializes the CollaboratorJobRunInfo from a dictionary."""
         return cls(
             collaborator_alias=d.get("collaborator_alias", None),
@@ -889,7 +889,7 @@ class ComplianceSecurityProfile:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ComplianceSecurityProfile:
+    def from_dict(cls, d: Dict[str, Any]) -> ComplianceSecurityProfile:
         """Deserializes the ComplianceSecurityProfile from a dictionary."""
         return cls(
             compliance_standards=_repeated_dict(d, "compliance_standards", settings.ComplianceStandard),
@@ -916,7 +916,7 @@ class CreateCleanRoomOutputCatalogResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateCleanRoomOutputCatalogResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateCleanRoomOutputCatalogResponse:
         """Deserializes the CreateCleanRoomOutputCatalogResponse from a dictionary."""
         return cls(output_catalog=_from_dict(d, "output_catalog", CleanRoomOutputCatalog))
 
@@ -937,7 +937,7 @@ class DeleteCleanRoomAssetResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DeleteCleanRoomAssetResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> DeleteCleanRoomAssetResponse:
         """Deserializes the DeleteCleanRoomAssetResponse from a dictionary."""
         return cls()
 
@@ -955,7 +955,7 @@ class DeleteResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DeleteResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> DeleteResponse:
         """Deserializes the DeleteResponse from a dictionary."""
         return cls()
 
@@ -988,7 +988,7 @@ class ListCleanRoomAssetsResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListCleanRoomAssetsResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ListCleanRoomAssetsResponse:
         """Deserializes the ListCleanRoomAssetsResponse from a dictionary."""
         return cls(assets=_repeated_dict(d, "assets", CleanRoomAsset), next_page_token=d.get("next_page_token", None))
 
@@ -1021,7 +1021,7 @@ class ListCleanRoomNotebookTaskRunsResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListCleanRoomNotebookTaskRunsResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ListCleanRoomNotebookTaskRunsResponse:
         """Deserializes the ListCleanRoomNotebookTaskRunsResponse from a dictionary."""
         return cls(
             next_page_token=d.get("next_page_token", None), runs=_repeated_dict(d, "runs", CleanRoomNotebookTaskRun)
@@ -1055,7 +1055,7 @@ class ListCleanRoomsResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListCleanRoomsResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ListCleanRoomsResponse:
         """Deserializes the ListCleanRoomsResponse from a dictionary."""
         return cls(
             clean_rooms=_repeated_dict(d, "clean_rooms", CleanRoom), next_page_token=d.get("next_page_token", None)
@@ -1088,7 +1088,7 @@ class UpdateCleanRoomRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateCleanRoomRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateCleanRoomRequest:
         """Deserializes the UpdateCleanRoomRequest from a dictionary."""
         return cls(clean_room=_from_dict(d, "clean_room", CleanRoom), name=d.get("name", None))
 

--- a/databricks/sdk/service/compute.py
+++ b/databricks/sdk/service/compute.py
@@ -73,7 +73,7 @@ class AddInstanceProfile:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> AddInstanceProfile:
+    def from_dict(cls, d: Dict[str, Any]) -> AddInstanceProfile:
         """Deserializes the AddInstanceProfile from a dictionary."""
         return cls(
             iam_role_arn=d.get("iam_role_arn", None),
@@ -96,7 +96,7 @@ class AddResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> AddResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> AddResponse:
         """Deserializes the AddResponse from a dictionary."""
         return cls()
 
@@ -122,7 +122,7 @@ class Adlsgen2Info:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> Adlsgen2Info:
+    def from_dict(cls, d: Dict[str, Any]) -> Adlsgen2Info:
         """Deserializes the Adlsgen2Info from a dictionary."""
         return cls(destination=d.get("destination", None))
 
@@ -156,7 +156,7 @@ class AutoScale:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> AutoScale:
+    def from_dict(cls, d: Dict[str, Any]) -> AutoScale:
         """Deserializes the AutoScale from a dictionary."""
         return cls(max_workers=d.get("max_workers", None), min_workers=d.get("min_workers", None))
 
@@ -293,7 +293,7 @@ class AwsAttributes:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> AwsAttributes:
+    def from_dict(cls, d: Dict[str, Any]) -> AwsAttributes:
         """Deserializes the AwsAttributes from a dictionary."""
         return cls(
             availability=_enum(d, "availability", AwsAvailability),
@@ -371,7 +371,7 @@ class AzureAttributes:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> AzureAttributes:
+    def from_dict(cls, d: Dict[str, Any]) -> AzureAttributes:
         """Deserializes the AzureAttributes from a dictionary."""
         return cls(
             availability=_enum(d, "availability", AzureAvailability),
@@ -422,7 +422,7 @@ class CancelCommand:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CancelCommand:
+    def from_dict(cls, d: Dict[str, Any]) -> CancelCommand:
         """Deserializes the CancelCommand from a dictionary."""
         return cls(
             cluster_id=d.get("clusterId", None),
@@ -444,7 +444,7 @@ class CancelResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CancelResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> CancelResponse:
         """Deserializes the CancelResponse from a dictionary."""
         return cls()
 
@@ -476,7 +476,7 @@ class ChangeClusterOwner:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ChangeClusterOwner:
+    def from_dict(cls, d: Dict[str, Any]) -> ChangeClusterOwner:
         """Deserializes the ChangeClusterOwner from a dictionary."""
         return cls(cluster_id=d.get("cluster_id", None), owner_username=d.get("owner_username", None))
 
@@ -494,7 +494,7 @@ class ChangeClusterOwnerResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ChangeClusterOwnerResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ChangeClusterOwnerResponse:
         """Deserializes the ChangeClusterOwnerResponse from a dictionary."""
         return cls()
 
@@ -526,7 +526,7 @@ class ClientsTypes:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ClientsTypes:
+    def from_dict(cls, d: Dict[str, Any]) -> ClientsTypes:
         """Deserializes the ClientsTypes from a dictionary."""
         return cls(jobs=d.get("jobs", None), notebooks=d.get("notebooks", None))
 
@@ -551,7 +551,7 @@ class CloneCluster:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CloneCluster:
+    def from_dict(cls, d: Dict[str, Any]) -> CloneCluster:
         """Deserializes the CloneCluster from a dictionary."""
         return cls(source_cluster_id=d.get("source_cluster_id", None))
 
@@ -575,7 +575,7 @@ class CloudProviderNodeInfo:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CloudProviderNodeInfo:
+    def from_dict(cls, d: Dict[str, Any]) -> CloudProviderNodeInfo:
         """Deserializes the CloudProviderNodeInfo from a dictionary."""
         return cls(status=_repeated_enum(d, "status", CloudProviderNodeStatus))
 
@@ -627,7 +627,7 @@ class ClusterAccessControlRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ClusterAccessControlRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> ClusterAccessControlRequest:
         """Deserializes the ClusterAccessControlRequest from a dictionary."""
         return cls(
             group_name=d.get("group_name", None),
@@ -685,7 +685,7 @@ class ClusterAccessControlResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ClusterAccessControlResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ClusterAccessControlResponse:
         """Deserializes the ClusterAccessControlResponse from a dictionary."""
         return cls(
             all_permissions=_repeated_dict(d, "all_permissions", ClusterPermission),
@@ -977,7 +977,7 @@ class ClusterAttributes:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ClusterAttributes:
+    def from_dict(cls, d: Dict[str, Any]) -> ClusterAttributes:
         """Deserializes the ClusterAttributes from a dictionary."""
         return cls(
             autotermination_minutes=d.get("autotermination_minutes", None),
@@ -1046,7 +1046,7 @@ class ClusterCompliance:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ClusterCompliance:
+    def from_dict(cls, d: Dict[str, Any]) -> ClusterCompliance:
         """Deserializes the ClusterCompliance from a dictionary."""
         return cls(
             cluster_id=d.get("cluster_id", None),
@@ -1515,7 +1515,7 @@ class ClusterDetails:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ClusterDetails:
+    def from_dict(cls, d: Dict[str, Any]) -> ClusterDetails:
         """Deserializes the ClusterDetails from a dictionary."""
         return cls(
             autoscale=_from_dict(d, "autoscale", AutoScale),
@@ -1617,7 +1617,7 @@ class ClusterEvent:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ClusterEvent:
+    def from_dict(cls, d: Dict[str, Any]) -> ClusterEvent:
         """Deserializes the ClusterEvent from a dictionary."""
         return cls(
             cluster_id=d.get("cluster_id", None),
@@ -1655,7 +1655,7 @@ class ClusterLibraryStatuses:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ClusterLibraryStatuses:
+    def from_dict(cls, d: Dict[str, Any]) -> ClusterLibraryStatuses:
         """Deserializes the ClusterLibraryStatuses from a dictionary."""
         return cls(
             cluster_id=d.get("cluster_id", None),
@@ -1702,7 +1702,7 @@ class ClusterLogConf:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ClusterLogConf:
+    def from_dict(cls, d: Dict[str, Any]) -> ClusterLogConf:
         """Deserializes the ClusterLogConf from a dictionary."""
         return cls(
             dbfs=_from_dict(d, "dbfs", DbfsStorageInfo),
@@ -1743,7 +1743,7 @@ class ClusterPermission:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ClusterPermission:
+    def from_dict(cls, d: Dict[str, Any]) -> ClusterPermission:
         """Deserializes the ClusterPermission from a dictionary."""
         return cls(
             inherited=d.get("inherited", None),
@@ -1791,7 +1791,7 @@ class ClusterPermissions:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ClusterPermissions:
+    def from_dict(cls, d: Dict[str, Any]) -> ClusterPermissions:
         """Deserializes the ClusterPermissions from a dictionary."""
         return cls(
             access_control_list=_repeated_dict(d, "access_control_list", ClusterAccessControlResponse),
@@ -1826,7 +1826,7 @@ class ClusterPermissionsDescription:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ClusterPermissionsDescription:
+    def from_dict(cls, d: Dict[str, Any]) -> ClusterPermissionsDescription:
         """Deserializes the ClusterPermissionsDescription from a dictionary."""
         return cls(
             description=d.get("description", None),
@@ -1860,7 +1860,7 @@ class ClusterPermissionsRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ClusterPermissionsRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> ClusterPermissionsRequest:
         """Deserializes the ClusterPermissionsRequest from a dictionary."""
         return cls(
             access_control_list=_repeated_dict(d, "access_control_list", ClusterAccessControlRequest),
@@ -1909,7 +1909,7 @@ class ClusterPolicyAccessControlRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ClusterPolicyAccessControlRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> ClusterPolicyAccessControlRequest:
         """Deserializes the ClusterPolicyAccessControlRequest from a dictionary."""
         return cls(
             group_name=d.get("group_name", None),
@@ -1967,7 +1967,7 @@ class ClusterPolicyAccessControlResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ClusterPolicyAccessControlResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ClusterPolicyAccessControlResponse:
         """Deserializes the ClusterPolicyAccessControlResponse from a dictionary."""
         return cls(
             all_permissions=_repeated_dict(d, "all_permissions", ClusterPolicyPermission),
@@ -2010,7 +2010,7 @@ class ClusterPolicyPermission:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ClusterPolicyPermission:
+    def from_dict(cls, d: Dict[str, Any]) -> ClusterPolicyPermission:
         """Deserializes the ClusterPolicyPermission from a dictionary."""
         return cls(
             inherited=d.get("inherited", None),
@@ -2056,7 +2056,7 @@ class ClusterPolicyPermissions:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ClusterPolicyPermissions:
+    def from_dict(cls, d: Dict[str, Any]) -> ClusterPolicyPermissions:
         """Deserializes the ClusterPolicyPermissions from a dictionary."""
         return cls(
             access_control_list=_repeated_dict(d, "access_control_list", ClusterPolicyAccessControlResponse),
@@ -2091,7 +2091,7 @@ class ClusterPolicyPermissionsDescription:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ClusterPolicyPermissionsDescription:
+    def from_dict(cls, d: Dict[str, Any]) -> ClusterPolicyPermissionsDescription:
         """Deserializes the ClusterPolicyPermissionsDescription from a dictionary."""
         return cls(
             description=d.get("description", None),
@@ -2125,7 +2125,7 @@ class ClusterPolicyPermissionsRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ClusterPolicyPermissionsRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> ClusterPolicyPermissionsRequest:
         """Deserializes the ClusterPolicyPermissionsRequest from a dictionary."""
         return cls(
             access_control_list=_repeated_dict(d, "access_control_list", ClusterPolicyAccessControlRequest),
@@ -2174,7 +2174,7 @@ class ClusterSettingsChange:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ClusterSettingsChange:
+    def from_dict(cls, d: Dict[str, Any]) -> ClusterSettingsChange:
         """Deserializes the ClusterSettingsChange from a dictionary."""
         return cls(
             field=d.get("field", None), new_value=d.get("new_value", None), previous_value=d.get("previous_value", None)
@@ -2216,7 +2216,7 @@ class ClusterSize:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ClusterSize:
+    def from_dict(cls, d: Dict[str, Any]) -> ClusterSize:
         """Deserializes the ClusterSize from a dictionary."""
         return cls(autoscale=_from_dict(d, "autoscale", AutoScale), num_workers=d.get("num_workers", None))
 
@@ -2545,7 +2545,7 @@ class ClusterSpec:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ClusterSpec:
+    def from_dict(cls, d: Dict[str, Any]) -> ClusterSpec:
         """Deserializes the ClusterSpec from a dictionary."""
         return cls(
             apply_policy_default_values=d.get("apply_policy_default_values", None),
@@ -2621,7 +2621,7 @@ class Command:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> Command:
+    def from_dict(cls, d: Dict[str, Any]) -> Command:
         """Deserializes the Command from a dictionary."""
         return cls(
             cluster_id=d.get("clusterId", None),
@@ -2672,7 +2672,7 @@ class CommandStatusResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CommandStatusResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> CommandStatusResponse:
         """Deserializes the CommandStatusResponse from a dictionary."""
         return cls(
             id=d.get("id", None), results=_from_dict(d, "results", Results), status=_enum(d, "status", CommandStatus)
@@ -2711,7 +2711,7 @@ class ContextStatusResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ContextStatusResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ContextStatusResponse:
         """Deserializes the ContextStatusResponse from a dictionary."""
         return cls(id=d.get("id", None), status=_enum(d, "status", ContextStatus))
 
@@ -3035,7 +3035,7 @@ class CreateCluster:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateCluster:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateCluster:
         """Deserializes the CreateCluster from a dictionary."""
         return cls(
             apply_policy_default_values=d.get("apply_policy_default_values", None),
@@ -3091,7 +3091,7 @@ class CreateClusterResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateClusterResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateClusterResponse:
         """Deserializes the CreateClusterResponse from a dictionary."""
         return cls(cluster_id=d.get("cluster_id", None))
 
@@ -3122,7 +3122,7 @@ class CreateContext:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateContext:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateContext:
         """Deserializes the CreateContext from a dictionary."""
         return cls(cluster_id=d.get("clusterId", None), language=_enum(d, "language", Language))
 
@@ -3252,7 +3252,7 @@ class CreateInstancePool:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateInstancePool:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateInstancePool:
         """Deserializes the CreateInstancePool from a dictionary."""
         return cls(
             aws_attributes=_from_dict(d, "aws_attributes", InstancePoolAwsAttributes),
@@ -3291,7 +3291,7 @@ class CreateInstancePoolResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateInstancePoolResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateInstancePoolResponse:
         """Deserializes the CreateInstancePoolResponse from a dictionary."""
         return cls(instance_pool_id=d.get("instance_pool_id", None))
 
@@ -3373,7 +3373,7 @@ class CreatePolicy:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreatePolicy:
+    def from_dict(cls, d: Dict[str, Any]) -> CreatePolicy:
         """Deserializes the CreatePolicy from a dictionary."""
         return cls(
             definition=d.get("definition", None),
@@ -3406,7 +3406,7 @@ class CreatePolicyResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreatePolicyResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> CreatePolicyResponse:
         """Deserializes the CreatePolicyResponse from a dictionary."""
         return cls(policy_id=d.get("policy_id", None))
 
@@ -3431,7 +3431,7 @@ class CreateResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateResponse:
         """Deserializes the CreateResponse from a dictionary."""
         return cls(script_id=d.get("script_id", None))
 
@@ -3455,7 +3455,7 @@ class Created:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> Created:
+    def from_dict(cls, d: Dict[str, Any]) -> Created:
         """Deserializes the Created from a dictionary."""
         return cls(id=d.get("id", None))
 
@@ -3495,7 +3495,7 @@ class CustomPolicyTag:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CustomPolicyTag:
+    def from_dict(cls, d: Dict[str, Any]) -> CustomPolicyTag:
         """Deserializes the CustomPolicyTag from a dictionary."""
         return cls(key=d.get("key", None), value=d.get("value", None))
 
@@ -3541,7 +3541,7 @@ class DataPlaneEventDetails:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DataPlaneEventDetails:
+    def from_dict(cls, d: Dict[str, Any]) -> DataPlaneEventDetails:
         """Deserializes the DataPlaneEventDetails from a dictionary."""
         return cls(
             event_type=_enum(d, "event_type", DataPlaneEventDetailsEventType),
@@ -3616,7 +3616,7 @@ class DbfsStorageInfo:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DbfsStorageInfo:
+    def from_dict(cls, d: Dict[str, Any]) -> DbfsStorageInfo:
         """Deserializes the DbfsStorageInfo from a dictionary."""
         return cls(destination=d.get("destination", None))
 
@@ -3641,7 +3641,7 @@ class DeleteCluster:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DeleteCluster:
+    def from_dict(cls, d: Dict[str, Any]) -> DeleteCluster:
         """Deserializes the DeleteCluster from a dictionary."""
         return cls(cluster_id=d.get("cluster_id", None))
 
@@ -3659,7 +3659,7 @@ class DeleteClusterResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DeleteClusterResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> DeleteClusterResponse:
         """Deserializes the DeleteClusterResponse from a dictionary."""
         return cls()
 
@@ -3684,7 +3684,7 @@ class DeleteInstancePool:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DeleteInstancePool:
+    def from_dict(cls, d: Dict[str, Any]) -> DeleteInstancePool:
         """Deserializes the DeleteInstancePool from a dictionary."""
         return cls(instance_pool_id=d.get("instance_pool_id", None))
 
@@ -3702,7 +3702,7 @@ class DeleteInstancePoolResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DeleteInstancePoolResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> DeleteInstancePoolResponse:
         """Deserializes the DeleteInstancePoolResponse from a dictionary."""
         return cls()
 
@@ -3727,7 +3727,7 @@ class DeletePolicy:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DeletePolicy:
+    def from_dict(cls, d: Dict[str, Any]) -> DeletePolicy:
         """Deserializes the DeletePolicy from a dictionary."""
         return cls(policy_id=d.get("policy_id", None))
 
@@ -3745,7 +3745,7 @@ class DeletePolicyResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DeletePolicyResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> DeletePolicyResponse:
         """Deserializes the DeletePolicyResponse from a dictionary."""
         return cls()
 
@@ -3763,7 +3763,7 @@ class DeleteResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DeleteResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> DeleteResponse:
         """Deserializes the DeleteResponse from a dictionary."""
         return cls()
 
@@ -3793,7 +3793,7 @@ class DestroyContext:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DestroyContext:
+    def from_dict(cls, d: Dict[str, Any]) -> DestroyContext:
         """Deserializes the DestroyContext from a dictionary."""
         return cls(cluster_id=d.get("clusterId", None), context_id=d.get("contextId", None))
 
@@ -3811,7 +3811,7 @@ class DestroyResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DestroyResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> DestroyResponse:
         """Deserializes the DestroyResponse from a dictionary."""
         return cls()
 
@@ -3879,7 +3879,7 @@ class DiskSpec:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DiskSpec:
+    def from_dict(cls, d: Dict[str, Any]) -> DiskSpec:
         """Deserializes the DiskSpec from a dictionary."""
         return cls(
             disk_count=d.get("disk_count", None),
@@ -3915,7 +3915,7 @@ class DiskType:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DiskType:
+    def from_dict(cls, d: Dict[str, Any]) -> DiskType:
         """Deserializes the DiskType from a dictionary."""
         return cls(
             azure_disk_volume_type=_enum(d, "azure_disk_volume_type", DiskTypeAzureDiskVolumeType),
@@ -3962,7 +3962,7 @@ class DockerBasicAuth:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DockerBasicAuth:
+    def from_dict(cls, d: Dict[str, Any]) -> DockerBasicAuth:
         """Deserializes the DockerBasicAuth from a dictionary."""
         return cls(password=d.get("password", None), username=d.get("username", None))
 
@@ -3993,7 +3993,7 @@ class DockerImage:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DockerImage:
+    def from_dict(cls, d: Dict[str, Any]) -> DockerImage:
         """Deserializes the DockerImage from a dictionary."""
         return cls(basic_auth=_from_dict(d, "basic_auth", DockerBasicAuth), url=d.get("url", None))
 
@@ -4323,7 +4323,7 @@ class EditCluster:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> EditCluster:
+    def from_dict(cls, d: Dict[str, Any]) -> EditCluster:
         """Deserializes the EditCluster from a dictionary."""
         return cls(
             apply_policy_default_values=d.get("apply_policy_default_values", None),
@@ -4373,7 +4373,7 @@ class EditClusterResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> EditClusterResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> EditClusterResponse:
         """Deserializes the EditClusterResponse from a dictionary."""
         return cls()
 
@@ -4453,7 +4453,7 @@ class EditInstancePool:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> EditInstancePool:
+    def from_dict(cls, d: Dict[str, Any]) -> EditInstancePool:
         """Deserializes the EditInstancePool from a dictionary."""
         return cls(
             custom_tags=d.get("custom_tags", None),
@@ -4479,7 +4479,7 @@ class EditInstancePoolResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> EditInstancePoolResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> EditInstancePoolResponse:
         """Deserializes the EditInstancePoolResponse from a dictionary."""
         return cls()
 
@@ -4568,7 +4568,7 @@ class EditPolicy:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> EditPolicy:
+    def from_dict(cls, d: Dict[str, Any]) -> EditPolicy:
         """Deserializes the EditPolicy from a dictionary."""
         return cls(
             definition=d.get("definition", None),
@@ -4595,7 +4595,7 @@ class EditPolicyResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> EditPolicyResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> EditPolicyResponse:
         """Deserializes the EditPolicyResponse from a dictionary."""
         return cls()
 
@@ -4613,7 +4613,7 @@ class EditResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> EditResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> EditResponse:
         """Deserializes the EditResponse from a dictionary."""
         return cls()
 
@@ -4646,7 +4646,7 @@ class EnforceClusterComplianceRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> EnforceClusterComplianceRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> EnforceClusterComplianceRequest:
         """Deserializes the EnforceClusterComplianceRequest from a dictionary."""
         return cls(cluster_id=d.get("cluster_id", None), validate_only=d.get("validate_only", None))
 
@@ -4680,7 +4680,7 @@ class EnforceClusterComplianceResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> EnforceClusterComplianceResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> EnforceClusterComplianceResponse:
         """Deserializes the EnforceClusterComplianceResponse from a dictionary."""
         return cls(changes=_repeated_dict(d, "changes", ClusterSettingsChange), has_changes=d.get("has_changes", None))
 
@@ -4722,7 +4722,7 @@ class Environment:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> Environment:
+    def from_dict(cls, d: Dict[str, Any]) -> Environment:
         """Deserializes the Environment from a dictionary."""
         return cls(client=d.get("client", None), dependencies=d.get("dependencies", None))
 
@@ -4883,7 +4883,7 @@ class EventDetails:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> EventDetails:
+    def from_dict(cls, d: Dict[str, Any]) -> EventDetails:
         """Deserializes the EventDetails from a dictionary."""
         return cls(
             attributes=_from_dict(d, "attributes", ClusterAttributes),
@@ -5019,7 +5019,7 @@ class GcpAttributes:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GcpAttributes:
+    def from_dict(cls, d: Dict[str, Any]) -> GcpAttributes:
         """Deserializes the GcpAttributes from a dictionary."""
         return cls(
             availability=_enum(d, "availability", GcpAvailability),
@@ -5060,7 +5060,7 @@ class GcsStorageInfo:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GcsStorageInfo:
+    def from_dict(cls, d: Dict[str, Any]) -> GcsStorageInfo:
         """Deserializes the GcsStorageInfo from a dictionary."""
         return cls(destination=d.get("destination", None))
 
@@ -5095,7 +5095,7 @@ class GetClusterComplianceResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GetClusterComplianceResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> GetClusterComplianceResponse:
         """Deserializes the GetClusterComplianceResponse from a dictionary."""
         return cls(is_compliant=d.get("is_compliant", None), violations=d.get("violations", None))
 
@@ -5120,7 +5120,7 @@ class GetClusterPermissionLevelsResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GetClusterPermissionLevelsResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> GetClusterPermissionLevelsResponse:
         """Deserializes the GetClusterPermissionLevelsResponse from a dictionary."""
         return cls(permission_levels=_repeated_dict(d, "permission_levels", ClusterPermissionsDescription))
 
@@ -5145,7 +5145,7 @@ class GetClusterPolicyPermissionLevelsResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GetClusterPolicyPermissionLevelsResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> GetClusterPolicyPermissionLevelsResponse:
         """Deserializes the GetClusterPolicyPermissionLevelsResponse from a dictionary."""
         return cls(permission_levels=_repeated_dict(d, "permission_levels", ClusterPolicyPermissionsDescription))
 
@@ -5215,7 +5215,7 @@ class GetEvents:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GetEvents:
+    def from_dict(cls, d: Dict[str, Any]) -> GetEvents:
         """Deserializes the GetEvents from a dictionary."""
         return cls(
             cluster_id=d.get("cluster_id", None),
@@ -5270,7 +5270,7 @@ class GetEventsResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GetEventsResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> GetEventsResponse:
         """Deserializes the GetEventsResponse from a dictionary."""
         return cls(
             events=_repeated_dict(d, "events", ClusterEvent),
@@ -5447,7 +5447,7 @@ class GetInstancePool:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GetInstancePool:
+    def from_dict(cls, d: Dict[str, Any]) -> GetInstancePool:
         """Deserializes the GetInstancePool from a dictionary."""
         return cls(
             aws_attributes=_from_dict(d, "aws_attributes", InstancePoolAwsAttributes),
@@ -5491,7 +5491,7 @@ class GetInstancePoolPermissionLevelsResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GetInstancePoolPermissionLevelsResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> GetInstancePoolPermissionLevelsResponse:
         """Deserializes the GetInstancePoolPermissionLevelsResponse from a dictionary."""
         return cls(permission_levels=_repeated_dict(d, "permission_levels", InstancePoolPermissionsDescription))
 
@@ -5516,7 +5516,7 @@ class GetSparkVersionsResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GetSparkVersionsResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> GetSparkVersionsResponse:
         """Deserializes the GetSparkVersionsResponse from a dictionary."""
         return cls(versions=_repeated_dict(d, "versions", SparkVersion))
 
@@ -5570,7 +5570,7 @@ class GlobalInitScriptCreateRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GlobalInitScriptCreateRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> GlobalInitScriptCreateRequest:
         """Deserializes the GlobalInitScriptCreateRequest from a dictionary."""
         return cls(
             enabled=d.get("enabled", None),
@@ -5650,7 +5650,7 @@ class GlobalInitScriptDetails:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GlobalInitScriptDetails:
+    def from_dict(cls, d: Dict[str, Any]) -> GlobalInitScriptDetails:
         """Deserializes the GlobalInitScriptDetails from a dictionary."""
         return cls(
             created_at=d.get("created_at", None),
@@ -5741,7 +5741,7 @@ class GlobalInitScriptDetailsWithContent:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GlobalInitScriptDetailsWithContent:
+    def from_dict(cls, d: Dict[str, Any]) -> GlobalInitScriptDetailsWithContent:
         """Deserializes the GlobalInitScriptDetailsWithContent from a dictionary."""
         return cls(
             created_at=d.get("created_at", None),
@@ -5812,7 +5812,7 @@ class GlobalInitScriptUpdateRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GlobalInitScriptUpdateRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> GlobalInitScriptUpdateRequest:
         """Deserializes the GlobalInitScriptUpdateRequest from a dictionary."""
         return cls(
             enabled=d.get("enabled", None),
@@ -5857,7 +5857,7 @@ class InitScriptEventDetails:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> InitScriptEventDetails:
+    def from_dict(cls, d: Dict[str, Any]) -> InitScriptEventDetails:
         """Deserializes the InitScriptEventDetails from a dictionary."""
         return cls(
             cluster=_repeated_dict(d, "cluster", InitScriptInfoAndExecutionDetails),
@@ -5900,7 +5900,7 @@ class InitScriptExecutionDetails:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> InitScriptExecutionDetails:
+    def from_dict(cls, d: Dict[str, Any]) -> InitScriptExecutionDetails:
         """Deserializes the InitScriptExecutionDetails from a dictionary."""
         return cls(
             error_message=d.get("error_message", None),
@@ -5990,7 +5990,7 @@ class InitScriptInfo:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> InitScriptInfo:
+    def from_dict(cls, d: Dict[str, Any]) -> InitScriptInfo:
         """Deserializes the InitScriptInfo from a dictionary."""
         return cls(
             abfss=_from_dict(d, "abfss", Adlsgen2Info),
@@ -6030,7 +6030,7 @@ class InitScriptInfoAndExecutionDetails:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> InitScriptInfoAndExecutionDetails:
+    def from_dict(cls, d: Dict[str, Any]) -> InitScriptInfoAndExecutionDetails:
         """Deserializes the InitScriptInfoAndExecutionDetails from a dictionary."""
         return cls(
             execution_details=_from_dict(d, "execution_details", InitScriptExecutionDetails),
@@ -6065,7 +6065,7 @@ class InstallLibraries:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> InstallLibraries:
+    def from_dict(cls, d: Dict[str, Any]) -> InstallLibraries:
         """Deserializes the InstallLibraries from a dictionary."""
         return cls(cluster_id=d.get("cluster_id", None), libraries=_repeated_dict(d, "libraries", Library))
 
@@ -6083,7 +6083,7 @@ class InstallLibrariesResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> InstallLibrariesResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> InstallLibrariesResponse:
         """Deserializes the InstallLibrariesResponse from a dictionary."""
         return cls()
 
@@ -6129,7 +6129,7 @@ class InstancePoolAccessControlRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> InstancePoolAccessControlRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> InstancePoolAccessControlRequest:
         """Deserializes the InstancePoolAccessControlRequest from a dictionary."""
         return cls(
             group_name=d.get("group_name", None),
@@ -6187,7 +6187,7 @@ class InstancePoolAccessControlResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> InstancePoolAccessControlResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> InstancePoolAccessControlResponse:
         """Deserializes the InstancePoolAccessControlResponse from a dictionary."""
         return cls(
             all_permissions=_repeated_dict(d, "all_permissions", InstancePoolPermission),
@@ -6366,7 +6366,7 @@ class InstancePoolAndStats:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> InstancePoolAndStats:
+    def from_dict(cls, d: Dict[str, Any]) -> InstancePoolAndStats:
         """Deserializes the InstancePoolAndStats from a dictionary."""
         return cls(
             aws_attributes=_from_dict(d, "aws_attributes", InstancePoolAwsAttributes),
@@ -6440,7 +6440,7 @@ class InstancePoolAwsAttributes:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> InstancePoolAwsAttributes:
+    def from_dict(cls, d: Dict[str, Any]) -> InstancePoolAwsAttributes:
         """Deserializes the InstancePoolAwsAttributes from a dictionary."""
         return cls(
             availability=_enum(d, "availability", InstancePoolAwsAttributesAvailability),
@@ -6488,7 +6488,7 @@ class InstancePoolAzureAttributes:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> InstancePoolAzureAttributes:
+    def from_dict(cls, d: Dict[str, Any]) -> InstancePoolAzureAttributes:
         """Deserializes the InstancePoolAzureAttributes from a dictionary."""
         return cls(
             availability=_enum(d, "availability", InstancePoolAzureAttributesAvailability),
@@ -6555,7 +6555,7 @@ class InstancePoolGcpAttributes:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> InstancePoolGcpAttributes:
+    def from_dict(cls, d: Dict[str, Any]) -> InstancePoolGcpAttributes:
         """Deserializes the InstancePoolGcpAttributes from a dictionary."""
         return cls(
             gcp_availability=_enum(d, "gcp_availability", GcpAvailability),
@@ -6596,7 +6596,7 @@ class InstancePoolPermission:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> InstancePoolPermission:
+    def from_dict(cls, d: Dict[str, Any]) -> InstancePoolPermission:
         """Deserializes the InstancePoolPermission from a dictionary."""
         return cls(
             inherited=d.get("inherited", None),
@@ -6643,7 +6643,7 @@ class InstancePoolPermissions:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> InstancePoolPermissions:
+    def from_dict(cls, d: Dict[str, Any]) -> InstancePoolPermissions:
         """Deserializes the InstancePoolPermissions from a dictionary."""
         return cls(
             access_control_list=_repeated_dict(d, "access_control_list", InstancePoolAccessControlResponse),
@@ -6678,7 +6678,7 @@ class InstancePoolPermissionsDescription:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> InstancePoolPermissionsDescription:
+    def from_dict(cls, d: Dict[str, Any]) -> InstancePoolPermissionsDescription:
         """Deserializes the InstancePoolPermissionsDescription from a dictionary."""
         return cls(
             description=d.get("description", None),
@@ -6712,7 +6712,7 @@ class InstancePoolPermissionsRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> InstancePoolPermissionsRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> InstancePoolPermissionsRequest:
         """Deserializes the InstancePoolPermissionsRequest from a dictionary."""
         return cls(
             access_control_list=_repeated_dict(d, "access_control_list", InstancePoolAccessControlRequest),
@@ -6769,7 +6769,7 @@ class InstancePoolStats:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> InstancePoolStats:
+    def from_dict(cls, d: Dict[str, Any]) -> InstancePoolStats:
         """Deserializes the InstancePoolStats from a dictionary."""
         return cls(
             idle_count=d.get("idle_count", None),
@@ -6801,7 +6801,7 @@ class InstancePoolStatus:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> InstancePoolStatus:
+    def from_dict(cls, d: Dict[str, Any]) -> InstancePoolStatus:
         """Deserializes the InstancePoolStatus from a dictionary."""
         return cls(pending_instance_errors=_repeated_dict(d, "pending_instance_errors", PendingInstanceError))
 
@@ -6849,7 +6849,7 @@ class InstanceProfile:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> InstanceProfile:
+    def from_dict(cls, d: Dict[str, Any]) -> InstanceProfile:
         """Deserializes the InstanceProfile from a dictionary."""
         return cls(
             iam_role_arn=d.get("iam_role_arn", None),
@@ -6950,7 +6950,7 @@ class Library:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> Library:
+    def from_dict(cls, d: Dict[str, Any]) -> Library:
         """Deserializes the Library from a dictionary."""
         return cls(
             cran=_from_dict(d, "cran", RCranLibrary),
@@ -7006,7 +7006,7 @@ class LibraryFullStatus:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> LibraryFullStatus:
+    def from_dict(cls, d: Dict[str, Any]) -> LibraryFullStatus:
         """Deserializes the LibraryFullStatus from a dictionary."""
         return cls(
             is_library_for_all_clusters=d.get("is_library_for_all_clusters", None),
@@ -7049,7 +7049,7 @@ class ListAllClusterLibraryStatusesResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListAllClusterLibraryStatusesResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ListAllClusterLibraryStatusesResponse:
         """Deserializes the ListAllClusterLibraryStatusesResponse from a dictionary."""
         return cls(statuses=_repeated_dict(d, "statuses", ClusterLibraryStatuses))
 
@@ -7081,7 +7081,7 @@ class ListAvailableZonesResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListAvailableZonesResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ListAvailableZonesResponse:
         """Deserializes the ListAvailableZonesResponse from a dictionary."""
         return cls(default_zone=d.get("default_zone", None), zones=d.get("zones", None))
 
@@ -7122,7 +7122,7 @@ class ListClusterCompliancesResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListClusterCompliancesResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ListClusterCompliancesResponse:
         """Deserializes the ListClusterCompliancesResponse from a dictionary."""
         return cls(
             clusters=_repeated_dict(d, "clusters", ClusterCompliance),
@@ -7172,7 +7172,7 @@ class ListClustersFilterBy:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListClustersFilterBy:
+    def from_dict(cls, d: Dict[str, Any]) -> ListClustersFilterBy:
         """Deserializes the ListClustersFilterBy from a dictionary."""
         return cls(
             cluster_sources=_repeated_enum(d, "cluster_sources", ClusterSource),
@@ -7218,7 +7218,7 @@ class ListClustersResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListClustersResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ListClustersResponse:
         """Deserializes the ListClustersResponse from a dictionary."""
         return cls(
             clusters=_repeated_dict(d, "clusters", ClusterDetails),
@@ -7255,7 +7255,7 @@ class ListClustersSortBy:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListClustersSortBy:
+    def from_dict(cls, d: Dict[str, Any]) -> ListClustersSortBy:
         """Deserializes the ListClustersSortBy from a dictionary."""
         return cls(
             direction=_enum(d, "direction", ListClustersSortByDirection),
@@ -7297,7 +7297,7 @@ class ListGlobalInitScriptsResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListGlobalInitScriptsResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ListGlobalInitScriptsResponse:
         """Deserializes the ListGlobalInitScriptsResponse from a dictionary."""
         return cls(scripts=_repeated_dict(d, "scripts", GlobalInitScriptDetails))
 
@@ -7321,7 +7321,7 @@ class ListInstancePools:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListInstancePools:
+    def from_dict(cls, d: Dict[str, Any]) -> ListInstancePools:
         """Deserializes the ListInstancePools from a dictionary."""
         return cls(instance_pools=_repeated_dict(d, "instance_pools", InstancePoolAndStats))
 
@@ -7346,7 +7346,7 @@ class ListInstanceProfilesResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListInstanceProfilesResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ListInstanceProfilesResponse:
         """Deserializes the ListInstanceProfilesResponse from a dictionary."""
         return cls(instance_profiles=_repeated_dict(d, "instance_profiles", InstanceProfile))
 
@@ -7371,7 +7371,7 @@ class ListNodeTypesResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListNodeTypesResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ListNodeTypesResponse:
         """Deserializes the ListNodeTypesResponse from a dictionary."""
         return cls(node_types=_repeated_dict(d, "node_types", NodeType))
 
@@ -7396,7 +7396,7 @@ class ListPoliciesResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListPoliciesResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ListPoliciesResponse:
         """Deserializes the ListPoliciesResponse from a dictionary."""
         return cls(policies=_repeated_dict(d, "policies", Policy))
 
@@ -7429,7 +7429,7 @@ class ListPolicyFamiliesResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListPolicyFamiliesResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ListPolicyFamiliesResponse:
         """Deserializes the ListPolicyFamiliesResponse from a dictionary."""
         return cls(
             next_page_token=d.get("next_page_token", None),
@@ -7470,7 +7470,7 @@ class LocalFileInfo:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> LocalFileInfo:
+    def from_dict(cls, d: Dict[str, Any]) -> LocalFileInfo:
         """Deserializes the LocalFileInfo from a dictionary."""
         return cls(destination=d.get("destination", None))
 
@@ -7502,7 +7502,7 @@ class LogAnalyticsInfo:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> LogAnalyticsInfo:
+    def from_dict(cls, d: Dict[str, Any]) -> LogAnalyticsInfo:
         """Deserializes the LogAnalyticsInfo from a dictionary."""
         return cls(
             log_analytics_primary_key=d.get("log_analytics_primary_key", None),
@@ -7539,7 +7539,7 @@ class LogSyncStatus:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> LogSyncStatus:
+    def from_dict(cls, d: Dict[str, Any]) -> LogSyncStatus:
         """Deserializes the LogSyncStatus from a dictionary."""
         return cls(last_attempted=d.get("last_attempted", None), last_exception=d.get("last_exception", None))
 
@@ -7582,7 +7582,7 @@ class MavenLibrary:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> MavenLibrary:
+    def from_dict(cls, d: Dict[str, Any]) -> MavenLibrary:
         """Deserializes the MavenLibrary from a dictionary."""
         return cls(
             coordinates=d.get("coordinates", None), exclusions=d.get("exclusions", None), repo=d.get("repo", None)
@@ -7632,7 +7632,7 @@ class NodeInstanceType:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> NodeInstanceType:
+    def from_dict(cls, d: Dict[str, Any]) -> NodeInstanceType:
         """Deserializes the NodeInstanceType from a dictionary."""
         return cls(
             instance_type_id=d.get("instance_type_id", None),
@@ -7794,7 +7794,7 @@ class NodeType:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> NodeType:
+    def from_dict(cls, d: Dict[str, Any]) -> NodeType:
         """Deserializes the NodeType from a dictionary."""
         return cls(
             category=d.get("category", None),
@@ -7846,7 +7846,7 @@ class PendingInstanceError:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> PendingInstanceError:
+    def from_dict(cls, d: Dict[str, Any]) -> PendingInstanceError:
         """Deserializes the PendingInstanceError from a dictionary."""
         return cls(instance_id=d.get("instance_id", None), message=d.get("message", None))
 
@@ -7871,7 +7871,7 @@ class PermanentDeleteCluster:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> PermanentDeleteCluster:
+    def from_dict(cls, d: Dict[str, Any]) -> PermanentDeleteCluster:
         """Deserializes the PermanentDeleteCluster from a dictionary."""
         return cls(cluster_id=d.get("cluster_id", None))
 
@@ -7889,7 +7889,7 @@ class PermanentDeleteClusterResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> PermanentDeleteClusterResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> PermanentDeleteClusterResponse:
         """Deserializes the PermanentDeleteClusterResponse from a dictionary."""
         return cls()
 
@@ -7914,7 +7914,7 @@ class PinCluster:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> PinCluster:
+    def from_dict(cls, d: Dict[str, Any]) -> PinCluster:
         """Deserializes the PinCluster from a dictionary."""
         return cls(cluster_id=d.get("cluster_id", None))
 
@@ -7932,7 +7932,7 @@ class PinClusterResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> PinClusterResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> PinClusterResponse:
         """Deserializes the PinClusterResponse from a dictionary."""
         return cls()
 
@@ -8046,7 +8046,7 @@ class Policy:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> Policy:
+    def from_dict(cls, d: Dict[str, Any]) -> Policy:
         """Deserializes the Policy from a dictionary."""
         return cls(
             created_at_timestamp=d.get("created_at_timestamp", None),
@@ -8106,7 +8106,7 @@ class PolicyFamily:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> PolicyFamily:
+    def from_dict(cls, d: Dict[str, Any]) -> PolicyFamily:
         """Deserializes the PolicyFamily from a dictionary."""
         return cls(
             definition=d.get("definition", None),
@@ -8144,7 +8144,7 @@ class PythonPyPiLibrary:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> PythonPyPiLibrary:
+    def from_dict(cls, d: Dict[str, Any]) -> PythonPyPiLibrary:
         """Deserializes the PythonPyPiLibrary from a dictionary."""
         return cls(package=d.get("package", None), repo=d.get("repo", None))
 
@@ -8176,7 +8176,7 @@ class RCranLibrary:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> RCranLibrary:
+    def from_dict(cls, d: Dict[str, Any]) -> RCranLibrary:
         """Deserializes the RCranLibrary from a dictionary."""
         return cls(package=d.get("package", None), repo=d.get("repo", None))
 
@@ -8201,7 +8201,7 @@ class RemoveInstanceProfile:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> RemoveInstanceProfile:
+    def from_dict(cls, d: Dict[str, Any]) -> RemoveInstanceProfile:
         """Deserializes the RemoveInstanceProfile from a dictionary."""
         return cls(instance_profile_arn=d.get("instance_profile_arn", None))
 
@@ -8219,7 +8219,7 @@ class RemoveResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> RemoveResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> RemoveResponse:
         """Deserializes the RemoveResponse from a dictionary."""
         return cls()
 
@@ -8266,7 +8266,7 @@ class ResizeCluster:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ResizeCluster:
+    def from_dict(cls, d: Dict[str, Any]) -> ResizeCluster:
         """Deserializes the ResizeCluster from a dictionary."""
         return cls(
             autoscale=_from_dict(d, "autoscale", AutoScale),
@@ -8288,7 +8288,7 @@ class ResizeClusterResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ResizeClusterResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ResizeClusterResponse:
         """Deserializes the ResizeClusterResponse from a dictionary."""
         return cls()
 
@@ -8320,7 +8320,7 @@ class RestartCluster:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> RestartCluster:
+    def from_dict(cls, d: Dict[str, Any]) -> RestartCluster:
         """Deserializes the RestartCluster from a dictionary."""
         return cls(cluster_id=d.get("cluster_id", None), restart_user=d.get("restart_user", None))
 
@@ -8338,7 +8338,7 @@ class RestartClusterResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> RestartClusterResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> RestartClusterResponse:
         """Deserializes the RestartClusterResponse from a dictionary."""
         return cls()
 
@@ -8432,7 +8432,7 @@ class Results:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> Results:
+    def from_dict(cls, d: Dict[str, Any]) -> Results:
         """Deserializes the Results from a dictionary."""
         return cls(
             cause=d.get("cause", None),
@@ -8536,7 +8536,7 @@ class S3StorageInfo:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> S3StorageInfo:
+    def from_dict(cls, d: Dict[str, Any]) -> S3StorageInfo:
         """Deserializes the S3StorageInfo from a dictionary."""
         return cls(
             canned_acl=d.get("canned_acl", None),
@@ -8620,7 +8620,7 @@ class SparkNode:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> SparkNode:
+    def from_dict(cls, d: Dict[str, Any]) -> SparkNode:
         """Deserializes the SparkNode from a dictionary."""
         return cls(
             host_private_ip=d.get("host_private_ip", None),
@@ -8653,7 +8653,7 @@ class SparkNodeAwsAttributes:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> SparkNodeAwsAttributes:
+    def from_dict(cls, d: Dict[str, Any]) -> SparkNodeAwsAttributes:
         """Deserializes the SparkNodeAwsAttributes from a dictionary."""
         return cls(is_spot=d.get("is_spot", None))
 
@@ -8688,7 +8688,7 @@ class SparkVersion:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> SparkVersion:
+    def from_dict(cls, d: Dict[str, Any]) -> SparkVersion:
         """Deserializes the SparkVersion from a dictionary."""
         return cls(key=d.get("key", None), name=d.get("name", None))
 
@@ -8713,7 +8713,7 @@ class StartCluster:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> StartCluster:
+    def from_dict(cls, d: Dict[str, Any]) -> StartCluster:
         """Deserializes the StartCluster from a dictionary."""
         return cls(cluster_id=d.get("cluster_id", None))
 
@@ -8731,7 +8731,7 @@ class StartClusterResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> StartClusterResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> StartClusterResponse:
         """Deserializes the StartClusterResponse from a dictionary."""
         return cls()
 
@@ -8783,7 +8783,7 @@ class TerminationReason:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> TerminationReason:
+    def from_dict(cls, d: Dict[str, Any]) -> TerminationReason:
         """Deserializes the TerminationReason from a dictionary."""
         return cls(
             code=_enum(d, "code", TerminationReasonCode),
@@ -8912,7 +8912,7 @@ class UninstallLibraries:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UninstallLibraries:
+    def from_dict(cls, d: Dict[str, Any]) -> UninstallLibraries:
         """Deserializes the UninstallLibraries from a dictionary."""
         return cls(cluster_id=d.get("cluster_id", None), libraries=_repeated_dict(d, "libraries", Library))
 
@@ -8930,7 +8930,7 @@ class UninstallLibrariesResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UninstallLibrariesResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> UninstallLibrariesResponse:
         """Deserializes the UninstallLibrariesResponse from a dictionary."""
         return cls()
 
@@ -8955,7 +8955,7 @@ class UnpinCluster:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UnpinCluster:
+    def from_dict(cls, d: Dict[str, Any]) -> UnpinCluster:
         """Deserializes the UnpinCluster from a dictionary."""
         return cls(cluster_id=d.get("cluster_id", None))
 
@@ -8973,7 +8973,7 @@ class UnpinClusterResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UnpinClusterResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> UnpinClusterResponse:
         """Deserializes the UnpinClusterResponse from a dictionary."""
         return cls()
 
@@ -9015,7 +9015,7 @@ class UpdateCluster:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateCluster:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateCluster:
         """Deserializes the UpdateCluster from a dictionary."""
         return cls(
             cluster=_from_dict(d, "cluster", UpdateClusterResource),
@@ -9327,7 +9327,7 @@ class UpdateClusterResource:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateClusterResource:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateClusterResource:
         """Deserializes the UpdateClusterResource from a dictionary."""
         return cls(
             autoscale=_from_dict(d, "autoscale", AutoScale),
@@ -9375,7 +9375,7 @@ class UpdateClusterResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateClusterResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateClusterResponse:
         """Deserializes the UpdateClusterResponse from a dictionary."""
         return cls()
 
@@ -9393,7 +9393,7 @@ class UpdateResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateResponse:
         """Deserializes the UpdateResponse from a dictionary."""
         return cls()
 
@@ -9418,7 +9418,7 @@ class VolumesStorageInfo:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> VolumesStorageInfo:
+    def from_dict(cls, d: Dict[str, Any]) -> VolumesStorageInfo:
         """Deserializes the VolumesStorageInfo from a dictionary."""
         return cls(destination=d.get("destination", None))
 
@@ -9443,7 +9443,7 @@ class WorkloadType:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> WorkloadType:
+    def from_dict(cls, d: Dict[str, Any]) -> WorkloadType:
         """Deserializes the WorkloadType from a dictionary."""
         return cls(clients=_from_dict(d, "clients", ClientsTypes))
 
@@ -9468,7 +9468,7 @@ class WorkspaceStorageInfo:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> WorkspaceStorageInfo:
+    def from_dict(cls, d: Dict[str, Any]) -> WorkspaceStorageInfo:
         """Deserializes the WorkspaceStorageInfo from a dictionary."""
         return cls(destination=d.get("destination", None))
 

--- a/databricks/sdk/service/dashboards.py
+++ b/databricks/sdk/service/dashboards.py
@@ -8,7 +8,7 @@ import time
 from dataclasses import dataclass
 from datetime import timedelta
 from enum import Enum
-from typing import Callable, Dict, Iterator, List, Optional
+from typing import Any, Callable, Dict, Iterator, List, Optional
 
 from ..errors import OperationFailed
 from ._internal import Wait, _enum, _from_dict, _repeated_dict
@@ -40,7 +40,7 @@ class CancelQueryExecutionResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CancelQueryExecutionResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> CancelQueryExecutionResponse:
         """Deserializes the CancelQueryExecutionResponse from a dictionary."""
         return cls(status=_repeated_dict(d, "status", CancelQueryExecutionResponseStatus))
 
@@ -82,7 +82,7 @@ class CancelQueryExecutionResponseStatus:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CancelQueryExecutionResponseStatus:
+    def from_dict(cls, d: Dict[str, Any]) -> CancelQueryExecutionResponseStatus:
         """Deserializes the CancelQueryExecutionResponseStatus from a dictionary."""
         return cls(
             data_token=d.get("data_token", None),
@@ -124,7 +124,7 @@ class CronSchedule:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CronSchedule:
+    def from_dict(cls, d: Dict[str, Any]) -> CronSchedule:
         """Deserializes the CronSchedule from a dictionary."""
         return cls(quartz_cron_expression=d.get("quartz_cron_expression", None), timezone_id=d.get("timezone_id", None))
 
@@ -221,7 +221,7 @@ class Dashboard:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> Dashboard:
+    def from_dict(cls, d: Dict[str, Any]) -> Dashboard:
         """Deserializes the Dashboard from a dictionary."""
         return cls(
             create_time=d.get("create_time", None),
@@ -276,7 +276,7 @@ class DeleteScheduleResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DeleteScheduleResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> DeleteScheduleResponse:
         """Deserializes the DeleteScheduleResponse from a dictionary."""
         return cls()
 
@@ -294,7 +294,7 @@ class DeleteSubscriptionResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DeleteSubscriptionResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> DeleteSubscriptionResponse:
         """Deserializes the DeleteSubscriptionResponse from a dictionary."""
         return cls()
 
@@ -315,7 +315,7 @@ class Empty:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> Empty:
+    def from_dict(cls, d: Dict[str, Any]) -> Empty:
         """Deserializes the Empty from a dictionary."""
         return cls()
 
@@ -360,7 +360,7 @@ class ExecutePublishedDashboardQueryRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ExecutePublishedDashboardQueryRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> ExecutePublishedDashboardQueryRequest:
         """Deserializes the ExecutePublishedDashboardQueryRequest from a dictionary."""
         return cls(
             dashboard_name=d.get("dashboard_name", None),
@@ -382,7 +382,7 @@ class ExecuteQueryResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ExecuteQueryResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ExecuteQueryResponse:
         """Deserializes the ExecuteQueryResponse from a dictionary."""
         return cls()
 
@@ -414,7 +414,7 @@ class GenieAttachment:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GenieAttachment:
+    def from_dict(cls, d: Dict[str, Any]) -> GenieAttachment:
         """Deserializes the GenieAttachment from a dictionary."""
         return cls(query=_from_dict(d, "query", QueryAttachment), text=_from_dict(d, "text", TextAttachment))
 
@@ -474,7 +474,7 @@ class GenieConversation:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GenieConversation:
+    def from_dict(cls, d: Dict[str, Any]) -> GenieConversation:
         """Deserializes the GenieConversation from a dictionary."""
         return cls(
             created_timestamp=d.get("created_timestamp", None),
@@ -520,7 +520,7 @@ class GenieCreateConversationMessageRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GenieCreateConversationMessageRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> GenieCreateConversationMessageRequest:
         """Deserializes the GenieCreateConversationMessageRequest from a dictionary."""
         return cls(
             content=d.get("content", None),
@@ -550,7 +550,7 @@ class GenieGetMessageQueryResultResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GenieGetMessageQueryResultResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> GenieGetMessageQueryResultResponse:
         """Deserializes the GenieGetMessageQueryResultResponse from a dictionary."""
         return cls(statement_response=_from_dict(d, "statement_response", sql.StatementResponse))
 
@@ -657,7 +657,7 @@ class GenieMessage:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GenieMessage:
+    def from_dict(cls, d: Dict[str, Any]) -> GenieMessage:
         """Deserializes the GenieMessage from a dictionary."""
         return cls(
             attachments=_repeated_dict(d, "attachments", GenieAttachment),
@@ -701,7 +701,7 @@ class GenieStartConversationMessageRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GenieStartConversationMessageRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> GenieStartConversationMessageRequest:
         """Deserializes the GenieStartConversationMessageRequest from a dictionary."""
         return cls(content=d.get("content", None), space_id=d.get("space_id", None))
 
@@ -745,7 +745,7 @@ class GenieStartConversationResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GenieStartConversationResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> GenieStartConversationResponse:
         """Deserializes the GenieStartConversationResponse from a dictionary."""
         return cls(
             conversation=_from_dict(d, "conversation", GenieConversation),
@@ -768,7 +768,7 @@ class GetPublishedDashboardEmbeddedResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GetPublishedDashboardEmbeddedResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> GetPublishedDashboardEmbeddedResponse:
         """Deserializes the GetPublishedDashboardEmbeddedResponse from a dictionary."""
         return cls()
 
@@ -806,7 +806,7 @@ class ListDashboardsResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListDashboardsResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ListDashboardsResponse:
         """Deserializes the ListDashboardsResponse from a dictionary."""
         return cls(
             dashboards=_repeated_dict(d, "dashboards", Dashboard), next_page_token=d.get("next_page_token", None)
@@ -840,7 +840,7 @@ class ListSchedulesResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListSchedulesResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ListSchedulesResponse:
         """Deserializes the ListSchedulesResponse from a dictionary."""
         return cls(next_page_token=d.get("next_page_token", None), schedules=_repeated_dict(d, "schedules", Schedule))
 
@@ -872,7 +872,7 @@ class ListSubscriptionsResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListSubscriptionsResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ListSubscriptionsResponse:
         """Deserializes the ListSubscriptionsResponse from a dictionary."""
         return cls(
             next_page_token=d.get("next_page_token", None),
@@ -905,7 +905,7 @@ class MessageError:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> MessageError:
+    def from_dict(cls, d: Dict[str, Any]) -> MessageError:
         """Deserializes the MessageError from a dictionary."""
         return cls(error=d.get("error", None), type=_enum(d, "type", MessageErrorType))
 
@@ -1024,7 +1024,7 @@ class MigrateDashboardRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> MigrateDashboardRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> MigrateDashboardRequest:
         """Deserializes the MigrateDashboardRequest from a dictionary."""
         return cls(
             display_name=d.get("display_name", None),
@@ -1055,7 +1055,7 @@ class PendingStatus:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> PendingStatus:
+    def from_dict(cls, d: Dict[str, Any]) -> PendingStatus:
         """Deserializes the PendingStatus from a dictionary."""
         return cls(data_token=d.get("data_token", None))
 
@@ -1079,7 +1079,7 @@ class PollQueryStatusResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> PollQueryStatusResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> PollQueryStatusResponse:
         """Deserializes the PollQueryStatusResponse from a dictionary."""
         return cls(data=_repeated_dict(d, "data", PollQueryStatusResponseData))
 
@@ -1103,7 +1103,7 @@ class PollQueryStatusResponseData:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> PollQueryStatusResponseData:
+    def from_dict(cls, d: Dict[str, Any]) -> PollQueryStatusResponseData:
         """Deserializes the PollQueryStatusResponseData from a dictionary."""
         return cls(status=_from_dict(d, "status", QueryResponseStatus))
 
@@ -1143,7 +1143,7 @@ class PublishRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> PublishRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> PublishRequest:
         """Deserializes the PublishRequest from a dictionary."""
         return cls(
             dashboard_id=d.get("dashboard_id", None),
@@ -1193,7 +1193,7 @@ class PublishedDashboard:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> PublishedDashboard:
+    def from_dict(cls, d: Dict[str, Any]) -> PublishedDashboard:
         """Deserializes the PublishedDashboard from a dictionary."""
         return cls(
             display_name=d.get("display_name", None),
@@ -1277,7 +1277,7 @@ class QueryAttachment:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> QueryAttachment:
+    def from_dict(cls, d: Dict[str, Any]) -> QueryAttachment:
         """Deserializes the QueryAttachment from a dictionary."""
         return cls(
             cached_query_schema=_from_dict(d, "cached_query_schema", QuerySchema),
@@ -1342,7 +1342,7 @@ class QueryResponseStatus:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> QueryResponseStatus:
+    def from_dict(cls, d: Dict[str, Any]) -> QueryResponseStatus:
         """Deserializes the QueryResponseStatus from a dictionary."""
         return cls(
             canceled=_from_dict(d, "canceled", Empty),
@@ -1380,7 +1380,7 @@ class QuerySchema:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> QuerySchema:
+    def from_dict(cls, d: Dict[str, Any]) -> QuerySchema:
         """Deserializes the QuerySchema from a dictionary."""
         return cls(columns=_repeated_dict(d, "columns", QuerySchemaColumn), statement_id=d.get("statement_id", None))
 
@@ -1418,7 +1418,7 @@ class QuerySchemaColumn:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> QuerySchemaColumn:
+    def from_dict(cls, d: Dict[str, Any]) -> QuerySchemaColumn:
         """Deserializes the QuerySchemaColumn from a dictionary."""
         return cls(
             data_type=_enum(d, "data_type", DataType), name=d.get("name", None), type_text=d.get("type_text", None)
@@ -1460,7 +1460,7 @@ class Result:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> Result:
+    def from_dict(cls, d: Dict[str, Any]) -> Result:
         """Deserializes the Result from a dictionary."""
         return cls(
             is_truncated=d.get("is_truncated", None),
@@ -1547,7 +1547,7 @@ class Schedule:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> Schedule:
+    def from_dict(cls, d: Dict[str, Any]) -> Schedule:
         """Deserializes the Schedule from a dictionary."""
         return cls(
             create_time=d.get("create_time", None),
@@ -1597,7 +1597,7 @@ class Subscriber:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> Subscriber:
+    def from_dict(cls, d: Dict[str, Any]) -> Subscriber:
         """Deserializes the Subscriber from a dictionary."""
         return cls(
             destination_subscriber=_from_dict(d, "destination_subscriber", SubscriptionSubscriberDestination),
@@ -1676,7 +1676,7 @@ class Subscription:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> Subscription:
+    def from_dict(cls, d: Dict[str, Any]) -> Subscription:
         """Deserializes the Subscription from a dictionary."""
         return cls(
             create_time=d.get("create_time", None),
@@ -1710,7 +1710,7 @@ class SubscriptionSubscriberDestination:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> SubscriptionSubscriberDestination:
+    def from_dict(cls, d: Dict[str, Any]) -> SubscriptionSubscriberDestination:
         """Deserializes the SubscriptionSubscriberDestination from a dictionary."""
         return cls(destination_id=d.get("destination_id", None))
 
@@ -1735,7 +1735,7 @@ class SubscriptionSubscriberUser:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> SubscriptionSubscriberUser:
+    def from_dict(cls, d: Dict[str, Any]) -> SubscriptionSubscriberUser:
         """Deserializes the SubscriptionSubscriberUser from a dictionary."""
         return cls(user_id=d.get("user_id", None))
 
@@ -1768,7 +1768,7 @@ class SuccessStatus:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> SuccessStatus:
+    def from_dict(cls, d: Dict[str, Any]) -> SuccessStatus:
         """Deserializes the SuccessStatus from a dictionary."""
         return cls(data_token=d.get("data_token", None), truncated=d.get("truncated", None))
 
@@ -1799,7 +1799,7 @@ class TextAttachment:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> TextAttachment:
+    def from_dict(cls, d: Dict[str, Any]) -> TextAttachment:
         """Deserializes the TextAttachment from a dictionary."""
         return cls(content=d.get("content", None), id=d.get("id", None))
 
@@ -1817,7 +1817,7 @@ class TrashDashboardResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> TrashDashboardResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> TrashDashboardResponse:
         """Deserializes the TrashDashboardResponse from a dictionary."""
         return cls()
 
@@ -1835,7 +1835,7 @@ class UnpublishDashboardResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UnpublishDashboardResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> UnpublishDashboardResponse:
         """Deserializes the UnpublishDashboardResponse from a dictionary."""
         return cls()
 

--- a/databricks/sdk/service/files.py
+++ b/databricks/sdk/service/files.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import BinaryIO, Dict, Iterator, List, Optional
+from typing import Any, BinaryIO, Dict, Iterator, List, Optional
 
 from ._internal import _escape_multi_segment_path_parameter, _repeated_dict
 
@@ -41,7 +41,7 @@ class AddBlock:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> AddBlock:
+    def from_dict(cls, d: Dict[str, Any]) -> AddBlock:
         """Deserializes the AddBlock from a dictionary."""
         return cls(data=d.get("data", None), handle=d.get("handle", None))
 
@@ -59,7 +59,7 @@ class AddBlockResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> AddBlockResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> AddBlockResponse:
         """Deserializes the AddBlockResponse from a dictionary."""
         return cls()
 
@@ -84,7 +84,7 @@ class Close:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> Close:
+    def from_dict(cls, d: Dict[str, Any]) -> Close:
         """Deserializes the Close from a dictionary."""
         return cls(handle=d.get("handle", None))
 
@@ -102,7 +102,7 @@ class CloseResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CloseResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> CloseResponse:
         """Deserializes the CloseResponse from a dictionary."""
         return cls()
 
@@ -134,7 +134,7 @@ class Create:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> Create:
+    def from_dict(cls, d: Dict[str, Any]) -> Create:
         """Deserializes the Create from a dictionary."""
         return cls(overwrite=d.get("overwrite", None), path=d.get("path", None))
 
@@ -152,7 +152,7 @@ class CreateDirectoryResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateDirectoryResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateDirectoryResponse:
         """Deserializes the CreateDirectoryResponse from a dictionary."""
         return cls()
 
@@ -178,7 +178,7 @@ class CreateResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateResponse:
         """Deserializes the CreateResponse from a dictionary."""
         return cls(handle=d.get("handle", None))
 
@@ -211,7 +211,7 @@ class Delete:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> Delete:
+    def from_dict(cls, d: Dict[str, Any]) -> Delete:
         """Deserializes the Delete from a dictionary."""
         return cls(path=d.get("path", None), recursive=d.get("recursive", None))
 
@@ -229,7 +229,7 @@ class DeleteDirectoryResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DeleteDirectoryResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> DeleteDirectoryResponse:
         """Deserializes the DeleteDirectoryResponse from a dictionary."""
         return cls()
 
@@ -247,7 +247,7 @@ class DeleteResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DeleteResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> DeleteResponse:
         """Deserializes the DeleteResponse from a dictionary."""
         return cls()
 
@@ -300,7 +300,7 @@ class DirectoryEntry:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DirectoryEntry:
+    def from_dict(cls, d: Dict[str, Any]) -> DirectoryEntry:
         """Deserializes the DirectoryEntry from a dictionary."""
         return cls(
             file_size=d.get("file_size", None),
@@ -348,7 +348,7 @@ class DownloadResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DownloadResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> DownloadResponse:
         """Deserializes the DownloadResponse from a dictionary."""
         return cls(
             content_length=int(d.get("content-length", None)),
@@ -399,7 +399,7 @@ class FileInfo:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> FileInfo:
+    def from_dict(cls, d: Dict[str, Any]) -> FileInfo:
         """Deserializes the FileInfo from a dictionary."""
         return cls(
             file_size=d.get("file_size", None),
@@ -422,7 +422,7 @@ class GetDirectoryMetadataResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GetDirectoryMetadataResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> GetDirectoryMetadataResponse:
         """Deserializes the GetDirectoryMetadataResponse from a dictionary."""
         return cls()
 
@@ -458,7 +458,7 @@ class GetMetadataResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GetMetadataResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> GetMetadataResponse:
         """Deserializes the GetMetadataResponse from a dictionary."""
         return cls(
             content_length=int(d.get("content-length", None)),
@@ -494,7 +494,7 @@ class ListDirectoryResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListDirectoryResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ListDirectoryResponse:
         """Deserializes the ListDirectoryResponse from a dictionary."""
         return cls(
             contents=_repeated_dict(d, "contents", DirectoryEntry), next_page_token=d.get("next_page_token", None)
@@ -521,7 +521,7 @@ class ListStatusResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListStatusResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ListStatusResponse:
         """Deserializes the ListStatusResponse from a dictionary."""
         return cls(files=_repeated_dict(d, "files", FileInfo))
 
@@ -546,7 +546,7 @@ class MkDirs:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> MkDirs:
+    def from_dict(cls, d: Dict[str, Any]) -> MkDirs:
         """Deserializes the MkDirs from a dictionary."""
         return cls(path=d.get("path", None))
 
@@ -564,7 +564,7 @@ class MkDirsResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> MkDirsResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> MkDirsResponse:
         """Deserializes the MkDirsResponse from a dictionary."""
         return cls()
 
@@ -596,7 +596,7 @@ class Move:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> Move:
+    def from_dict(cls, d: Dict[str, Any]) -> Move:
         """Deserializes the Move from a dictionary."""
         return cls(destination_path=d.get("destination_path", None), source_path=d.get("source_path", None))
 
@@ -614,7 +614,7 @@ class MoveResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> MoveResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> MoveResponse:
         """Deserializes the MoveResponse from a dictionary."""
         return cls()
 
@@ -653,7 +653,7 @@ class Put:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> Put:
+    def from_dict(cls, d: Dict[str, Any]) -> Put:
         """Deserializes the Put from a dictionary."""
         return cls(contents=d.get("contents", None), overwrite=d.get("overwrite", None), path=d.get("path", None))
 
@@ -671,7 +671,7 @@ class PutResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> PutResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> PutResponse:
         """Deserializes the PutResponse from a dictionary."""
         return cls()
 
@@ -704,7 +704,7 @@ class ReadResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ReadResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ReadResponse:
         """Deserializes the ReadResponse from a dictionary."""
         return cls(bytes_read=d.get("bytes_read", None), data=d.get("data", None))
 
@@ -722,7 +722,7 @@ class UploadResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UploadResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> UploadResponse:
         """Deserializes the UploadResponse from a dictionary."""
         return cls()
 

--- a/databricks/sdk/service/iam.py
+++ b/databricks/sdk/service/iam.py
@@ -56,7 +56,7 @@ class AccessControlRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> AccessControlRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> AccessControlRequest:
         """Deserializes the AccessControlRequest from a dictionary."""
         return cls(
             group_name=d.get("group_name", None),
@@ -114,7 +114,7 @@ class AccessControlResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> AccessControlResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> AccessControlResponse:
         """Deserializes the AccessControlResponse from a dictionary."""
         return cls(
             all_permissions=_repeated_dict(d, "all_permissions", Permission),
@@ -147,7 +147,7 @@ class Actor:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> Actor:
+    def from_dict(cls, d: Dict[str, Any]) -> Actor:
         """Deserializes the Actor from a dictionary."""
         return cls(actor_id=d.get("actor_id", None))
 
@@ -177,7 +177,7 @@ class CheckPolicyResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CheckPolicyResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> CheckPolicyResponse:
         """Deserializes the CheckPolicyResponse from a dictionary."""
         return cls(
             consistency_token=_from_dict(d, "consistency_token", ConsistencyToken),
@@ -228,7 +228,7 @@ class ComplexValue:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ComplexValue:
+    def from_dict(cls, d: Dict[str, Any]) -> ComplexValue:
         """Deserializes the ComplexValue from a dictionary."""
         return cls(
             display=d.get("display", None),
@@ -258,7 +258,7 @@ class ConsistencyToken:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ConsistencyToken:
+    def from_dict(cls, d: Dict[str, Any]) -> ConsistencyToken:
         """Deserializes the ConsistencyToken from a dictionary."""
         return cls(value=d.get("value", None))
 
@@ -276,7 +276,7 @@ class DeleteResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DeleteResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> DeleteResponse:
         """Deserializes the DeleteResponse from a dictionary."""
         return cls()
 
@@ -294,7 +294,7 @@ class DeleteWorkspacePermissionAssignmentResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DeleteWorkspacePermissionAssignmentResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> DeleteWorkspacePermissionAssignmentResponse:
         """Deserializes the DeleteWorkspacePermissionAssignmentResponse from a dictionary."""
         return cls()
 
@@ -318,7 +318,7 @@ class GetAssignableRolesForResourceResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GetAssignableRolesForResourceResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> GetAssignableRolesForResourceResponse:
         """Deserializes the GetAssignableRolesForResourceResponse from a dictionary."""
         return cls(roles=_repeated_dict(d, "roles", Role))
 
@@ -343,7 +343,7 @@ class GetPasswordPermissionLevelsResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GetPasswordPermissionLevelsResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> GetPasswordPermissionLevelsResponse:
         """Deserializes the GetPasswordPermissionLevelsResponse from a dictionary."""
         return cls(permission_levels=_repeated_dict(d, "permission_levels", PasswordPermissionsDescription))
 
@@ -368,7 +368,7 @@ class GetPermissionLevelsResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GetPermissionLevelsResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> GetPermissionLevelsResponse:
         """Deserializes the GetPermissionLevelsResponse from a dictionary."""
         return cls(permission_levels=_repeated_dict(d, "permission_levels", PermissionsDescription))
 
@@ -406,7 +406,7 @@ class GrantRule:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GrantRule:
+    def from_dict(cls, d: Dict[str, Any]) -> GrantRule:
         """Deserializes the GrantRule from a dictionary."""
         return cls(principals=d.get("principals", None), role=d.get("role", None))
 
@@ -487,7 +487,7 @@ class Group:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> Group:
+    def from_dict(cls, d: Dict[str, Any]) -> Group:
         """Deserializes the Group from a dictionary."""
         return cls(
             display_name=d.get("displayName", None),
@@ -555,7 +555,7 @@ class ListGroupsResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListGroupsResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ListGroupsResponse:
         """Deserializes the ListGroupsResponse from a dictionary."""
         return cls(
             items_per_page=d.get("itemsPerPage", None),
@@ -619,7 +619,7 @@ class ListServicePrincipalResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListServicePrincipalResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ListServicePrincipalResponse:
         """Deserializes the ListServicePrincipalResponse from a dictionary."""
         return cls(
             items_per_page=d.get("itemsPerPage", None),
@@ -684,7 +684,7 @@ class ListUsersResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListUsersResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ListUsersResponse:
         """Deserializes the ListUsersResponse from a dictionary."""
         return cls(
             items_per_page=d.get("itemsPerPage", None),
@@ -736,7 +736,7 @@ class MigratePermissionsRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> MigratePermissionsRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> MigratePermissionsRequest:
         """Deserializes the MigratePermissionsRequest from a dictionary."""
         return cls(
             from_workspace_group_name=d.get("from_workspace_group_name", None),
@@ -766,7 +766,7 @@ class MigratePermissionsResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> MigratePermissionsResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> MigratePermissionsResponse:
         """Deserializes the MigratePermissionsResponse from a dictionary."""
         return cls(permissions_migrated=d.get("permissions_migrated", None))
 
@@ -798,7 +798,7 @@ class Name:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> Name:
+    def from_dict(cls, d: Dict[str, Any]) -> Name:
         """Deserializes the Name from a dictionary."""
         return cls(family_name=d.get("familyName", None), given_name=d.get("givenName", None))
 
@@ -834,7 +834,7 @@ class ObjectPermissions:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ObjectPermissions:
+    def from_dict(cls, d: Dict[str, Any]) -> ObjectPermissions:
         """Deserializes the ObjectPermissions from a dictionary."""
         return cls(
             access_control_list=_repeated_dict(d, "access_control_list", AccessControlResponse),
@@ -876,7 +876,7 @@ class PartialUpdate:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> PartialUpdate:
+    def from_dict(cls, d: Dict[str, Any]) -> PartialUpdate:
         """Deserializes the PartialUpdate from a dictionary."""
         return cls(
             id=d.get("id", None),
@@ -926,7 +926,7 @@ class PasswordAccessControlRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> PasswordAccessControlRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> PasswordAccessControlRequest:
         """Deserializes the PasswordAccessControlRequest from a dictionary."""
         return cls(
             group_name=d.get("group_name", None),
@@ -984,7 +984,7 @@ class PasswordAccessControlResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> PasswordAccessControlResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> PasswordAccessControlResponse:
         """Deserializes the PasswordAccessControlResponse from a dictionary."""
         return cls(
             all_permissions=_repeated_dict(d, "all_permissions", PasswordPermission),
@@ -1027,7 +1027,7 @@ class PasswordPermission:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> PasswordPermission:
+    def from_dict(cls, d: Dict[str, Any]) -> PasswordPermission:
         """Deserializes the PasswordPermission from a dictionary."""
         return cls(
             inherited=d.get("inherited", None),
@@ -1073,7 +1073,7 @@ class PasswordPermissions:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> PasswordPermissions:
+    def from_dict(cls, d: Dict[str, Any]) -> PasswordPermissions:
         """Deserializes the PasswordPermissions from a dictionary."""
         return cls(
             access_control_list=_repeated_dict(d, "access_control_list", PasswordAccessControlResponse),
@@ -1108,7 +1108,7 @@ class PasswordPermissionsDescription:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> PasswordPermissionsDescription:
+    def from_dict(cls, d: Dict[str, Any]) -> PasswordPermissionsDescription:
         """Deserializes the PasswordPermissionsDescription from a dictionary."""
         return cls(
             description=d.get("description", None),
@@ -1135,7 +1135,7 @@ class PasswordPermissionsRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> PasswordPermissionsRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> PasswordPermissionsRequest:
         """Deserializes the PasswordPermissionsRequest from a dictionary."""
         return cls(access_control_list=_repeated_dict(d, "access_control_list", PasswordAccessControlRequest))
 
@@ -1174,7 +1174,7 @@ class Patch:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> Patch:
+    def from_dict(cls, d: Dict[str, Any]) -> Patch:
         """Deserializes the Patch from a dictionary."""
         return cls(op=_enum(d, "op", PatchOp), path=d.get("path", None), value=d.get("value", None))
 
@@ -1200,7 +1200,7 @@ class PatchResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> PatchResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> PatchResponse:
         """Deserializes the PatchResponse from a dictionary."""
         return cls()
 
@@ -1242,7 +1242,7 @@ class Permission:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> Permission:
+    def from_dict(cls, d: Dict[str, Any]) -> Permission:
         """Deserializes the Permission from a dictionary."""
         return cls(
             inherited=d.get("inherited", None),
@@ -1288,7 +1288,7 @@ class PermissionAssignment:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> PermissionAssignment:
+    def from_dict(cls, d: Dict[str, Any]) -> PermissionAssignment:
         """Deserializes the PermissionAssignment from a dictionary."""
         return cls(
             error=d.get("error", None),
@@ -1317,7 +1317,7 @@ class PermissionAssignments:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> PermissionAssignments:
+    def from_dict(cls, d: Dict[str, Any]) -> PermissionAssignments:
         """Deserializes the PermissionAssignments from a dictionary."""
         return cls(permission_assignments=_repeated_dict(d, "permission_assignments", PermissionAssignment))
 
@@ -1370,7 +1370,7 @@ class PermissionOutput:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> PermissionOutput:
+    def from_dict(cls, d: Dict[str, Any]) -> PermissionOutput:
         """Deserializes the PermissionOutput from a dictionary."""
         return cls(
             description=d.get("description", None), permission_level=_enum(d, "permission_level", WorkspacePermission)
@@ -1403,7 +1403,7 @@ class PermissionsDescription:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> PermissionsDescription:
+    def from_dict(cls, d: Dict[str, Any]) -> PermissionsDescription:
         """Deserializes the PermissionsDescription from a dictionary."""
         return cls(
             description=d.get("description", None), permission_level=_enum(d, "permission_level", PermissionLevel)
@@ -1445,7 +1445,7 @@ class PermissionsRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> PermissionsRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> PermissionsRequest:
         """Deserializes the PermissionsRequest from a dictionary."""
         return cls(
             access_control_list=_repeated_dict(d, "access_control_list", AccessControlRequest),
@@ -1504,7 +1504,7 @@ class PrincipalOutput:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> PrincipalOutput:
+    def from_dict(cls, d: Dict[str, Any]) -> PrincipalOutput:
         """Deserializes the PrincipalOutput from a dictionary."""
         return cls(
             display_name=d.get("display_name", None),
@@ -1557,7 +1557,7 @@ class ResourceInfo:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ResourceInfo:
+    def from_dict(cls, d: Dict[str, Any]) -> ResourceInfo:
         """Deserializes the ResourceInfo from a dictionary."""
         return cls(
             id=d.get("id", None),
@@ -1587,7 +1587,7 @@ class ResourceMeta:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ResourceMeta:
+    def from_dict(cls, d: Dict[str, Any]) -> ResourceMeta:
         """Deserializes the ResourceMeta from a dictionary."""
         return cls(resource_type=d.get("resourceType", None))
 
@@ -1612,7 +1612,7 @@ class Role:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> Role:
+    def from_dict(cls, d: Dict[str, Any]) -> Role:
         """Deserializes the Role from a dictionary."""
         return cls(name=d.get("name", None))
 
@@ -1650,7 +1650,7 @@ class RuleSetResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> RuleSetResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> RuleSetResponse:
         """Deserializes the RuleSetResponse from a dictionary."""
         return cls(
             etag=d.get("etag", None), grant_rules=_repeated_dict(d, "grant_rules", GrantRule), name=d.get("name", None)
@@ -1691,7 +1691,7 @@ class RuleSetUpdateRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> RuleSetUpdateRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> RuleSetUpdateRequest:
         """Deserializes the RuleSetUpdateRequest from a dictionary."""
         return cls(
             etag=d.get("etag", None), grant_rules=_repeated_dict(d, "grant_rules", GrantRule), name=d.get("name", None)
@@ -1775,7 +1775,7 @@ class ServicePrincipal:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ServicePrincipal:
+    def from_dict(cls, d: Dict[str, Any]) -> ServicePrincipal:
         """Deserializes the ServicePrincipal from a dictionary."""
         return cls(
             active=d.get("active", None),
@@ -1808,7 +1808,7 @@ class UpdateResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateResponse:
         """Deserializes the UpdateResponse from a dictionary."""
         return cls()
 
@@ -1839,7 +1839,7 @@ class UpdateRuleSetRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateRuleSetRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateRuleSetRequest:
         """Deserializes the UpdateRuleSetRequest from a dictionary."""
         return cls(name=d.get("name", None), rule_set=_from_dict(d, "rule_set", RuleSetUpdateRequest))
 
@@ -1882,7 +1882,7 @@ class UpdateWorkspaceAssignments:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateWorkspaceAssignments:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateWorkspaceAssignments:
         """Deserializes the UpdateWorkspaceAssignments from a dictionary."""
         return cls(
             permissions=_repeated_enum(d, "permissions", WorkspacePermission),
@@ -1987,7 +1987,7 @@ class User:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> User:
+    def from_dict(cls, d: Dict[str, Any]) -> User:
         """Deserializes the User from a dictionary."""
         return cls(
             active=d.get("active", None),
@@ -2039,7 +2039,7 @@ class WorkspacePermissions:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> WorkspacePermissions:
+    def from_dict(cls, d: Dict[str, Any]) -> WorkspacePermissions:
         """Deserializes the WorkspacePermissions from a dictionary."""
         return cls(permissions=_repeated_dict(d, "permissions", PermissionOutput))
 

--- a/databricks/sdk/service/jobs.py
+++ b/databricks/sdk/service/jobs.py
@@ -8,7 +8,7 @@ import time
 from dataclasses import dataclass
 from datetime import timedelta
 from enum import Enum
-from typing import Callable, Dict, Iterator, List, Optional
+from typing import Any, Callable, Dict, Iterator, List, Optional
 
 from ..errors import OperationFailed
 from ._internal import Wait, _enum, _from_dict, _repeated_dict
@@ -83,7 +83,7 @@ class BaseJob:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> BaseJob:
+    def from_dict(cls, d: Dict[str, Any]) -> BaseJob:
         """Deserializes the BaseJob from a dictionary."""
         return cls(
             created_time=d.get("created_time", None),
@@ -393,7 +393,7 @@ class BaseRun:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> BaseRun:
+    def from_dict(cls, d: Dict[str, Any]) -> BaseRun:
         """Deserializes the BaseRun from a dictionary."""
         return cls(
             attempt_number=d.get("attempt_number", None),
@@ -460,7 +460,7 @@ class CancelAllRuns:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CancelAllRuns:
+    def from_dict(cls, d: Dict[str, Any]) -> CancelAllRuns:
         """Deserializes the CancelAllRuns from a dictionary."""
         return cls(all_queued_runs=d.get("all_queued_runs", None), job_id=d.get("job_id", None))
 
@@ -478,7 +478,7 @@ class CancelAllRunsResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CancelAllRunsResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> CancelAllRunsResponse:
         """Deserializes the CancelAllRunsResponse from a dictionary."""
         return cls()
 
@@ -503,7 +503,7 @@ class CancelRun:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CancelRun:
+    def from_dict(cls, d: Dict[str, Any]) -> CancelRun:
         """Deserializes the CancelRun from a dictionary."""
         return cls(run_id=d.get("run_id", None))
 
@@ -521,7 +521,7 @@ class CancelRunResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CancelRunResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> CancelRunResponse:
         """Deserializes the CancelRunResponse from a dictionary."""
         return cls()
 
@@ -591,7 +591,7 @@ class CleanRoomTaskRunState:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CleanRoomTaskRunState:
+    def from_dict(cls, d: Dict[str, Any]) -> CleanRoomTaskRunState:
         """Deserializes the CleanRoomTaskRunState from a dictionary."""
         return cls(
             life_cycle_state=_enum(d, "life_cycle_state", CleanRoomTaskRunLifeCycleState),
@@ -641,7 +641,7 @@ class CleanRoomsNotebookTask:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CleanRoomsNotebookTask:
+    def from_dict(cls, d: Dict[str, Any]) -> CleanRoomsNotebookTask:
         """Deserializes the CleanRoomsNotebookTask from a dictionary."""
         return cls(
             clean_room_name=d.get("clean_room_name", None),
@@ -685,7 +685,7 @@ class CleanRoomsNotebookTaskCleanRoomsNotebookTaskOutput:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CleanRoomsNotebookTaskCleanRoomsNotebookTaskOutput:
+    def from_dict(cls, d: Dict[str, Any]) -> CleanRoomsNotebookTaskCleanRoomsNotebookTaskOutput:
         """Deserializes the CleanRoomsNotebookTaskCleanRoomsNotebookTaskOutput from a dictionary."""
         return cls(
             clean_room_job_run_state=_from_dict(d, "clean_room_job_run_state", CleanRoomTaskRunState),
@@ -732,7 +732,7 @@ class ClusterInstance:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ClusterInstance:
+    def from_dict(cls, d: Dict[str, Any]) -> ClusterInstance:
         """Deserializes the ClusterInstance from a dictionary."""
         return cls(cluster_id=d.get("cluster_id", None), spark_context_id=d.get("spark_context_id", None))
 
@@ -782,7 +782,7 @@ class ClusterSpec:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ClusterSpec:
+    def from_dict(cls, d: Dict[str, Any]) -> ClusterSpec:
         """Deserializes the ClusterSpec from a dictionary."""
         return cls(
             existing_cluster_id=d.get("existing_cluster_id", None),
@@ -842,7 +842,7 @@ class ConditionTask:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ConditionTask:
+    def from_dict(cls, d: Dict[str, Any]) -> ConditionTask:
         """Deserializes the ConditionTask from a dictionary."""
         return cls(left=d.get("left", None), op=_enum(d, "op", ConditionTaskOp), right=d.get("right", None))
 
@@ -886,7 +886,7 @@ class Continuous:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> Continuous:
+    def from_dict(cls, d: Dict[str, Any]) -> Continuous:
         """Deserializes the Continuous from a dictionary."""
         return cls(pause_status=_enum(d, "pause_status", PauseStatus))
 
@@ -1120,7 +1120,7 @@ class CreateJob:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateJob:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateJob:
         """Deserializes the CreateJob from a dictionary."""
         return cls(
             access_control_list=_repeated_dict(d, "access_control_list", JobAccessControlRequest),
@@ -1173,7 +1173,7 @@ class CreateResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateResponse:
         """Deserializes the CreateResponse from a dictionary."""
         return cls(job_id=d.get("job_id", None))
 
@@ -1218,7 +1218,7 @@ class CronSchedule:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CronSchedule:
+    def from_dict(cls, d: Dict[str, Any]) -> CronSchedule:
         """Deserializes the CronSchedule from a dictionary."""
         return cls(
             pause_status=_enum(d, "pause_status", PauseStatus),
@@ -1255,7 +1255,7 @@ class DbtOutput:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DbtOutput:
+    def from_dict(cls, d: Dict[str, Any]) -> DbtOutput:
         """Deserializes the DbtOutput from a dictionary."""
         return cls(artifacts_headers=d.get("artifacts_headers", None), artifacts_link=d.get("artifacts_link", None))
 
@@ -1336,7 +1336,7 @@ class DbtTask:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DbtTask:
+    def from_dict(cls, d: Dict[str, Any]) -> DbtTask:
         """Deserializes the DbtTask from a dictionary."""
         return cls(
             catalog=d.get("catalog", None),
@@ -1369,7 +1369,7 @@ class DeleteJob:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DeleteJob:
+    def from_dict(cls, d: Dict[str, Any]) -> DeleteJob:
         """Deserializes the DeleteJob from a dictionary."""
         return cls(job_id=d.get("job_id", None))
 
@@ -1387,7 +1387,7 @@ class DeleteResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DeleteResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> DeleteResponse:
         """Deserializes the DeleteResponse from a dictionary."""
         return cls()
 
@@ -1412,7 +1412,7 @@ class DeleteRun:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DeleteRun:
+    def from_dict(cls, d: Dict[str, Any]) -> DeleteRun:
         """Deserializes the DeleteRun from a dictionary."""
         return cls(run_id=d.get("run_id", None))
 
@@ -1430,7 +1430,7 @@ class DeleteRunResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DeleteRunResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> DeleteRunResponse:
         """Deserializes the DeleteRunResponse from a dictionary."""
         return cls()
 
@@ -1476,7 +1476,7 @@ class EnforcePolicyComplianceForJobResponseJobClusterSettingsChange:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> EnforcePolicyComplianceForJobResponseJobClusterSettingsChange:
+    def from_dict(cls, d: Dict[str, Any]) -> EnforcePolicyComplianceForJobResponseJobClusterSettingsChange:
         """Deserializes the EnforcePolicyComplianceForJobResponseJobClusterSettingsChange from a dictionary."""
         return cls(
             field=d.get("field", None), new_value=d.get("new_value", None), previous_value=d.get("previous_value", None)
@@ -1510,7 +1510,7 @@ class EnforcePolicyComplianceRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> EnforcePolicyComplianceRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> EnforcePolicyComplianceRequest:
         """Deserializes the EnforcePolicyComplianceRequest from a dictionary."""
         return cls(job_id=d.get("job_id", None), validate_only=d.get("validate_only", None))
 
@@ -1554,7 +1554,7 @@ class EnforcePolicyComplianceResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> EnforcePolicyComplianceResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> EnforcePolicyComplianceResponse:
         """Deserializes the EnforcePolicyComplianceResponse from a dictionary."""
         return cls(
             has_changes=d.get("has_changes", None),
@@ -1590,7 +1590,7 @@ class ExportRunOutput:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ExportRunOutput:
+    def from_dict(cls, d: Dict[str, Any]) -> ExportRunOutput:
         """Deserializes the ExportRunOutput from a dictionary."""
         return cls(views=_repeated_dict(d, "views", ViewItem))
 
@@ -1633,7 +1633,7 @@ class FileArrivalTriggerConfiguration:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> FileArrivalTriggerConfiguration:
+    def from_dict(cls, d: Dict[str, Any]) -> FileArrivalTriggerConfiguration:
         """Deserializes the FileArrivalTriggerConfiguration from a dictionary."""
         return cls(
             min_time_between_triggers_seconds=d.get("min_time_between_triggers_seconds", None),
@@ -1669,7 +1669,7 @@ class ForEachStats:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ForEachStats:
+    def from_dict(cls, d: Dict[str, Any]) -> ForEachStats:
         """Deserializes the ForEachStats from a dictionary."""
         return cls(
             error_message_stats=_repeated_dict(d, "error_message_stats", ForEachTaskErrorMessageStats),
@@ -1712,7 +1712,7 @@ class ForEachTask:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ForEachTask:
+    def from_dict(cls, d: Dict[str, Any]) -> ForEachTask:
         """Deserializes the ForEachTask from a dictionary."""
         return cls(
             concurrency=d.get("concurrency", None), inputs=d.get("inputs", None), task=_from_dict(d, "task", Task)
@@ -1753,7 +1753,7 @@ class ForEachTaskErrorMessageStats:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ForEachTaskErrorMessageStats:
+    def from_dict(cls, d: Dict[str, Any]) -> ForEachTaskErrorMessageStats:
         """Deserializes the ForEachTaskErrorMessageStats from a dictionary."""
         return cls(
             count=d.get("count", None),
@@ -1817,7 +1817,7 @@ class ForEachTaskTaskRunStats:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ForEachTaskTaskRunStats:
+    def from_dict(cls, d: Dict[str, Any]) -> ForEachTaskTaskRunStats:
         """Deserializes the ForEachTaskTaskRunStats from a dictionary."""
         return cls(
             active_iterations=d.get("active_iterations", None),
@@ -1855,7 +1855,7 @@ class GetJobPermissionLevelsResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GetJobPermissionLevelsResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> GetJobPermissionLevelsResponse:
         """Deserializes the GetJobPermissionLevelsResponse from a dictionary."""
         return cls(permission_levels=_repeated_dict(d, "permission_levels", JobPermissionsDescription))
 
@@ -1892,7 +1892,7 @@ class GetPolicyComplianceResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GetPolicyComplianceResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> GetPolicyComplianceResponse:
         """Deserializes the GetPolicyComplianceResponse from a dictionary."""
         return cls(is_compliant=d.get("is_compliant", None), violations=d.get("violations", None))
 
@@ -1934,7 +1934,7 @@ class GitSnapshot:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GitSnapshot:
+    def from_dict(cls, d: Dict[str, Any]) -> GitSnapshot:
         """Deserializes the GitSnapshot from a dictionary."""
         return cls(used_commit=d.get("used_commit", None))
 
@@ -2014,7 +2014,7 @@ class GitSource:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GitSource:
+    def from_dict(cls, d: Dict[str, Any]) -> GitSource:
         """Deserializes the GitSource from a dictionary."""
         return cls(
             git_branch=d.get("git_branch", None),
@@ -2111,7 +2111,7 @@ class Job:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> Job:
+    def from_dict(cls, d: Dict[str, Any]) -> Job:
         """Deserializes the Job from a dictionary."""
         return cls(
             created_time=d.get("created_time", None),
@@ -2166,7 +2166,7 @@ class JobAccessControlRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> JobAccessControlRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> JobAccessControlRequest:
         """Deserializes the JobAccessControlRequest from a dictionary."""
         return cls(
             group_name=d.get("group_name", None),
@@ -2224,7 +2224,7 @@ class JobAccessControlResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> JobAccessControlResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> JobAccessControlResponse:
         """Deserializes the JobAccessControlResponse from a dictionary."""
         return cls(
             all_permissions=_repeated_dict(d, "all_permissions", JobPermission),
@@ -2264,7 +2264,7 @@ class JobCluster:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> JobCluster:
+    def from_dict(cls, d: Dict[str, Any]) -> JobCluster:
         """Deserializes the JobCluster from a dictionary."""
         return cls(
             job_cluster_key=d.get("job_cluster_key", None),
@@ -2309,7 +2309,7 @@ class JobCompliance:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> JobCompliance:
+    def from_dict(cls, d: Dict[str, Any]) -> JobCompliance:
         """Deserializes the JobCompliance from a dictionary."""
         return cls(
             is_compliant=d.get("is_compliant", None), job_id=d.get("job_id", None), violations=d.get("violations", None)
@@ -2345,7 +2345,7 @@ class JobDeployment:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> JobDeployment:
+    def from_dict(cls, d: Dict[str, Any]) -> JobDeployment:
         """Deserializes the JobDeployment from a dictionary."""
         return cls(kind=_enum(d, "kind", JobDeploymentKind), metadata_file_path=d.get("metadata_file_path", None))
 
@@ -2436,7 +2436,7 @@ class JobEmailNotifications:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> JobEmailNotifications:
+    def from_dict(cls, d: Dict[str, Any]) -> JobEmailNotifications:
         """Deserializes the JobEmailNotifications from a dictionary."""
         return cls(
             no_alert_for_skipped_runs=d.get("no_alert_for_skipped_runs", None),
@@ -2476,7 +2476,7 @@ class JobEnvironment:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> JobEnvironment:
+    def from_dict(cls, d: Dict[str, Any]) -> JobEnvironment:
         """Deserializes the JobEnvironment from a dictionary."""
         return cls(environment_key=d.get("environment_key", None), spec=_from_dict(d, "spec", compute.Environment))
 
@@ -2510,7 +2510,7 @@ class JobNotificationSettings:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> JobNotificationSettings:
+    def from_dict(cls, d: Dict[str, Any]) -> JobNotificationSettings:
         """Deserializes the JobNotificationSettings from a dictionary."""
         return cls(
             no_alert_for_canceled_runs=d.get("no_alert_for_canceled_runs", None),
@@ -2552,7 +2552,7 @@ class JobParameter:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> JobParameter:
+    def from_dict(cls, d: Dict[str, Any]) -> JobParameter:
         """Deserializes the JobParameter from a dictionary."""
         return cls(default=d.get("default", None), name=d.get("name", None), value=d.get("value", None))
 
@@ -2584,7 +2584,7 @@ class JobParameterDefinition:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> JobParameterDefinition:
+    def from_dict(cls, d: Dict[str, Any]) -> JobParameterDefinition:
         """Deserializes the JobParameterDefinition from a dictionary."""
         return cls(default=d.get("default", None), name=d.get("name", None))
 
@@ -2621,7 +2621,7 @@ class JobPermission:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> JobPermission:
+    def from_dict(cls, d: Dict[str, Any]) -> JobPermission:
         """Deserializes the JobPermission from a dictionary."""
         return cls(
             inherited=d.get("inherited", None),
@@ -2670,7 +2670,7 @@ class JobPermissions:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> JobPermissions:
+    def from_dict(cls, d: Dict[str, Any]) -> JobPermissions:
         """Deserializes the JobPermissions from a dictionary."""
         return cls(
             access_control_list=_repeated_dict(d, "access_control_list", JobAccessControlResponse),
@@ -2705,7 +2705,7 @@ class JobPermissionsDescription:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> JobPermissionsDescription:
+    def from_dict(cls, d: Dict[str, Any]) -> JobPermissionsDescription:
         """Deserializes the JobPermissionsDescription from a dictionary."""
         return cls(
             description=d.get("description", None), permission_level=_enum(d, "permission_level", JobPermissionLevel)
@@ -2738,7 +2738,7 @@ class JobPermissionsRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> JobPermissionsRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> JobPermissionsRequest:
         """Deserializes the JobPermissionsRequest from a dictionary."""
         return cls(
             access_control_list=_repeated_dict(d, "access_control_list", JobAccessControlRequest),
@@ -2780,7 +2780,7 @@ class JobRunAs:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> JobRunAs:
+    def from_dict(cls, d: Dict[str, Any]) -> JobRunAs:
         """Deserializes the JobRunAs from a dictionary."""
         return cls(service_principal_name=d.get("service_principal_name", None), user_name=d.get("user_name", None))
 
@@ -3007,7 +3007,7 @@ class JobSettings:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> JobSettings:
+    def from_dict(cls, d: Dict[str, Any]) -> JobSettings:
         """Deserializes the JobSettings from a dictionary."""
         return cls(
             budget_policy_id=d.get("budget_policy_id", None),
@@ -3080,7 +3080,7 @@ class JobSource:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> JobSource:
+    def from_dict(cls, d: Dict[str, Any]) -> JobSource:
         """Deserializes the JobSource from a dictionary."""
         return cls(
             dirty_state=_enum(d, "dirty_state", JobSourceDirtyState),
@@ -3169,7 +3169,7 @@ class JobsHealthRule:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> JobsHealthRule:
+    def from_dict(cls, d: Dict[str, Any]) -> JobsHealthRule:
         """Deserializes the JobsHealthRule from a dictionary."""
         return cls(
             metric=_enum(d, "metric", JobsHealthMetric),
@@ -3199,7 +3199,7 @@ class JobsHealthRules:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> JobsHealthRules:
+    def from_dict(cls, d: Dict[str, Any]) -> JobsHealthRules:
         """Deserializes the JobsHealthRules from a dictionary."""
         return cls(rules=_repeated_dict(d, "rules", JobsHealthRule))
 
@@ -3240,7 +3240,7 @@ class ListJobComplianceForPolicyResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListJobComplianceForPolicyResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ListJobComplianceForPolicyResponse:
         """Deserializes the ListJobComplianceForPolicyResponse from a dictionary."""
         return cls(
             jobs=_repeated_dict(d, "jobs", JobCompliance),
@@ -3292,7 +3292,7 @@ class ListJobsResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListJobsResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ListJobsResponse:
         """Deserializes the ListJobsResponse from a dictionary."""
         return cls(
             has_more=d.get("has_more", None),
@@ -3346,7 +3346,7 @@ class ListRunsResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListRunsResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ListRunsResponse:
         """Deserializes the ListRunsResponse from a dictionary."""
         return cls(
             has_more=d.get("has_more", None),
@@ -3387,7 +3387,7 @@ class NotebookOutput:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> NotebookOutput:
+    def from_dict(cls, d: Dict[str, Any]) -> NotebookOutput:
         """Deserializes the NotebookOutput from a dictionary."""
         return cls(result=d.get("result", None), truncated=d.get("truncated", None))
 
@@ -3456,7 +3456,7 @@ class NotebookTask:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> NotebookTask:
+    def from_dict(cls, d: Dict[str, Any]) -> NotebookTask:
         """Deserializes the NotebookTask from a dictionary."""
         return cls(
             base_parameters=d.get("base_parameters", None),
@@ -3501,7 +3501,7 @@ class OutputSchemaInfo:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> OutputSchemaInfo:
+    def from_dict(cls, d: Dict[str, Any]) -> OutputSchemaInfo:
         """Deserializes the OutputSchemaInfo from a dictionary."""
         return cls(
             catalog_name=d.get("catalog_name", None),
@@ -3552,7 +3552,7 @@ class PeriodicTriggerConfiguration:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> PeriodicTriggerConfiguration:
+    def from_dict(cls, d: Dict[str, Any]) -> PeriodicTriggerConfiguration:
         """Deserializes the PeriodicTriggerConfiguration from a dictionary."""
         return cls(interval=d.get("interval", None), unit=_enum(d, "unit", PeriodicTriggerConfigurationTimeUnit))
 
@@ -3584,7 +3584,7 @@ class PipelineParams:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> PipelineParams:
+    def from_dict(cls, d: Dict[str, Any]) -> PipelineParams:
         """Deserializes the PipelineParams from a dictionary."""
         return cls(full_refresh=d.get("full_refresh", None))
 
@@ -3616,7 +3616,7 @@ class PipelineTask:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> PipelineTask:
+    def from_dict(cls, d: Dict[str, Any]) -> PipelineTask:
         """Deserializes the PipelineTask from a dictionary."""
         return cls(full_refresh=d.get("full_refresh", None), pipeline_id=d.get("pipeline_id", None))
 
@@ -3665,7 +3665,7 @@ class PythonWheelTask:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> PythonWheelTask:
+    def from_dict(cls, d: Dict[str, Any]) -> PythonWheelTask:
         """Deserializes the PythonWheelTask from a dictionary."""
         return cls(
             entry_point=d.get("entry_point", None),
@@ -3707,7 +3707,7 @@ class QueueDetails:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> QueueDetails:
+    def from_dict(cls, d: Dict[str, Any]) -> QueueDetails:
         """Deserializes the QueueDetails from a dictionary."""
         return cls(code=_enum(d, "code", QueueDetailsCodeCode), message=d.get("message", None))
 
@@ -3744,7 +3744,7 @@ class QueueSettings:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> QueueSettings:
+    def from_dict(cls, d: Dict[str, Any]) -> QueueSettings:
         """Deserializes the QueueSettings from a dictionary."""
         return cls(enabled=d.get("enabled", None))
 
@@ -3811,7 +3811,7 @@ class RepairHistoryItem:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> RepairHistoryItem:
+    def from_dict(cls, d: Dict[str, Any]) -> RepairHistoryItem:
         """Deserializes the RepairHistoryItem from a dictionary."""
         return cls(
             end_time=d.get("end_time", None),
@@ -3995,7 +3995,7 @@ class RepairRun:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> RepairRun:
+    def from_dict(cls, d: Dict[str, Any]) -> RepairRun:
         """Deserializes the RepairRun from a dictionary."""
         return cls(
             dbt_commands=d.get("dbt_commands", None),
@@ -4038,7 +4038,7 @@ class RepairRunResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> RepairRunResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> RepairRunResponse:
         """Deserializes the RepairRunResponse from a dictionary."""
         return cls(repair_id=d.get("repair_id", None))
 
@@ -4073,7 +4073,7 @@ class ResetJob:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ResetJob:
+    def from_dict(cls, d: Dict[str, Any]) -> ResetJob:
         """Deserializes the ResetJob from a dictionary."""
         return cls(job_id=d.get("job_id", None), new_settings=_from_dict(d, "new_settings", JobSettings))
 
@@ -4091,7 +4091,7 @@ class ResetResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ResetResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ResetResponse:
         """Deserializes the ResetResponse from a dictionary."""
         return cls()
 
@@ -4121,7 +4121,7 @@ class ResolvedConditionTaskValues:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ResolvedConditionTaskValues:
+    def from_dict(cls, d: Dict[str, Any]) -> ResolvedConditionTaskValues:
         """Deserializes the ResolvedConditionTaskValues from a dictionary."""
         return cls(left=d.get("left", None), right=d.get("right", None))
 
@@ -4145,7 +4145,7 @@ class ResolvedDbtTaskValues:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ResolvedDbtTaskValues:
+    def from_dict(cls, d: Dict[str, Any]) -> ResolvedDbtTaskValues:
         """Deserializes the ResolvedDbtTaskValues from a dictionary."""
         return cls(commands=d.get("commands", None))
 
@@ -4169,7 +4169,7 @@ class ResolvedNotebookTaskValues:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ResolvedNotebookTaskValues:
+    def from_dict(cls, d: Dict[str, Any]) -> ResolvedNotebookTaskValues:
         """Deserializes the ResolvedNotebookTaskValues from a dictionary."""
         return cls(base_parameters=d.get("base_parameters", None))
 
@@ -4193,7 +4193,7 @@ class ResolvedParamPairValues:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ResolvedParamPairValues:
+    def from_dict(cls, d: Dict[str, Any]) -> ResolvedParamPairValues:
         """Deserializes the ResolvedParamPairValues from a dictionary."""
         return cls(parameters=d.get("parameters", None))
 
@@ -4223,7 +4223,7 @@ class ResolvedPythonWheelTaskValues:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ResolvedPythonWheelTaskValues:
+    def from_dict(cls, d: Dict[str, Any]) -> ResolvedPythonWheelTaskValues:
         """Deserializes the ResolvedPythonWheelTaskValues from a dictionary."""
         return cls(named_parameters=d.get("named_parameters", None), parameters=d.get("parameters", None))
 
@@ -4253,7 +4253,7 @@ class ResolvedRunJobTaskValues:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ResolvedRunJobTaskValues:
+    def from_dict(cls, d: Dict[str, Any]) -> ResolvedRunJobTaskValues:
         """Deserializes the ResolvedRunJobTaskValues from a dictionary."""
         return cls(job_parameters=d.get("job_parameters", None), parameters=d.get("parameters", None))
 
@@ -4277,7 +4277,7 @@ class ResolvedStringParamsValues:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ResolvedStringParamsValues:
+    def from_dict(cls, d: Dict[str, Any]) -> ResolvedStringParamsValues:
         """Deserializes the ResolvedStringParamsValues from a dictionary."""
         return cls(parameters=d.get("parameters", None))
 
@@ -4355,7 +4355,7 @@ class ResolvedValues:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ResolvedValues:
+    def from_dict(cls, d: Dict[str, Any]) -> ResolvedValues:
         """Deserializes the ResolvedValues from a dictionary."""
         return cls(
             condition_task=_from_dict(d, "condition_task", ResolvedConditionTaskValues),
@@ -4685,7 +4685,7 @@ class Run:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> Run:
+    def from_dict(cls, d: Dict[str, Any]) -> Run:
         """Deserializes the Run from a dictionary."""
         return cls(
             attempt_number=d.get("attempt_number", None),
@@ -4778,7 +4778,7 @@ class RunConditionTask:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> RunConditionTask:
+    def from_dict(cls, d: Dict[str, Any]) -> RunConditionTask:
         """Deserializes the RunConditionTask from a dictionary."""
         return cls(
             left=d.get("left", None),
@@ -4831,7 +4831,7 @@ class RunForEachTask:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> RunForEachTask:
+    def from_dict(cls, d: Dict[str, Any]) -> RunForEachTask:
         """Deserializes the RunForEachTask from a dictionary."""
         return cls(
             concurrency=d.get("concurrency", None),
@@ -4879,7 +4879,7 @@ class RunJobOutput:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> RunJobOutput:
+    def from_dict(cls, d: Dict[str, Any]) -> RunJobOutput:
         """Deserializes the RunJobOutput from a dictionary."""
         return cls(run_id=d.get("run_id", None))
 
@@ -5017,7 +5017,7 @@ class RunJobTask:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> RunJobTask:
+    def from_dict(cls, d: Dict[str, Any]) -> RunJobTask:
         """Deserializes the RunJobTask from a dictionary."""
         return cls(
             dbt_commands=d.get("dbt_commands", None),
@@ -5243,7 +5243,7 @@ class RunNow:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> RunNow:
+    def from_dict(cls, d: Dict[str, Any]) -> RunNow:
         """Deserializes the RunNow from a dictionary."""
         return cls(
             dbt_commands=d.get("dbt_commands", None),
@@ -5292,7 +5292,7 @@ class RunNowResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> RunNowResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> RunNowResponse:
         """Deserializes the RunNowResponse from a dictionary."""
         return cls(number_in_job=d.get("number_in_job", None), run_id=d.get("run_id", None))
 
@@ -5400,7 +5400,7 @@ class RunOutput:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> RunOutput:
+    def from_dict(cls, d: Dict[str, Any]) -> RunOutput:
         """Deserializes the RunOutput from a dictionary."""
         return cls(
             clean_rooms_notebook_output=_from_dict(
@@ -5538,7 +5538,7 @@ class RunParameters:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> RunParameters:
+    def from_dict(cls, d: Dict[str, Any]) -> RunParameters:
         """Deserializes the RunParameters from a dictionary."""
         return cls(
             dbt_commands=d.get("dbt_commands", None),
@@ -5628,7 +5628,7 @@ class RunState:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> RunState:
+    def from_dict(cls, d: Dict[str, Any]) -> RunState:
         """Deserializes the RunState from a dictionary."""
         return cls(
             life_cycle_state=_enum(d, "life_cycle_state", RunLifeCycleState),
@@ -5676,7 +5676,7 @@ class RunStatus:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> RunStatus:
+    def from_dict(cls, d: Dict[str, Any]) -> RunStatus:
         """Deserializes the RunStatus from a dictionary."""
         return cls(
             queue_details=_from_dict(d, "queue_details", QueueDetails),
@@ -6058,7 +6058,7 @@ class RunTask:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> RunTask:
+    def from_dict(cls, d: Dict[str, Any]) -> RunTask:
         """Deserializes the RunTask from a dictionary."""
         return cls(
             attempt_number=d.get("attempt_number", None),
@@ -6181,7 +6181,7 @@ class SparkJarTask:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> SparkJarTask:
+    def from_dict(cls, d: Dict[str, Any]) -> SparkJarTask:
         """Deserializes the SparkJarTask from a dictionary."""
         return cls(
             jar_uri=d.get("jar_uri", None),
@@ -6238,7 +6238,7 @@ class SparkPythonTask:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> SparkPythonTask:
+    def from_dict(cls, d: Dict[str, Any]) -> SparkPythonTask:
         """Deserializes the SparkPythonTask from a dictionary."""
         return cls(
             parameters=d.get("parameters", None),
@@ -6271,7 +6271,7 @@ class SparkSubmitTask:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> SparkSubmitTask:
+    def from_dict(cls, d: Dict[str, Any]) -> SparkSubmitTask:
         """Deserializes the SparkSubmitTask from a dictionary."""
         return cls(parameters=d.get("parameters", None))
 
@@ -6328,7 +6328,7 @@ class SqlAlertOutput:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> SqlAlertOutput:
+    def from_dict(cls, d: Dict[str, Any]) -> SqlAlertOutput:
         """Deserializes the SqlAlertOutput from a dictionary."""
         return cls(
             alert_state=_enum(d, "alert_state", SqlAlertState),
@@ -6377,7 +6377,7 @@ class SqlDashboardOutput:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> SqlDashboardOutput:
+    def from_dict(cls, d: Dict[str, Any]) -> SqlDashboardOutput:
         """Deserializes the SqlDashboardOutput from a dictionary."""
         return cls(
             warehouse_id=d.get("warehouse_id", None), widgets=_repeated_dict(d, "widgets", SqlDashboardWidgetOutput)
@@ -6446,7 +6446,7 @@ class SqlDashboardWidgetOutput:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> SqlDashboardWidgetOutput:
+    def from_dict(cls, d: Dict[str, Any]) -> SqlDashboardWidgetOutput:
         """Deserializes the SqlDashboardWidgetOutput from a dictionary."""
         return cls(
             end_time=d.get("end_time", None),
@@ -6502,7 +6502,7 @@ class SqlOutput:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> SqlOutput:
+    def from_dict(cls, d: Dict[str, Any]) -> SqlOutput:
         """Deserializes the SqlOutput from a dictionary."""
         return cls(
             alert_output=_from_dict(d, "alert_output", SqlAlertOutput),
@@ -6531,7 +6531,7 @@ class SqlOutputError:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> SqlOutputError:
+    def from_dict(cls, d: Dict[str, Any]) -> SqlOutputError:
         """Deserializes the SqlOutputError from a dictionary."""
         return cls(message=d.get("message", None))
 
@@ -6583,7 +6583,7 @@ class SqlQueryOutput:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> SqlQueryOutput:
+    def from_dict(cls, d: Dict[str, Any]) -> SqlQueryOutput:
         """Deserializes the SqlQueryOutput from a dictionary."""
         return cls(
             endpoint_id=d.get("endpoint_id", None),
@@ -6614,7 +6614,7 @@ class SqlStatementOutput:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> SqlStatementOutput:
+    def from_dict(cls, d: Dict[str, Any]) -> SqlStatementOutput:
         """Deserializes the SqlStatementOutput from a dictionary."""
         return cls(lookup_key=d.get("lookup_key", None))
 
@@ -6677,7 +6677,7 @@ class SqlTask:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> SqlTask:
+    def from_dict(cls, d: Dict[str, Any]) -> SqlTask:
         """Deserializes the SqlTask from a dictionary."""
         return cls(
             alert=_from_dict(d, "alert", SqlTaskAlert),
@@ -6723,7 +6723,7 @@ class SqlTaskAlert:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> SqlTaskAlert:
+    def from_dict(cls, d: Dict[str, Any]) -> SqlTaskAlert:
         """Deserializes the SqlTaskAlert from a dictionary."""
         return cls(
             alert_id=d.get("alert_id", None),
@@ -6773,7 +6773,7 @@ class SqlTaskDashboard:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> SqlTaskDashboard:
+    def from_dict(cls, d: Dict[str, Any]) -> SqlTaskDashboard:
         """Deserializes the SqlTaskDashboard from a dictionary."""
         return cls(
             custom_subject=d.get("custom_subject", None),
@@ -6817,7 +6817,7 @@ class SqlTaskFile:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> SqlTaskFile:
+    def from_dict(cls, d: Dict[str, Any]) -> SqlTaskFile:
         """Deserializes the SqlTaskFile from a dictionary."""
         return cls(path=d.get("path", None), source=_enum(d, "source", Source))
 
@@ -6842,7 +6842,7 @@ class SqlTaskQuery:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> SqlTaskQuery:
+    def from_dict(cls, d: Dict[str, Any]) -> SqlTaskQuery:
         """Deserializes the SqlTaskQuery from a dictionary."""
         return cls(query_id=d.get("query_id", None))
 
@@ -6877,7 +6877,7 @@ class SqlTaskSubscription:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> SqlTaskSubscription:
+    def from_dict(cls, d: Dict[str, Any]) -> SqlTaskSubscription:
         """Deserializes the SqlTaskSubscription from a dictionary."""
         return cls(destination_id=d.get("destination_id", None), user_name=d.get("user_name", None))
 
@@ -7013,7 +7013,7 @@ class SubmitRun:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> SubmitRun:
+    def from_dict(cls, d: Dict[str, Any]) -> SubmitRun:
         """Deserializes the SubmitRun from a dictionary."""
         return cls(
             access_control_list=_repeated_dict(d, "access_control_list", JobAccessControlRequest),
@@ -7055,7 +7055,7 @@ class SubmitRunResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> SubmitRunResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> SubmitRunResponse:
         """Deserializes the SubmitRunResponse from a dictionary."""
         return cls(run_id=d.get("run_id", None))
 
@@ -7284,7 +7284,7 @@ class SubmitTask:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> SubmitTask:
+    def from_dict(cls, d: Dict[str, Any]) -> SubmitTask:
         """Deserializes the SubmitTask from a dictionary."""
         return cls(
             clean_rooms_notebook_task=_from_dict(d, "clean_rooms_notebook_task", CleanRoomsNotebookTask),
@@ -7360,7 +7360,7 @@ class TableUpdateTriggerConfiguration:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> TableUpdateTriggerConfiguration:
+    def from_dict(cls, d: Dict[str, Any]) -> TableUpdateTriggerConfiguration:
         """Deserializes the TableUpdateTriggerConfiguration from a dictionary."""
         return cls(
             condition=_enum(d, "condition", Condition),
@@ -7639,7 +7639,7 @@ class Task:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> Task:
+    def from_dict(cls, d: Dict[str, Any]) -> Task:
         """Deserializes the Task from a dictionary."""
         return cls(
             clean_rooms_notebook_task=_from_dict(d, "clean_rooms_notebook_task", CleanRoomsNotebookTask),
@@ -7703,7 +7703,7 @@ class TaskDependency:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> TaskDependency:
+    def from_dict(cls, d: Dict[str, Any]) -> TaskDependency:
         """Deserializes the TaskDependency from a dictionary."""
         return cls(outcome=d.get("outcome", None), task_key=d.get("task_key", None))
 
@@ -7778,7 +7778,7 @@ class TaskEmailNotifications:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> TaskEmailNotifications:
+    def from_dict(cls, d: Dict[str, Any]) -> TaskEmailNotifications:
         """Deserializes the TaskEmailNotifications from a dictionary."""
         return cls(
             no_alert_for_skipped_runs=d.get("no_alert_for_skipped_runs", None),
@@ -7828,7 +7828,7 @@ class TaskNotificationSettings:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> TaskNotificationSettings:
+    def from_dict(cls, d: Dict[str, Any]) -> TaskNotificationSettings:
         """Deserializes the TaskNotificationSettings from a dictionary."""
         return cls(
             alert_on_last_attempt=d.get("alert_on_last_attempt", None),
@@ -7974,7 +7974,7 @@ class TerminationDetails:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> TerminationDetails:
+    def from_dict(cls, d: Dict[str, Any]) -> TerminationDetails:
         """Deserializes the TerminationDetails from a dictionary."""
         return cls(
             code=_enum(d, "code", TerminationCodeCode),
@@ -8020,7 +8020,7 @@ class TriggerInfo:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> TriggerInfo:
+    def from_dict(cls, d: Dict[str, Any]) -> TriggerInfo:
         """Deserializes the TriggerInfo from a dictionary."""
         return cls(run_id=d.get("run_id", None))
 
@@ -8072,7 +8072,7 @@ class TriggerSettings:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> TriggerSettings:
+    def from_dict(cls, d: Dict[str, Any]) -> TriggerSettings:
         """Deserializes the TriggerSettings from a dictionary."""
         return cls(
             file_arrival=_from_dict(d, "file_arrival", FileArrivalTriggerConfiguration),
@@ -8147,7 +8147,7 @@ class UpdateJob:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateJob:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateJob:
         """Deserializes the UpdateJob from a dictionary."""
         return cls(
             fields_to_remove=d.get("fields_to_remove", None),
@@ -8169,7 +8169,7 @@ class UpdateResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateResponse:
         """Deserializes the UpdateResponse from a dictionary."""
         return cls()
 
@@ -8209,7 +8209,7 @@ class ViewItem:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ViewItem:
+    def from_dict(cls, d: Dict[str, Any]) -> ViewItem:
         """Deserializes the ViewItem from a dictionary."""
         return cls(content=d.get("content", None), name=d.get("name", None), type=_enum(d, "type", ViewType))
 
@@ -8249,7 +8249,7 @@ class Webhook:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> Webhook:
+    def from_dict(cls, d: Dict[str, Any]) -> Webhook:
         """Deserializes the Webhook from a dictionary."""
         return cls(id=d.get("id", None))
 
@@ -8314,7 +8314,7 @@ class WebhookNotifications:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> WebhookNotifications:
+    def from_dict(cls, d: Dict[str, Any]) -> WebhookNotifications:
         """Deserializes the WebhookNotifications from a dictionary."""
         return cls(
             on_duration_warning_threshold_exceeded=_repeated_dict(d, "on_duration_warning_threshold_exceeded", Webhook),

--- a/databricks/sdk/service/marketplace.py
+++ b/databricks/sdk/service/marketplace.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from enum import Enum
-from typing import Dict, Iterator, List, Optional
+from typing import Any, Dict, Iterator, List, Optional
 
 from ._internal import _enum, _from_dict, _repeated_dict, _repeated_enum
 
@@ -40,7 +40,7 @@ class AddExchangeForListingRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> AddExchangeForListingRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> AddExchangeForListingRequest:
         """Deserializes the AddExchangeForListingRequest from a dictionary."""
         return cls(exchange_id=d.get("exchange_id", None), listing_id=d.get("listing_id", None))
 
@@ -64,7 +64,7 @@ class AddExchangeForListingResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> AddExchangeForListingResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> AddExchangeForListingResponse:
         """Deserializes the AddExchangeForListingResponse from a dictionary."""
         return cls(exchange_for_listing=_from_dict(d, "exchange_for_listing", ExchangeListing))
 
@@ -98,7 +98,7 @@ class BatchGetListingsResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> BatchGetListingsResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> BatchGetListingsResponse:
         """Deserializes the BatchGetListingsResponse from a dictionary."""
         return cls(listings=_repeated_dict(d, "listings", Listing))
 
@@ -122,7 +122,7 @@ class BatchGetProvidersResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> BatchGetProvidersResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> BatchGetProvidersResponse:
         """Deserializes the BatchGetProvidersResponse from a dictionary."""
         return cls(providers=_repeated_dict(d, "providers", ProviderInfo))
 
@@ -172,7 +172,7 @@ class ConsumerTerms:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ConsumerTerms:
+    def from_dict(cls, d: Dict[str, Any]) -> ConsumerTerms:
         """Deserializes the ConsumerTerms from a dictionary."""
         return cls(version=d.get("version", None))
 
@@ -216,7 +216,7 @@ class ContactInfo:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ContactInfo:
+    def from_dict(cls, d: Dict[str, Any]) -> ContactInfo:
         """Deserializes the ContactInfo from a dictionary."""
         return cls(
             company=d.get("company", None),
@@ -251,7 +251,7 @@ class CreateExchangeFilterRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateExchangeFilterRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateExchangeFilterRequest:
         """Deserializes the CreateExchangeFilterRequest from a dictionary."""
         return cls(filter=_from_dict(d, "filter", ExchangeFilter))
 
@@ -275,7 +275,7 @@ class CreateExchangeFilterResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateExchangeFilterResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateExchangeFilterResponse:
         """Deserializes the CreateExchangeFilterResponse from a dictionary."""
         return cls(filter_id=d.get("filter_id", None))
 
@@ -299,7 +299,7 @@ class CreateExchangeRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateExchangeRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateExchangeRequest:
         """Deserializes the CreateExchangeRequest from a dictionary."""
         return cls(exchange=_from_dict(d, "exchange", Exchange))
 
@@ -323,7 +323,7 @@ class CreateExchangeResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateExchangeResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateExchangeResponse:
         """Deserializes the CreateExchangeResponse from a dictionary."""
         return cls(exchange_id=d.get("exchange_id", None))
 
@@ -365,7 +365,7 @@ class CreateFileRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateFileRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateFileRequest:
         """Deserializes the CreateFileRequest from a dictionary."""
         return cls(
             display_name=d.get("display_name", None),
@@ -401,7 +401,7 @@ class CreateFileResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateFileResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateFileResponse:
         """Deserializes the CreateFileResponse from a dictionary."""
         return cls(file_info=_from_dict(d, "file_info", FileInfo), upload_url=d.get("upload_url", None))
 
@@ -456,7 +456,7 @@ class CreateInstallationRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateInstallationRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateInstallationRequest:
         """Deserializes the CreateInstallationRequest from a dictionary."""
         return cls(
             accepted_consumer_terms=_from_dict(d, "accepted_consumer_terms", ConsumerTerms),
@@ -487,7 +487,7 @@ class CreateListingRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateListingRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateListingRequest:
         """Deserializes the CreateListingRequest from a dictionary."""
         return cls(listing=_from_dict(d, "listing", Listing))
 
@@ -511,7 +511,7 @@ class CreateListingResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateListingResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateListingResponse:
         """Deserializes the CreateListingResponse from a dictionary."""
         return cls(listing_id=d.get("listing_id", None))
 
@@ -585,7 +585,7 @@ class CreatePersonalizationRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreatePersonalizationRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> CreatePersonalizationRequest:
         """Deserializes the CreatePersonalizationRequest from a dictionary."""
         return cls(
             accepted_consumer_terms=_from_dict(d, "accepted_consumer_terms", ConsumerTerms),
@@ -619,7 +619,7 @@ class CreatePersonalizationRequestResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreatePersonalizationRequestResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> CreatePersonalizationRequestResponse:
         """Deserializes the CreatePersonalizationRequestResponse from a dictionary."""
         return cls(id=d.get("id", None))
 
@@ -643,7 +643,7 @@ class CreateProviderRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateProviderRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateProviderRequest:
         """Deserializes the CreateProviderRequest from a dictionary."""
         return cls(provider=_from_dict(d, "provider", ProviderInfo))
 
@@ -667,7 +667,7 @@ class CreateProviderResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateProviderResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateProviderResponse:
         """Deserializes the CreateProviderResponse from a dictionary."""
         return cls(id=d.get("id", None))
 
@@ -710,7 +710,7 @@ class DataRefreshInfo:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DataRefreshInfo:
+    def from_dict(cls, d: Dict[str, Any]) -> DataRefreshInfo:
         """Deserializes the DataRefreshInfo from a dictionary."""
         return cls(interval=d.get("interval", None), unit=_enum(d, "unit", DataRefresh))
 
@@ -728,7 +728,7 @@ class DeleteExchangeFilterResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DeleteExchangeFilterResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> DeleteExchangeFilterResponse:
         """Deserializes the DeleteExchangeFilterResponse from a dictionary."""
         return cls()
 
@@ -746,7 +746,7 @@ class DeleteExchangeResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DeleteExchangeResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> DeleteExchangeResponse:
         """Deserializes the DeleteExchangeResponse from a dictionary."""
         return cls()
 
@@ -764,7 +764,7 @@ class DeleteFileResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DeleteFileResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> DeleteFileResponse:
         """Deserializes the DeleteFileResponse from a dictionary."""
         return cls()
 
@@ -782,7 +782,7 @@ class DeleteInstallationResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DeleteInstallationResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> DeleteInstallationResponse:
         """Deserializes the DeleteInstallationResponse from a dictionary."""
         return cls()
 
@@ -800,7 +800,7 @@ class DeleteListingResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DeleteListingResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> DeleteListingResponse:
         """Deserializes the DeleteListingResponse from a dictionary."""
         return cls()
 
@@ -818,7 +818,7 @@ class DeleteProviderResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DeleteProviderResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> DeleteProviderResponse:
         """Deserializes the DeleteProviderResponse from a dictionary."""
         return cls()
 
@@ -896,7 +896,7 @@ class Exchange:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> Exchange:
+    def from_dict(cls, d: Dict[str, Any]) -> Exchange:
         """Deserializes the Exchange from a dictionary."""
         return cls(
             comment=d.get("comment", None),
@@ -978,7 +978,7 @@ class ExchangeFilter:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ExchangeFilter:
+    def from_dict(cls, d: Dict[str, Any]) -> ExchangeFilter:
         """Deserializes the ExchangeFilter from a dictionary."""
         return cls(
             created_at=d.get("created_at", None),
@@ -1053,7 +1053,7 @@ class ExchangeListing:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ExchangeListing:
+    def from_dict(cls, d: Dict[str, Any]) -> ExchangeListing:
         """Deserializes the ExchangeListing from a dictionary."""
         return cls(
             created_at=d.get("created_at", None),
@@ -1141,7 +1141,7 @@ class FileInfo:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> FileInfo:
+    def from_dict(cls, d: Dict[str, Any]) -> FileInfo:
         """Deserializes the FileInfo from a dictionary."""
         return cls(
             created_at=d.get("created_at", None),
@@ -1183,7 +1183,7 @@ class FileParent:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> FileParent:
+    def from_dict(cls, d: Dict[str, Any]) -> FileParent:
         """Deserializes the FileParent from a dictionary."""
         return cls(file_parent_type=_enum(d, "file_parent_type", FileParentType), parent_id=d.get("parent_id", None))
 
@@ -1227,7 +1227,7 @@ class GetExchangeResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GetExchangeResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> GetExchangeResponse:
         """Deserializes the GetExchangeResponse from a dictionary."""
         return cls(exchange=_from_dict(d, "exchange", Exchange))
 
@@ -1251,7 +1251,7 @@ class GetFileResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GetFileResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> GetFileResponse:
         """Deserializes the GetFileResponse from a dictionary."""
         return cls(file_info=_from_dict(d, "file_info", FileInfo))
 
@@ -1276,7 +1276,7 @@ class GetLatestVersionProviderAnalyticsDashboardResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GetLatestVersionProviderAnalyticsDashboardResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> GetLatestVersionProviderAnalyticsDashboardResponse:
         """Deserializes the GetLatestVersionProviderAnalyticsDashboardResponse from a dictionary."""
         return cls(version=d.get("version", None))
 
@@ -1306,7 +1306,7 @@ class GetListingContentMetadataResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GetListingContentMetadataResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> GetListingContentMetadataResponse:
         """Deserializes the GetListingContentMetadataResponse from a dictionary."""
         return cls(
             next_page_token=d.get("next_page_token", None),
@@ -1333,7 +1333,7 @@ class GetListingResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GetListingResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> GetListingResponse:
         """Deserializes the GetListingResponse from a dictionary."""
         return cls(listing=_from_dict(d, "listing", Listing))
 
@@ -1363,7 +1363,7 @@ class GetListingsResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GetListingsResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> GetListingsResponse:
         """Deserializes the GetListingsResponse from a dictionary."""
         return cls(listings=_repeated_dict(d, "listings", Listing), next_page_token=d.get("next_page_token", None))
 
@@ -1387,7 +1387,7 @@ class GetPersonalizationRequestResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GetPersonalizationRequestResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> GetPersonalizationRequestResponse:
         """Deserializes the GetPersonalizationRequestResponse from a dictionary."""
         return cls(personalization_requests=_repeated_dict(d, "personalization_requests", PersonalizationRequest))
 
@@ -1411,7 +1411,7 @@ class GetProviderResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GetProviderResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> GetProviderResponse:
         """Deserializes the GetProviderResponse from a dictionary."""
         return cls(provider=_from_dict(d, "provider", ProviderInfo))
 
@@ -1435,7 +1435,7 @@ class Installation:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> Installation:
+    def from_dict(cls, d: Dict[str, Any]) -> Installation:
         """Deserializes the Installation from a dictionary."""
         return cls(installation=_from_dict(d, "installation", InstallationDetail))
 
@@ -1531,7 +1531,7 @@ class InstallationDetail:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> InstallationDetail:
+    def from_dict(cls, d: Dict[str, Any]) -> InstallationDetail:
         """Deserializes the InstallationDetail from a dictionary."""
         return cls(
             catalog_name=d.get("catalog_name", None),
@@ -1581,7 +1581,7 @@ class ListAllInstallationsResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListAllInstallationsResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ListAllInstallationsResponse:
         """Deserializes the ListAllInstallationsResponse from a dictionary."""
         return cls(
             installations=_repeated_dict(d, "installations", InstallationDetail),
@@ -1614,7 +1614,7 @@ class ListAllPersonalizationRequestsResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListAllPersonalizationRequestsResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ListAllPersonalizationRequestsResponse:
         """Deserializes the ListAllPersonalizationRequestsResponse from a dictionary."""
         return cls(
             next_page_token=d.get("next_page_token", None),
@@ -1647,7 +1647,7 @@ class ListExchangeFiltersResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListExchangeFiltersResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ListExchangeFiltersResponse:
         """Deserializes the ListExchangeFiltersResponse from a dictionary."""
         return cls(filters=_repeated_dict(d, "filters", ExchangeFilter), next_page_token=d.get("next_page_token", None))
 
@@ -1677,7 +1677,7 @@ class ListExchangesForListingResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListExchangesForListingResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ListExchangesForListingResponse:
         """Deserializes the ListExchangesForListingResponse from a dictionary."""
         return cls(
             exchange_listing=_repeated_dict(d, "exchange_listing", ExchangeListing),
@@ -1710,7 +1710,7 @@ class ListExchangesResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListExchangesResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ListExchangesResponse:
         """Deserializes the ListExchangesResponse from a dictionary."""
         return cls(exchanges=_repeated_dict(d, "exchanges", Exchange), next_page_token=d.get("next_page_token", None))
 
@@ -1740,7 +1740,7 @@ class ListFilesResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListFilesResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ListFilesResponse:
         """Deserializes the ListFilesResponse from a dictionary."""
         return cls(file_infos=_repeated_dict(d, "file_infos", FileInfo), next_page_token=d.get("next_page_token", None))
 
@@ -1770,7 +1770,7 @@ class ListFulfillmentsResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListFulfillmentsResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ListFulfillmentsResponse:
         """Deserializes the ListFulfillmentsResponse from a dictionary."""
         return cls(
             fulfillments=_repeated_dict(d, "fulfillments", ListingFulfillment),
@@ -1803,7 +1803,7 @@ class ListInstallationsResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListInstallationsResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ListInstallationsResponse:
         """Deserializes the ListInstallationsResponse from a dictionary."""
         return cls(
             installations=_repeated_dict(d, "installations", InstallationDetail),
@@ -1836,7 +1836,7 @@ class ListListingsForExchangeResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListListingsForExchangeResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ListListingsForExchangeResponse:
         """Deserializes the ListListingsForExchangeResponse from a dictionary."""
         return cls(
             exchange_listings=_repeated_dict(d, "exchange_listings", ExchangeListing),
@@ -1869,7 +1869,7 @@ class ListListingsResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListListingsResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ListListingsResponse:
         """Deserializes the ListListingsResponse from a dictionary."""
         return cls(listings=_repeated_dict(d, "listings", Listing), next_page_token=d.get("next_page_token", None))
 
@@ -1906,7 +1906,7 @@ class ListProviderAnalyticsDashboardResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListProviderAnalyticsDashboardResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ListProviderAnalyticsDashboardResponse:
         """Deserializes the ListProviderAnalyticsDashboardResponse from a dictionary."""
         return cls(dashboard_id=d.get("dashboard_id", None), id=d.get("id", None), version=d.get("version", None))
 
@@ -1936,7 +1936,7 @@ class ListProvidersResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListProvidersResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ListProvidersResponse:
         """Deserializes the ListProvidersResponse from a dictionary."""
         return cls(
             next_page_token=d.get("next_page_token", None), providers=_repeated_dict(d, "providers", ProviderInfo)
@@ -1975,7 +1975,7 @@ class Listing:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> Listing:
+    def from_dict(cls, d: Dict[str, Any]) -> Listing:
         """Deserializes the Listing from a dictionary."""
         return cls(
             detail=_from_dict(d, "detail", ListingDetail),
@@ -2130,7 +2130,7 @@ class ListingDetail:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListingDetail:
+    def from_dict(cls, d: Dict[str, Any]) -> ListingDetail:
         """Deserializes the ListingDetail from a dictionary."""
         return cls(
             assets=_repeated_enum(d, "assets", AssetType),
@@ -2198,7 +2198,7 @@ class ListingFulfillment:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListingFulfillment:
+    def from_dict(cls, d: Dict[str, Any]) -> ListingFulfillment:
         """Deserializes the ListingFulfillment from a dictionary."""
         return cls(
             fulfillment_type=_enum(d, "fulfillment_type", FulfillmentType),
@@ -2228,7 +2228,7 @@ class ListingSetting:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListingSetting:
+    def from_dict(cls, d: Dict[str, Any]) -> ListingSetting:
         """Deserializes the ListingSetting from a dictionary."""
         return cls(visibility=_enum(d, "visibility", Visibility))
 
@@ -2380,7 +2380,7 @@ class ListingSummary:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListingSummary:
+    def from_dict(cls, d: Dict[str, Any]) -> ListingSummary:
         """Deserializes the ListingSummary from a dictionary."""
         return cls(
             categories=_repeated_enum(d, "categories", Category),
@@ -2432,7 +2432,7 @@ class ListingTag:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListingTag:
+    def from_dict(cls, d: Dict[str, Any]) -> ListingTag:
         """Deserializes the ListingTag from a dictionary."""
         return cls(tag_name=_enum(d, "tag_name", ListingTagType), tag_values=d.get("tag_values", None))
 
@@ -2565,7 +2565,7 @@ class PersonalizationRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> PersonalizationRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> PersonalizationRequest:
         """Deserializes the PersonalizationRequest from a dictionary."""
         return cls(
             comment=d.get("comment", None),
@@ -2614,7 +2614,7 @@ class ProviderAnalyticsDashboard:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ProviderAnalyticsDashboard:
+    def from_dict(cls, d: Dict[str, Any]) -> ProviderAnalyticsDashboard:
         """Deserializes the ProviderAnalyticsDashboard from a dictionary."""
         return cls(id=d.get("id", None))
 
@@ -2718,7 +2718,7 @@ class ProviderInfo:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ProviderInfo:
+    def from_dict(cls, d: Dict[str, Any]) -> ProviderInfo:
         """Deserializes the ProviderInfo from a dictionary."""
         return cls(
             business_contact_email=d.get("business_contact_email", None),
@@ -2763,7 +2763,7 @@ class RegionInfo:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> RegionInfo:
+    def from_dict(cls, d: Dict[str, Any]) -> RegionInfo:
         """Deserializes the RegionInfo from a dictionary."""
         return cls(cloud=d.get("cloud", None), region=d.get("region", None))
 
@@ -2781,7 +2781,7 @@ class RemoveExchangeForListingResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> RemoveExchangeForListingResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> RemoveExchangeForListingResponse:
         """Deserializes the RemoveExchangeForListingResponse from a dictionary."""
         return cls()
 
@@ -2806,7 +2806,7 @@ class RepoInfo:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> RepoInfo:
+    def from_dict(cls, d: Dict[str, Any]) -> RepoInfo:
         """Deserializes the RepoInfo from a dictionary."""
         return cls(git_repo_url=d.get("git_repo_url", None))
 
@@ -2839,7 +2839,7 @@ class RepoInstallation:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> RepoInstallation:
+    def from_dict(cls, d: Dict[str, Any]) -> RepoInstallation:
         """Deserializes the RepoInstallation from a dictionary."""
         return cls(repo_name=d.get("repo_name", None), repo_path=d.get("repo_path", None))
 
@@ -2869,7 +2869,7 @@ class SearchListingsResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> SearchListingsResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> SearchListingsResponse:
         """Deserializes the SearchListingsResponse from a dictionary."""
         return cls(listings=_repeated_dict(d, "listings", Listing), next_page_token=d.get("next_page_token", None))
 
@@ -2899,7 +2899,7 @@ class ShareInfo:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ShareInfo:
+    def from_dict(cls, d: Dict[str, Any]) -> ShareInfo:
         """Deserializes the ShareInfo from a dictionary."""
         return cls(name=d.get("name", None), type=_enum(d, "type", ListingShareType))
 
@@ -2931,7 +2931,7 @@ class SharedDataObject:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> SharedDataObject:
+    def from_dict(cls, d: Dict[str, Any]) -> SharedDataObject:
         """Deserializes the SharedDataObject from a dictionary."""
         return cls(data_object_type=d.get("data_object_type", None), name=d.get("name", None))
 
@@ -2975,7 +2975,7 @@ class TokenDetail:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> TokenDetail:
+    def from_dict(cls, d: Dict[str, Any]) -> TokenDetail:
         """Deserializes the TokenDetail from a dictionary."""
         return cls(
             bearer_token=d.get("bearerToken", None),
@@ -3048,7 +3048,7 @@ class TokenInfo:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> TokenInfo:
+    def from_dict(cls, d: Dict[str, Any]) -> TokenInfo:
         """Deserializes the TokenInfo from a dictionary."""
         return cls(
             activation_url=d.get("activation_url", None),
@@ -3086,7 +3086,7 @@ class UpdateExchangeFilterRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateExchangeFilterRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateExchangeFilterRequest:
         """Deserializes the UpdateExchangeFilterRequest from a dictionary."""
         return cls(filter=_from_dict(d, "filter", ExchangeFilter), id=d.get("id", None))
 
@@ -3110,7 +3110,7 @@ class UpdateExchangeFilterResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateExchangeFilterResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateExchangeFilterResponse:
         """Deserializes the UpdateExchangeFilterResponse from a dictionary."""
         return cls(filter=_from_dict(d, "filter", ExchangeFilter))
 
@@ -3140,7 +3140,7 @@ class UpdateExchangeRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateExchangeRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateExchangeRequest:
         """Deserializes the UpdateExchangeRequest from a dictionary."""
         return cls(exchange=_from_dict(d, "exchange", Exchange), id=d.get("id", None))
 
@@ -3164,7 +3164,7 @@ class UpdateExchangeResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateExchangeResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateExchangeResponse:
         """Deserializes the UpdateExchangeResponse from a dictionary."""
         return cls(exchange=_from_dict(d, "exchange", Exchange))
 
@@ -3206,7 +3206,7 @@ class UpdateInstallationRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateInstallationRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateInstallationRequest:
         """Deserializes the UpdateInstallationRequest from a dictionary."""
         return cls(
             installation=_from_dict(d, "installation", InstallationDetail),
@@ -3235,7 +3235,7 @@ class UpdateInstallationResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateInstallationResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateInstallationResponse:
         """Deserializes the UpdateInstallationResponse from a dictionary."""
         return cls(installation=_from_dict(d, "installation", InstallationDetail))
 
@@ -3265,7 +3265,7 @@ class UpdateListingRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateListingRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateListingRequest:
         """Deserializes the UpdateListingRequest from a dictionary."""
         return cls(id=d.get("id", None), listing=_from_dict(d, "listing", Listing))
 
@@ -3289,7 +3289,7 @@ class UpdateListingResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateListingResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateListingResponse:
         """Deserializes the UpdateListingResponse from a dictionary."""
         return cls(listing=_from_dict(d, "listing", Listing))
 
@@ -3337,7 +3337,7 @@ class UpdatePersonalizationRequestRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdatePersonalizationRequestRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdatePersonalizationRequestRequest:
         """Deserializes the UpdatePersonalizationRequestRequest from a dictionary."""
         return cls(
             listing_id=d.get("listing_id", None),
@@ -3367,7 +3367,7 @@ class UpdatePersonalizationRequestResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdatePersonalizationRequestResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdatePersonalizationRequestResponse:
         """Deserializes the UpdatePersonalizationRequestResponse from a dictionary."""
         return cls(request=_from_dict(d, "request", PersonalizationRequest))
 
@@ -3400,7 +3400,7 @@ class UpdateProviderAnalyticsDashboardRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateProviderAnalyticsDashboardRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateProviderAnalyticsDashboardRequest:
         """Deserializes the UpdateProviderAnalyticsDashboardRequest from a dictionary."""
         return cls(id=d.get("id", None), version=d.get("version", None))
 
@@ -3438,7 +3438,7 @@ class UpdateProviderAnalyticsDashboardResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateProviderAnalyticsDashboardResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateProviderAnalyticsDashboardResponse:
         """Deserializes the UpdateProviderAnalyticsDashboardResponse from a dictionary."""
         return cls(dashboard_id=d.get("dashboard_id", None), id=d.get("id", None), version=d.get("version", None))
 
@@ -3468,7 +3468,7 @@ class UpdateProviderRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateProviderRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateProviderRequest:
         """Deserializes the UpdateProviderRequest from a dictionary."""
         return cls(id=d.get("id", None), provider=_from_dict(d, "provider", ProviderInfo))
 
@@ -3492,7 +3492,7 @@ class UpdateProviderResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateProviderResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateProviderResponse:
         """Deserializes the UpdateProviderResponse from a dictionary."""
         return cls(provider=_from_dict(d, "provider", ProviderInfo))
 

--- a/databricks/sdk/service/ml.py
+++ b/databricks/sdk/service/ml.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from enum import Enum
-from typing import Dict, Iterator, List, Optional
+from typing import Any, Dict, Iterator, List, Optional
 
 from ._internal import _enum, _from_dict, _repeated_dict, _repeated_enum
 
@@ -123,7 +123,7 @@ class Activity:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> Activity:
+    def from_dict(cls, d: Dict[str, Any]) -> Activity:
         """Deserializes the Activity from a dictionary."""
         return cls(
             activity_type=_enum(d, "activity_type", ActivityType),
@@ -231,7 +231,7 @@ class ApproveTransitionRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ApproveTransitionRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> ApproveTransitionRequest:
         """Deserializes the ApproveTransitionRequest from a dictionary."""
         return cls(
             archive_existing_versions=d.get("archive_existing_versions", None),
@@ -262,7 +262,7 @@ class ApproveTransitionRequestResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ApproveTransitionRequestResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ApproveTransitionRequestResponse:
         """Deserializes the ApproveTransitionRequestResponse from a dictionary."""
         return cls(activity=_from_dict(d, "activity", Activity))
 
@@ -334,7 +334,7 @@ class CommentObject:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CommentObject:
+    def from_dict(cls, d: Dict[str, Any]) -> CommentObject:
         """Deserializes the CommentObject from a dictionary."""
         return cls(
             available_actions=_repeated_enum(d, "available_actions", CommentActivityAction),
@@ -380,7 +380,7 @@ class CreateComment:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateComment:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateComment:
         """Deserializes the CreateComment from a dictionary."""
         return cls(comment=d.get("comment", None), name=d.get("name", None), version=d.get("version", None))
 
@@ -405,7 +405,7 @@ class CreateCommentResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateCommentResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateCommentResponse:
         """Deserializes the CreateCommentResponse from a dictionary."""
         return cls(comment=_from_dict(d, "comment", CommentObject))
 
@@ -448,7 +448,7 @@ class CreateExperiment:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateExperiment:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateExperiment:
         """Deserializes the CreateExperiment from a dictionary."""
         return cls(
             artifact_location=d.get("artifact_location", None),
@@ -477,7 +477,7 @@ class CreateExperimentResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateExperimentResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateExperimentResponse:
         """Deserializes the CreateExperimentResponse from a dictionary."""
         return cls(experiment_id=d.get("experiment_id", None))
 
@@ -516,7 +516,7 @@ class CreateModelRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateModelRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateModelRequest:
         """Deserializes the CreateModelRequest from a dictionary."""
         return cls(
             description=d.get("description", None), name=d.get("name", None), tags=_repeated_dict(d, "tags", ModelTag)
@@ -542,7 +542,7 @@ class CreateModelResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateModelResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateModelResponse:
         """Deserializes the CreateModelResponse from a dictionary."""
         return cls(registered_model=_from_dict(d, "registered_model", Model))
 
@@ -604,7 +604,7 @@ class CreateModelVersionRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateModelVersionRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateModelVersionRequest:
         """Deserializes the CreateModelVersionRequest from a dictionary."""
         return cls(
             description=d.get("description", None),
@@ -636,7 +636,7 @@ class CreateModelVersionResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateModelVersionResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateModelVersionResponse:
         """Deserializes the CreateModelVersionResponse from a dictionary."""
         return cls(model_version=_from_dict(d, "model_version", ModelVersion))
 
@@ -727,7 +727,7 @@ class CreateRegistryWebhook:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateRegistryWebhook:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateRegistryWebhook:
         """Deserializes the CreateRegistryWebhook from a dictionary."""
         return cls(
             description=d.get("description", None),
@@ -781,7 +781,7 @@ class CreateRun:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateRun:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateRun:
         """Deserializes the CreateRun from a dictionary."""
         return cls(
             experiment_id=d.get("experiment_id", None),
@@ -811,7 +811,7 @@ class CreateRunResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateRunResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateRunResponse:
         """Deserializes the CreateRunResponse from a dictionary."""
         return cls(run=_from_dict(d, "run", Run))
 
@@ -865,7 +865,7 @@ class CreateTransitionRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateTransitionRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateTransitionRequest:
         """Deserializes the CreateTransitionRequest from a dictionary."""
         return cls(
             comment=d.get("comment", None),
@@ -895,7 +895,7 @@ class CreateTransitionRequestResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateTransitionRequestResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateTransitionRequestResponse:
         """Deserializes the CreateTransitionRequestResponse from a dictionary."""
         return cls(request=_from_dict(d, "request", TransitionRequest))
 
@@ -919,7 +919,7 @@ class CreateWebhookResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateWebhookResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateWebhookResponse:
         """Deserializes the CreateWebhookResponse from a dictionary."""
         return cls(webhook=_from_dict(d, "webhook", RegistryWebhook))
 
@@ -983,7 +983,7 @@ class Dataset:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> Dataset:
+    def from_dict(cls, d: Dict[str, Any]) -> Dataset:
         """Deserializes the Dataset from a dictionary."""
         return cls(
             digest=d.get("digest", None),
@@ -1022,7 +1022,7 @@ class DatasetInput:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DatasetInput:
+    def from_dict(cls, d: Dict[str, Any]) -> DatasetInput:
         """Deserializes the DatasetInput from a dictionary."""
         return cls(dataset=_from_dict(d, "dataset", Dataset), tags=_repeated_dict(d, "tags", InputTag))
 
@@ -1040,7 +1040,7 @@ class DeleteCommentResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DeleteCommentResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> DeleteCommentResponse:
         """Deserializes the DeleteCommentResponse from a dictionary."""
         return cls()
 
@@ -1065,7 +1065,7 @@ class DeleteExperiment:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DeleteExperiment:
+    def from_dict(cls, d: Dict[str, Any]) -> DeleteExperiment:
         """Deserializes the DeleteExperiment from a dictionary."""
         return cls(experiment_id=d.get("experiment_id", None))
 
@@ -1083,7 +1083,7 @@ class DeleteExperimentResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DeleteExperimentResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> DeleteExperimentResponse:
         """Deserializes the DeleteExperimentResponse from a dictionary."""
         return cls()
 
@@ -1101,7 +1101,7 @@ class DeleteModelResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DeleteModelResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> DeleteModelResponse:
         """Deserializes the DeleteModelResponse from a dictionary."""
         return cls()
 
@@ -1119,7 +1119,7 @@ class DeleteModelTagResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DeleteModelTagResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> DeleteModelTagResponse:
         """Deserializes the DeleteModelTagResponse from a dictionary."""
         return cls()
 
@@ -1137,7 +1137,7 @@ class DeleteModelVersionResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DeleteModelVersionResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> DeleteModelVersionResponse:
         """Deserializes the DeleteModelVersionResponse from a dictionary."""
         return cls()
 
@@ -1155,7 +1155,7 @@ class DeleteModelVersionTagResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DeleteModelVersionTagResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> DeleteModelVersionTagResponse:
         """Deserializes the DeleteModelVersionTagResponse from a dictionary."""
         return cls()
 
@@ -1180,7 +1180,7 @@ class DeleteRun:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DeleteRun:
+    def from_dict(cls, d: Dict[str, Any]) -> DeleteRun:
         """Deserializes the DeleteRun from a dictionary."""
         return cls(run_id=d.get("run_id", None))
 
@@ -1198,7 +1198,7 @@ class DeleteRunResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DeleteRunResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> DeleteRunResponse:
         """Deserializes the DeleteRunResponse from a dictionary."""
         return cls()
 
@@ -1239,7 +1239,7 @@ class DeleteRuns:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DeleteRuns:
+    def from_dict(cls, d: Dict[str, Any]) -> DeleteRuns:
         """Deserializes the DeleteRuns from a dictionary."""
         return cls(
             experiment_id=d.get("experiment_id", None),
@@ -1268,7 +1268,7 @@ class DeleteRunsResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DeleteRunsResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> DeleteRunsResponse:
         """Deserializes the DeleteRunsResponse from a dictionary."""
         return cls(runs_deleted=d.get("runs_deleted", None))
 
@@ -1300,7 +1300,7 @@ class DeleteTag:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DeleteTag:
+    def from_dict(cls, d: Dict[str, Any]) -> DeleteTag:
         """Deserializes the DeleteTag from a dictionary."""
         return cls(key=d.get("key", None), run_id=d.get("run_id", None))
 
@@ -1318,7 +1318,7 @@ class DeleteTagResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DeleteTagResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> DeleteTagResponse:
         """Deserializes the DeleteTagResponse from a dictionary."""
         return cls()
 
@@ -1336,7 +1336,7 @@ class DeleteTransitionRequestResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DeleteTransitionRequestResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> DeleteTransitionRequestResponse:
         """Deserializes the DeleteTransitionRequestResponse from a dictionary."""
         return cls()
 
@@ -1362,7 +1362,7 @@ class DeleteWebhookResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DeleteWebhookResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> DeleteWebhookResponse:
         """Deserializes the DeleteWebhookResponse from a dictionary."""
         return cls()
 
@@ -1430,7 +1430,7 @@ class Experiment:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> Experiment:
+    def from_dict(cls, d: Dict[str, Any]) -> Experiment:
         """Deserializes the Experiment from a dictionary."""
         return cls(
             artifact_location=d.get("artifact_location", None),
@@ -1484,7 +1484,7 @@ class ExperimentAccessControlRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ExperimentAccessControlRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> ExperimentAccessControlRequest:
         """Deserializes the ExperimentAccessControlRequest from a dictionary."""
         return cls(
             group_name=d.get("group_name", None),
@@ -1542,7 +1542,7 @@ class ExperimentAccessControlResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ExperimentAccessControlResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ExperimentAccessControlResponse:
         """Deserializes the ExperimentAccessControlResponse from a dictionary."""
         return cls(
             all_permissions=_repeated_dict(d, "all_permissions", ExperimentPermission),
@@ -1585,7 +1585,7 @@ class ExperimentPermission:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ExperimentPermission:
+    def from_dict(cls, d: Dict[str, Any]) -> ExperimentPermission:
         """Deserializes the ExperimentPermission from a dictionary."""
         return cls(
             inherited=d.get("inherited", None),
@@ -1633,7 +1633,7 @@ class ExperimentPermissions:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ExperimentPermissions:
+    def from_dict(cls, d: Dict[str, Any]) -> ExperimentPermissions:
         """Deserializes the ExperimentPermissions from a dictionary."""
         return cls(
             access_control_list=_repeated_dict(d, "access_control_list", ExperimentAccessControlResponse),
@@ -1668,7 +1668,7 @@ class ExperimentPermissionsDescription:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ExperimentPermissionsDescription:
+    def from_dict(cls, d: Dict[str, Any]) -> ExperimentPermissionsDescription:
         """Deserializes the ExperimentPermissionsDescription from a dictionary."""
         return cls(
             description=d.get("description", None),
@@ -1702,7 +1702,7 @@ class ExperimentPermissionsRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ExperimentPermissionsRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> ExperimentPermissionsRequest:
         """Deserializes the ExperimentPermissionsRequest from a dictionary."""
         return cls(
             access_control_list=_repeated_dict(d, "access_control_list", ExperimentAccessControlRequest),
@@ -1737,7 +1737,7 @@ class ExperimentTag:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ExperimentTag:
+    def from_dict(cls, d: Dict[str, Any]) -> ExperimentTag:
         """Deserializes the ExperimentTag from a dictionary."""
         return cls(key=d.get("key", None), value=d.get("value", None))
 
@@ -1776,7 +1776,7 @@ class FileInfo:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> FileInfo:
+    def from_dict(cls, d: Dict[str, Any]) -> FileInfo:
         """Deserializes the FileInfo from a dictionary."""
         return cls(file_size=d.get("file_size", None), is_dir=d.get("is_dir", None), path=d.get("path", None))
 
@@ -1801,7 +1801,7 @@ class GetExperimentPermissionLevelsResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GetExperimentPermissionLevelsResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> GetExperimentPermissionLevelsResponse:
         """Deserializes the GetExperimentPermissionLevelsResponse from a dictionary."""
         return cls(permission_levels=_repeated_dict(d, "permission_levels", ExperimentPermissionsDescription))
 
@@ -1826,7 +1826,7 @@ class GetExperimentResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GetExperimentResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> GetExperimentResponse:
         """Deserializes the GetExperimentResponse from a dictionary."""
         return cls(experiment=_from_dict(d, "experiment", Experiment))
 
@@ -1858,7 +1858,7 @@ class GetLatestVersionsRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GetLatestVersionsRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> GetLatestVersionsRequest:
         """Deserializes the GetLatestVersionsRequest from a dictionary."""
         return cls(name=d.get("name", None), stages=d.get("stages", None))
 
@@ -1884,7 +1884,7 @@ class GetLatestVersionsResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GetLatestVersionsResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> GetLatestVersionsResponse:
         """Deserializes the GetLatestVersionsResponse from a dictionary."""
         return cls(model_versions=_repeated_dict(d, "model_versions", ModelVersion))
 
@@ -1916,7 +1916,7 @@ class GetMetricHistoryResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GetMetricHistoryResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> GetMetricHistoryResponse:
         """Deserializes the GetMetricHistoryResponse from a dictionary."""
         return cls(metrics=_repeated_dict(d, "metrics", Metric), next_page_token=d.get("next_page_token", None))
 
@@ -1940,7 +1940,7 @@ class GetModelResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GetModelResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> GetModelResponse:
         """Deserializes the GetModelResponse from a dictionary."""
         return cls(registered_model_databricks=_from_dict(d, "registered_model_databricks", ModelDatabricks))
 
@@ -1965,7 +1965,7 @@ class GetModelVersionDownloadUriResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GetModelVersionDownloadUriResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> GetModelVersionDownloadUriResponse:
         """Deserializes the GetModelVersionDownloadUriResponse from a dictionary."""
         return cls(artifact_uri=d.get("artifact_uri", None))
 
@@ -1989,7 +1989,7 @@ class GetModelVersionResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GetModelVersionResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> GetModelVersionResponse:
         """Deserializes the GetModelVersionResponse from a dictionary."""
         return cls(model_version=_from_dict(d, "model_version", ModelVersion))
 
@@ -2014,7 +2014,7 @@ class GetRegisteredModelPermissionLevelsResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GetRegisteredModelPermissionLevelsResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> GetRegisteredModelPermissionLevelsResponse:
         """Deserializes the GetRegisteredModelPermissionLevelsResponse from a dictionary."""
         return cls(permission_levels=_repeated_dict(d, "permission_levels", RegisteredModelPermissionsDescription))
 
@@ -2039,7 +2039,7 @@ class GetRunResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GetRunResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> GetRunResponse:
         """Deserializes the GetRunResponse from a dictionary."""
         return cls(run=_from_dict(d, "run", Run))
 
@@ -2092,7 +2092,7 @@ class HttpUrlSpec:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> HttpUrlSpec:
+    def from_dict(cls, d: Dict[str, Any]) -> HttpUrlSpec:
         """Deserializes the HttpUrlSpec from a dictionary."""
         return cls(
             authorization=d.get("authorization", None),
@@ -2133,7 +2133,7 @@ class HttpUrlSpecWithoutSecret:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> HttpUrlSpecWithoutSecret:
+    def from_dict(cls, d: Dict[str, Any]) -> HttpUrlSpecWithoutSecret:
         """Deserializes the HttpUrlSpecWithoutSecret from a dictionary."""
         return cls(enable_ssl_verification=d.get("enable_ssl_verification", None), url=d.get("url", None))
 
@@ -2165,7 +2165,7 @@ class InputTag:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> InputTag:
+    def from_dict(cls, d: Dict[str, Any]) -> InputTag:
         """Deserializes the InputTag from a dictionary."""
         return cls(key=d.get("key", None), value=d.get("value", None))
 
@@ -2205,7 +2205,7 @@ class JobSpec:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> JobSpec:
+    def from_dict(cls, d: Dict[str, Any]) -> JobSpec:
         """Deserializes the JobSpec from a dictionary."""
         return cls(
             access_token=d.get("access_token", None),
@@ -2243,7 +2243,7 @@ class JobSpecWithoutSecret:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> JobSpecWithoutSecret:
+    def from_dict(cls, d: Dict[str, Any]) -> JobSpecWithoutSecret:
         """Deserializes the JobSpecWithoutSecret from a dictionary."""
         return cls(job_id=d.get("job_id", None), workspace_url=d.get("workspace_url", None))
 
@@ -2282,7 +2282,7 @@ class ListArtifactsResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListArtifactsResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ListArtifactsResponse:
         """Deserializes the ListArtifactsResponse from a dictionary."""
         return cls(
             files=_repeated_dict(d, "files", FileInfo),
@@ -2319,7 +2319,7 @@ class ListExperimentsResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListExperimentsResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ListExperimentsResponse:
         """Deserializes the ListExperimentsResponse from a dictionary."""
         return cls(
             experiments=_repeated_dict(d, "experiments", Experiment), next_page_token=d.get("next_page_token", None)
@@ -2352,7 +2352,7 @@ class ListModelsResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListModelsResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ListModelsResponse:
         """Deserializes the ListModelsResponse from a dictionary."""
         return cls(
             next_page_token=d.get("next_page_token", None),
@@ -2387,7 +2387,7 @@ class ListRegistryWebhooks:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListRegistryWebhooks:
+    def from_dict(cls, d: Dict[str, Any]) -> ListRegistryWebhooks:
         """Deserializes the ListRegistryWebhooks from a dictionary."""
         return cls(
             next_page_token=d.get("next_page_token", None), webhooks=_repeated_dict(d, "webhooks", RegistryWebhook)
@@ -2414,7 +2414,7 @@ class ListTransitionRequestsResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListTransitionRequestsResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ListTransitionRequestsResponse:
         """Deserializes the ListTransitionRequestsResponse from a dictionary."""
         return cls(requests=_repeated_dict(d, "requests", Activity))
 
@@ -2463,7 +2463,7 @@ class LogBatch:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> LogBatch:
+    def from_dict(cls, d: Dict[str, Any]) -> LogBatch:
         """Deserializes the LogBatch from a dictionary."""
         return cls(
             metrics=_repeated_dict(d, "metrics", Metric),
@@ -2486,7 +2486,7 @@ class LogBatchResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> LogBatchResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> LogBatchResponse:
         """Deserializes the LogBatchResponse from a dictionary."""
         return cls()
 
@@ -2518,7 +2518,7 @@ class LogInputs:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> LogInputs:
+    def from_dict(cls, d: Dict[str, Any]) -> LogInputs:
         """Deserializes the LogInputs from a dictionary."""
         return cls(datasets=_repeated_dict(d, "datasets", DatasetInput), run_id=d.get("run_id", None))
 
@@ -2536,7 +2536,7 @@ class LogInputsResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> LogInputsResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> LogInputsResponse:
         """Deserializes the LogInputsResponse from a dictionary."""
         return cls()
 
@@ -2597,7 +2597,7 @@ class LogMetric:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> LogMetric:
+    def from_dict(cls, d: Dict[str, Any]) -> LogMetric:
         """Deserializes the LogMetric from a dictionary."""
         return cls(
             key=d.get("key", None),
@@ -2622,7 +2622,7 @@ class LogMetricResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> LogMetricResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> LogMetricResponse:
         """Deserializes the LogMetricResponse from a dictionary."""
         return cls()
 
@@ -2654,7 +2654,7 @@ class LogModel:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> LogModel:
+    def from_dict(cls, d: Dict[str, Any]) -> LogModel:
         """Deserializes the LogModel from a dictionary."""
         return cls(model_json=d.get("model_json", None), run_id=d.get("run_id", None))
 
@@ -2672,7 +2672,7 @@ class LogModelResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> LogModelResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> LogModelResponse:
         """Deserializes the LogModelResponse from a dictionary."""
         return cls()
 
@@ -2719,7 +2719,7 @@ class LogParam:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> LogParam:
+    def from_dict(cls, d: Dict[str, Any]) -> LogParam:
         """Deserializes the LogParam from a dictionary."""
         return cls(
             key=d.get("key", None),
@@ -2742,7 +2742,7 @@ class LogParamResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> LogParamResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> LogParamResponse:
         """Deserializes the LogParamResponse from a dictionary."""
         return cls()
 
@@ -2788,7 +2788,7 @@ class Metric:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> Metric:
+    def from_dict(cls, d: Dict[str, Any]) -> Metric:
         """Deserializes the Metric from a dictionary."""
         return cls(
             key=d.get("key", None),
@@ -2861,7 +2861,7 @@ class Model:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> Model:
+    def from_dict(cls, d: Dict[str, Any]) -> Model:
         """Deserializes the Model from a dictionary."""
         return cls(
             creation_timestamp=d.get("creation_timestamp", None),
@@ -2951,7 +2951,7 @@ class ModelDatabricks:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ModelDatabricks:
+    def from_dict(cls, d: Dict[str, Any]) -> ModelDatabricks:
         """Deserializes the ModelDatabricks from a dictionary."""
         return cls(
             creation_timestamp=d.get("creation_timestamp", None),
@@ -2993,7 +2993,7 @@ class ModelTag:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ModelTag:
+    def from_dict(cls, d: Dict[str, Any]) -> ModelTag:
         """Deserializes the ModelTag from a dictionary."""
         return cls(key=d.get("key", None), value=d.get("value", None))
 
@@ -3103,7 +3103,7 @@ class ModelVersion:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ModelVersion:
+    def from_dict(cls, d: Dict[str, Any]) -> ModelVersion:
         """Deserializes the ModelVersion from a dictionary."""
         return cls(
             creation_timestamp=d.get("creation_timestamp", None),
@@ -3250,7 +3250,7 @@ class ModelVersionDatabricks:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ModelVersionDatabricks:
+    def from_dict(cls, d: Dict[str, Any]) -> ModelVersionDatabricks:
         """Deserializes the ModelVersionDatabricks from a dictionary."""
         return cls(
             creation_timestamp=d.get("creation_timestamp", None),
@@ -3305,7 +3305,7 @@ class ModelVersionTag:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ModelVersionTag:
+    def from_dict(cls, d: Dict[str, Any]) -> ModelVersionTag:
         """Deserializes the ModelVersionTag from a dictionary."""
         return cls(key=d.get("key", None), value=d.get("value", None))
 
@@ -3337,7 +3337,7 @@ class Param:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> Param:
+    def from_dict(cls, d: Dict[str, Any]) -> Param:
         """Deserializes the Param from a dictionary."""
         return cls(key=d.get("key", None), value=d.get("value", None))
 
@@ -3394,7 +3394,7 @@ class RegisteredModelAccessControlRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> RegisteredModelAccessControlRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> RegisteredModelAccessControlRequest:
         """Deserializes the RegisteredModelAccessControlRequest from a dictionary."""
         return cls(
             group_name=d.get("group_name", None),
@@ -3452,7 +3452,7 @@ class RegisteredModelAccessControlResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> RegisteredModelAccessControlResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> RegisteredModelAccessControlResponse:
         """Deserializes the RegisteredModelAccessControlResponse from a dictionary."""
         return cls(
             all_permissions=_repeated_dict(d, "all_permissions", RegisteredModelPermission),
@@ -3495,7 +3495,7 @@ class RegisteredModelPermission:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> RegisteredModelPermission:
+    def from_dict(cls, d: Dict[str, Any]) -> RegisteredModelPermission:
         """Deserializes the RegisteredModelPermission from a dictionary."""
         return cls(
             inherited=d.get("inherited", None),
@@ -3545,7 +3545,7 @@ class RegisteredModelPermissions:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> RegisteredModelPermissions:
+    def from_dict(cls, d: Dict[str, Any]) -> RegisteredModelPermissions:
         """Deserializes the RegisteredModelPermissions from a dictionary."""
         return cls(
             access_control_list=_repeated_dict(d, "access_control_list", RegisteredModelAccessControlResponse),
@@ -3580,7 +3580,7 @@ class RegisteredModelPermissionsDescription:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> RegisteredModelPermissionsDescription:
+    def from_dict(cls, d: Dict[str, Any]) -> RegisteredModelPermissionsDescription:
         """Deserializes the RegisteredModelPermissionsDescription from a dictionary."""
         return cls(
             description=d.get("description", None),
@@ -3614,7 +3614,7 @@ class RegisteredModelPermissionsRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> RegisteredModelPermissionsRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> RegisteredModelPermissionsRequest:
         """Deserializes the RegisteredModelPermissionsRequest from a dictionary."""
         return cls(
             access_control_list=_repeated_dict(d, "access_control_list", RegisteredModelAccessControlRequest),
@@ -3729,7 +3729,7 @@ class RegistryWebhook:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> RegistryWebhook:
+    def from_dict(cls, d: Dict[str, Any]) -> RegistryWebhook:
         """Deserializes the RegistryWebhook from a dictionary."""
         return cls(
             creation_timestamp=d.get("creation_timestamp", None),
@@ -3823,7 +3823,7 @@ class RejectTransitionRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> RejectTransitionRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> RejectTransitionRequest:
         """Deserializes the RejectTransitionRequest from a dictionary."""
         return cls(
             comment=d.get("comment", None),
@@ -3853,7 +3853,7 @@ class RejectTransitionRequestResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> RejectTransitionRequestResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> RejectTransitionRequestResponse:
         """Deserializes the RejectTransitionRequestResponse from a dictionary."""
         return cls(activity=_from_dict(d, "activity", Activity))
 
@@ -3885,7 +3885,7 @@ class RenameModelRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> RenameModelRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> RenameModelRequest:
         """Deserializes the RenameModelRequest from a dictionary."""
         return cls(name=d.get("name", None), new_name=d.get("new_name", None))
 
@@ -3909,7 +3909,7 @@ class RenameModelResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> RenameModelResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> RenameModelResponse:
         """Deserializes the RenameModelResponse from a dictionary."""
         return cls(registered_model=_from_dict(d, "registered_model", Model))
 
@@ -3934,7 +3934,7 @@ class RestoreExperiment:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> RestoreExperiment:
+    def from_dict(cls, d: Dict[str, Any]) -> RestoreExperiment:
         """Deserializes the RestoreExperiment from a dictionary."""
         return cls(experiment_id=d.get("experiment_id", None))
 
@@ -3952,7 +3952,7 @@ class RestoreExperimentResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> RestoreExperimentResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> RestoreExperimentResponse:
         """Deserializes the RestoreExperimentResponse from a dictionary."""
         return cls()
 
@@ -3977,7 +3977,7 @@ class RestoreRun:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> RestoreRun:
+    def from_dict(cls, d: Dict[str, Any]) -> RestoreRun:
         """Deserializes the RestoreRun from a dictionary."""
         return cls(run_id=d.get("run_id", None))
 
@@ -3995,7 +3995,7 @@ class RestoreRunResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> RestoreRunResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> RestoreRunResponse:
         """Deserializes the RestoreRunResponse from a dictionary."""
         return cls()
 
@@ -4036,7 +4036,7 @@ class RestoreRuns:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> RestoreRuns:
+    def from_dict(cls, d: Dict[str, Any]) -> RestoreRuns:
         """Deserializes the RestoreRuns from a dictionary."""
         return cls(
             experiment_id=d.get("experiment_id", None),
@@ -4065,7 +4065,7 @@ class RestoreRunsResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> RestoreRunsResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> RestoreRunsResponse:
         """Deserializes the RestoreRunsResponse from a dictionary."""
         return cls(runs_restored=d.get("runs_restored", None))
 
@@ -4104,7 +4104,7 @@ class Run:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> Run:
+    def from_dict(cls, d: Dict[str, Any]) -> Run:
         """Deserializes the Run from a dictionary."""
         return cls(
             data=_from_dict(d, "data", RunData),
@@ -4147,7 +4147,7 @@ class RunData:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> RunData:
+    def from_dict(cls, d: Dict[str, Any]) -> RunData:
         """Deserializes the RunData from a dictionary."""
         return cls(
             metrics=_repeated_dict(d, "metrics", Metric),
@@ -4236,7 +4236,7 @@ class RunInfo:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> RunInfo:
+    def from_dict(cls, d: Dict[str, Any]) -> RunInfo:
         """Deserializes the RunInfo from a dictionary."""
         return cls(
             artifact_uri=d.get("artifact_uri", None),
@@ -4281,7 +4281,7 @@ class RunInputs:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> RunInputs:
+    def from_dict(cls, d: Dict[str, Any]) -> RunInputs:
         """Deserializes the RunInputs from a dictionary."""
         return cls(dataset_inputs=_repeated_dict(d, "dataset_inputs", DatasetInput))
 
@@ -4313,7 +4313,7 @@ class RunTag:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> RunTag:
+    def from_dict(cls, d: Dict[str, Any]) -> RunTag:
         """Deserializes the RunTag from a dictionary."""
         return cls(key=d.get("key", None), value=d.get("value", None))
 
@@ -4369,7 +4369,7 @@ class SearchExperiments:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> SearchExperiments:
+    def from_dict(cls, d: Dict[str, Any]) -> SearchExperiments:
         """Deserializes the SearchExperiments from a dictionary."""
         return cls(
             filter=d.get("filter", None),
@@ -4408,7 +4408,7 @@ class SearchExperimentsResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> SearchExperimentsResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> SearchExperimentsResponse:
         """Deserializes the SearchExperimentsResponse from a dictionary."""
         return cls(
             experiments=_repeated_dict(d, "experiments", Experiment), next_page_token=d.get("next_page_token", None)
@@ -4451,7 +4451,7 @@ class SearchModelVersionsResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> SearchModelVersionsResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> SearchModelVersionsResponse:
         """Deserializes the SearchModelVersionsResponse from a dictionary."""
         return cls(
             model_versions=_repeated_dict(d, "model_versions", ModelVersion),
@@ -4486,7 +4486,7 @@ class SearchModelsResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> SearchModelsResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> SearchModelsResponse:
         """Deserializes the SearchModelsResponse from a dictionary."""
         return cls(
             next_page_token=d.get("next_page_token", None),
@@ -4562,7 +4562,7 @@ class SearchRuns:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> SearchRuns:
+    def from_dict(cls, d: Dict[str, Any]) -> SearchRuns:
         """Deserializes the SearchRuns from a dictionary."""
         return cls(
             experiment_ids=d.get("experiment_ids", None),
@@ -4601,7 +4601,7 @@ class SearchRunsResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> SearchRunsResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> SearchRunsResponse:
         """Deserializes the SearchRunsResponse from a dictionary."""
         return cls(next_page_token=d.get("next_page_token", None), runs=_repeated_dict(d, "runs", Run))
 
@@ -4650,7 +4650,7 @@ class SetExperimentTag:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> SetExperimentTag:
+    def from_dict(cls, d: Dict[str, Any]) -> SetExperimentTag:
         """Deserializes the SetExperimentTag from a dictionary."""
         return cls(experiment_id=d.get("experiment_id", None), key=d.get("key", None), value=d.get("value", None))
 
@@ -4668,7 +4668,7 @@ class SetExperimentTagResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> SetExperimentTagResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> SetExperimentTagResponse:
         """Deserializes the SetExperimentTagResponse from a dictionary."""
         return cls()
 
@@ -4710,7 +4710,7 @@ class SetModelTagRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> SetModelTagRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> SetModelTagRequest:
         """Deserializes the SetModelTagRequest from a dictionary."""
         return cls(key=d.get("key", None), name=d.get("name", None), value=d.get("value", None))
 
@@ -4728,7 +4728,7 @@ class SetModelTagResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> SetModelTagResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> SetModelTagResponse:
         """Deserializes the SetModelTagResponse from a dictionary."""
         return cls()
 
@@ -4777,7 +4777,7 @@ class SetModelVersionTagRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> SetModelVersionTagRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> SetModelVersionTagRequest:
         """Deserializes the SetModelVersionTagRequest from a dictionary."""
         return cls(
             key=d.get("key", None), name=d.get("name", None), value=d.get("value", None), version=d.get("version", None)
@@ -4797,7 +4797,7 @@ class SetModelVersionTagResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> SetModelVersionTagResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> SetModelVersionTagResponse:
         """Deserializes the SetModelVersionTagResponse from a dictionary."""
         return cls()
 
@@ -4846,7 +4846,7 @@ class SetTag:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> SetTag:
+    def from_dict(cls, d: Dict[str, Any]) -> SetTag:
         """Deserializes the SetTag from a dictionary."""
         return cls(
             key=d.get("key", None),
@@ -4869,7 +4869,7 @@ class SetTagResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> SetTagResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> SetTagResponse:
         """Deserializes the SetTagResponse from a dictionary."""
         return cls()
 
@@ -4933,7 +4933,7 @@ class TestRegistryWebhook:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> TestRegistryWebhook:
+    def from_dict(cls, d: Dict[str, Any]) -> TestRegistryWebhook:
         """Deserializes the TestRegistryWebhook from a dictionary."""
         return cls(body=d.get("body", None), status_code=d.get("status_code", None))
 
@@ -4966,7 +4966,7 @@ class TestRegistryWebhookRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> TestRegistryWebhookRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> TestRegistryWebhookRequest:
         """Deserializes the TestRegistryWebhookRequest from a dictionary."""
         return cls(event=_enum(d, "event", RegistryWebhookEvent), id=d.get("id", None))
 
@@ -4991,7 +4991,7 @@ class TestRegistryWebhookResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> TestRegistryWebhookResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> TestRegistryWebhookResponse:
         """Deserializes the TestRegistryWebhookResponse from a dictionary."""
         return cls(webhook=_from_dict(d, "webhook", TestRegistryWebhook))
 
@@ -5052,7 +5052,7 @@ class TransitionModelVersionStageDatabricks:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> TransitionModelVersionStageDatabricks:
+    def from_dict(cls, d: Dict[str, Any]) -> TransitionModelVersionStageDatabricks:
         """Deserializes the TransitionModelVersionStageDatabricks from a dictionary."""
         return cls(
             archive_existing_versions=d.get("archive_existing_versions", None),
@@ -5121,7 +5121,7 @@ class TransitionRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> TransitionRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> TransitionRequest:
         """Deserializes the TransitionRequest from a dictionary."""
         return cls(
             available_actions=_repeated_enum(d, "available_actions", ActivityAction),
@@ -5151,7 +5151,7 @@ class TransitionStageResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> TransitionStageResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> TransitionStageResponse:
         """Deserializes the TransitionStageResponse from a dictionary."""
         return cls(model_version=_from_dict(d, "model_version", ModelVersionDatabricks))
 
@@ -5183,7 +5183,7 @@ class UpdateComment:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateComment:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateComment:
         """Deserializes the UpdateComment from a dictionary."""
         return cls(comment=d.get("comment", None), id=d.get("id", None))
 
@@ -5208,7 +5208,7 @@ class UpdateCommentResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateCommentResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateCommentResponse:
         """Deserializes the UpdateCommentResponse from a dictionary."""
         return cls(comment=_from_dict(d, "comment", CommentObject))
 
@@ -5240,7 +5240,7 @@ class UpdateExperiment:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateExperiment:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateExperiment:
         """Deserializes the UpdateExperiment from a dictionary."""
         return cls(experiment_id=d.get("experiment_id", None), new_name=d.get("new_name", None))
 
@@ -5258,7 +5258,7 @@ class UpdateExperimentResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateExperimentResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateExperimentResponse:
         """Deserializes the UpdateExperimentResponse from a dictionary."""
         return cls()
 
@@ -5290,7 +5290,7 @@ class UpdateModelRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateModelRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateModelRequest:
         """Deserializes the UpdateModelRequest from a dictionary."""
         return cls(description=d.get("description", None), name=d.get("name", None))
 
@@ -5308,7 +5308,7 @@ class UpdateModelResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateModelResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateModelResponse:
         """Deserializes the UpdateModelResponse from a dictionary."""
         return cls()
 
@@ -5347,7 +5347,7 @@ class UpdateModelVersionRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateModelVersionRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateModelVersionRequest:
         """Deserializes the UpdateModelVersionRequest from a dictionary."""
         return cls(description=d.get("description", None), name=d.get("name", None), version=d.get("version", None))
 
@@ -5365,7 +5365,7 @@ class UpdateModelVersionResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateModelVersionResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateModelVersionResponse:
         """Deserializes the UpdateModelVersionResponse from a dictionary."""
         return cls()
 
@@ -5456,7 +5456,7 @@ class UpdateRegistryWebhook:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateRegistryWebhook:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateRegistryWebhook:
         """Deserializes the UpdateRegistryWebhook from a dictionary."""
         return cls(
             description=d.get("description", None),
@@ -5510,7 +5510,7 @@ class UpdateRun:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateRun:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateRun:
         """Deserializes the UpdateRun from a dictionary."""
         return cls(
             end_time=d.get("end_time", None),
@@ -5540,7 +5540,7 @@ class UpdateRunResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateRunResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateRunResponse:
         """Deserializes the UpdateRunResponse from a dictionary."""
         return cls(run_info=_from_dict(d, "run_info", RunInfo))
 
@@ -5568,7 +5568,7 @@ class UpdateWebhookResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateWebhookResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateWebhookResponse:
         """Deserializes the UpdateWebhookResponse from a dictionary."""
         return cls()
 

--- a/databricks/sdk/service/oauth2.py
+++ b/databricks/sdk/service/oauth2.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import Dict, Iterator, List, Optional
+from typing import Any, Dict, Iterator, List, Optional
 
 from ._internal import _from_dict, _repeated_dict
 
@@ -71,7 +71,7 @@ class CreateCustomAppIntegration:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateCustomAppIntegration:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateCustomAppIntegration:
         """Deserializes the CreateCustomAppIntegration from a dictionary."""
         return cls(
             confidential=d.get("confidential", None),
@@ -118,7 +118,7 @@ class CreateCustomAppIntegrationOutput:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateCustomAppIntegrationOutput:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateCustomAppIntegrationOutput:
         """Deserializes the CreateCustomAppIntegrationOutput from a dictionary."""
         return cls(
             client_id=d.get("client_id", None),
@@ -154,7 +154,7 @@ class CreatePublishedAppIntegration:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreatePublishedAppIntegration:
+    def from_dict(cls, d: Dict[str, Any]) -> CreatePublishedAppIntegration:
         """Deserializes the CreatePublishedAppIntegration from a dictionary."""
         return cls(
             app_id=d.get("app_id", None), token_access_policy=_from_dict(d, "token_access_policy", TokenAccessPolicy)
@@ -181,7 +181,7 @@ class CreatePublishedAppIntegrationOutput:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreatePublishedAppIntegrationOutput:
+    def from_dict(cls, d: Dict[str, Any]) -> CreatePublishedAppIntegrationOutput:
         """Deserializes the CreatePublishedAppIntegrationOutput from a dictionary."""
         return cls(integration_id=d.get("integration_id", None))
 
@@ -241,7 +241,7 @@ class CreateServicePrincipalSecretResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateServicePrincipalSecretResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateServicePrincipalSecretResponse:
         """Deserializes the CreateServicePrincipalSecretResponse from a dictionary."""
         return cls(
             create_time=d.get("create_time", None),
@@ -266,7 +266,7 @@ class DeleteCustomAppIntegrationOutput:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DeleteCustomAppIntegrationOutput:
+    def from_dict(cls, d: Dict[str, Any]) -> DeleteCustomAppIntegrationOutput:
         """Deserializes the DeleteCustomAppIntegrationOutput from a dictionary."""
         return cls()
 
@@ -284,7 +284,7 @@ class DeletePublishedAppIntegrationOutput:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DeletePublishedAppIntegrationOutput:
+    def from_dict(cls, d: Dict[str, Any]) -> DeletePublishedAppIntegrationOutput:
         """Deserializes the DeletePublishedAppIntegrationOutput from a dictionary."""
         return cls()
 
@@ -302,7 +302,7 @@ class DeleteResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DeleteResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> DeleteResponse:
         """Deserializes the DeleteResponse from a dictionary."""
         return cls()
 
@@ -368,7 +368,7 @@ class FederationPolicy:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> FederationPolicy:
+    def from_dict(cls, d: Dict[str, Any]) -> FederationPolicy:
         """Deserializes the FederationPolicy from a dictionary."""
         return cls(
             create_time=d.get("create_time", None),
@@ -467,7 +467,7 @@ class GetCustomAppIntegrationOutput:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GetCustomAppIntegrationOutput:
+    def from_dict(cls, d: Dict[str, Any]) -> GetCustomAppIntegrationOutput:
         """Deserializes the GetCustomAppIntegrationOutput from a dictionary."""
         return cls(
             client_id=d.get("client_id", None),
@@ -510,7 +510,7 @@ class GetCustomAppIntegrationsOutput:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GetCustomAppIntegrationsOutput:
+    def from_dict(cls, d: Dict[str, Any]) -> GetCustomAppIntegrationsOutput:
         """Deserializes the GetCustomAppIntegrationsOutput from a dictionary."""
         return cls(
             apps=_repeated_dict(d, "apps", GetCustomAppIntegrationOutput),
@@ -571,7 +571,7 @@ class GetPublishedAppIntegrationOutput:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GetPublishedAppIntegrationOutput:
+    def from_dict(cls, d: Dict[str, Any]) -> GetPublishedAppIntegrationOutput:
         """Deserializes the GetPublishedAppIntegrationOutput from a dictionary."""
         return cls(
             app_id=d.get("app_id", None),
@@ -609,7 +609,7 @@ class GetPublishedAppIntegrationsOutput:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GetPublishedAppIntegrationsOutput:
+    def from_dict(cls, d: Dict[str, Any]) -> GetPublishedAppIntegrationsOutput:
         """Deserializes the GetPublishedAppIntegrationsOutput from a dictionary."""
         return cls(
             apps=_repeated_dict(d, "apps", GetPublishedAppIntegrationOutput),
@@ -645,7 +645,7 @@ class GetPublishedAppsOutput:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GetPublishedAppsOutput:
+    def from_dict(cls, d: Dict[str, Any]) -> GetPublishedAppsOutput:
         """Deserializes the GetPublishedAppsOutput from a dictionary."""
         return cls(apps=_repeated_dict(d, "apps", PublishedAppOutput), next_page_token=d.get("next_page_token", None))
 
@@ -675,7 +675,7 @@ class ListFederationPoliciesResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListFederationPoliciesResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ListFederationPoliciesResponse:
         """Deserializes the ListFederationPoliciesResponse from a dictionary."""
         return cls(
             next_page_token=d.get("next_page_token", None), policies=_repeated_dict(d, "policies", FederationPolicy)
@@ -709,7 +709,7 @@ class ListServicePrincipalSecretsResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListServicePrincipalSecretsResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ListServicePrincipalSecretsResponse:
         """Deserializes the ListServicePrincipalSecretsResponse from a dictionary."""
         return cls(next_page_token=d.get("next_page_token", None), secrets=_repeated_dict(d, "secrets", SecretInfo))
 
@@ -773,7 +773,7 @@ class OidcFederationPolicy:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> OidcFederationPolicy:
+    def from_dict(cls, d: Dict[str, Any]) -> OidcFederationPolicy:
         """Deserializes the OidcFederationPolicy from a dictionary."""
         return cls(
             audiences=d.get("audiences", None),
@@ -847,7 +847,7 @@ class PublishedAppOutput:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> PublishedAppOutput:
+    def from_dict(cls, d: Dict[str, Any]) -> PublishedAppOutput:
         """Deserializes the PublishedAppOutput from a dictionary."""
         return cls(
             app_id=d.get("app_id", None),
@@ -908,7 +908,7 @@ class SecretInfo:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> SecretInfo:
+    def from_dict(cls, d: Dict[str, Any]) -> SecretInfo:
         """Deserializes the SecretInfo from a dictionary."""
         return cls(
             create_time=d.get("create_time", None),
@@ -946,7 +946,7 @@ class TokenAccessPolicy:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> TokenAccessPolicy:
+    def from_dict(cls, d: Dict[str, Any]) -> TokenAccessPolicy:
         """Deserializes the TokenAccessPolicy from a dictionary."""
         return cls(
             access_token_ttl_in_minutes=d.get("access_token_ttl_in_minutes", None),
@@ -1003,7 +1003,7 @@ class UpdateCustomAppIntegration:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateCustomAppIntegration:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateCustomAppIntegration:
         """Deserializes the UpdateCustomAppIntegration from a dictionary."""
         return cls(
             integration_id=d.get("integration_id", None),
@@ -1027,7 +1027,7 @@ class UpdateCustomAppIntegrationOutput:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateCustomAppIntegrationOutput:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateCustomAppIntegrationOutput:
         """Deserializes the UpdateCustomAppIntegrationOutput from a dictionary."""
         return cls()
 
@@ -1058,7 +1058,7 @@ class UpdatePublishedAppIntegration:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdatePublishedAppIntegration:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdatePublishedAppIntegration:
         """Deserializes the UpdatePublishedAppIntegration from a dictionary."""
         return cls(
             integration_id=d.get("integration_id", None),
@@ -1079,7 +1079,7 @@ class UpdatePublishedAppIntegrationOutput:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdatePublishedAppIntegrationOutput:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdatePublishedAppIntegrationOutput:
         """Deserializes the UpdatePublishedAppIntegrationOutput from a dictionary."""
         return cls()
 

--- a/databricks/sdk/service/pipelines.py
+++ b/databricks/sdk/service/pipelines.py
@@ -8,7 +8,7 @@ import time
 from dataclasses import dataclass
 from datetime import timedelta
 from enum import Enum
-from typing import Callable, Dict, Iterator, List, Optional
+from typing import Any, Callable, Dict, Iterator, List, Optional
 
 from ..errors import OperationFailed
 from ._internal import Wait, _enum, _from_dict, _repeated_dict, _repeated_enum
@@ -227,7 +227,7 @@ class CreatePipeline:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreatePipeline:
+    def from_dict(cls, d: Dict[str, Any]) -> CreatePipeline:
         """Deserializes the CreatePipeline from a dictionary."""
         return cls(
             allow_duplicate_names=d.get("allow_duplicate_names", None),
@@ -286,7 +286,7 @@ class CreatePipelineResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreatePipelineResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> CreatePipelineResponse:
         """Deserializes the CreatePipelineResponse from a dictionary."""
         return cls(
             effective_settings=_from_dict(d, "effective_settings", PipelineSpec), pipeline_id=d.get("pipeline_id", None)
@@ -318,7 +318,7 @@ class CronTrigger:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CronTrigger:
+    def from_dict(cls, d: Dict[str, Any]) -> CronTrigger:
         """Deserializes the CronTrigger from a dictionary."""
         return cls(quartz_cron_schedule=d.get("quartz_cron_schedule", None), timezone_id=d.get("timezone_id", None))
 
@@ -350,7 +350,7 @@ class DataPlaneId:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DataPlaneId:
+    def from_dict(cls, d: Dict[str, Any]) -> DataPlaneId:
         """Deserializes the DataPlaneId from a dictionary."""
         return cls(instance=d.get("instance", None), seq_no=d.get("seq_no", None))
 
@@ -381,7 +381,7 @@ class DeletePipelineResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DeletePipelineResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> DeletePipelineResponse:
         """Deserializes the DeletePipelineResponse from a dictionary."""
         return cls()
 
@@ -608,7 +608,7 @@ class EditPipeline:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> EditPipeline:
+    def from_dict(cls, d: Dict[str, Any]) -> EditPipeline:
         """Deserializes the EditPipeline from a dictionary."""
         return cls(
             allow_duplicate_names=d.get("allow_duplicate_names", None),
@@ -654,7 +654,7 @@ class EditPipelineResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> EditPipelineResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> EditPipelineResponse:
         """Deserializes the EditPipelineResponse from a dictionary."""
         return cls()
 
@@ -686,7 +686,7 @@ class ErrorDetail:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ErrorDetail:
+    def from_dict(cls, d: Dict[str, Any]) -> ErrorDetail:
         """Deserializes the ErrorDetail from a dictionary."""
         return cls(exceptions=_repeated_dict(d, "exceptions", SerializedException), fatal=d.get("fatal", None))
 
@@ -720,7 +720,7 @@ class FileLibrary:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> FileLibrary:
+    def from_dict(cls, d: Dict[str, Any]) -> FileLibrary:
         """Deserializes the FileLibrary from a dictionary."""
         return cls(path=d.get("path", None))
 
@@ -752,7 +752,7 @@ class Filters:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> Filters:
+    def from_dict(cls, d: Dict[str, Any]) -> Filters:
         """Deserializes the Filters from a dictionary."""
         return cls(exclude=d.get("exclude", None), include=d.get("include", None))
 
@@ -777,7 +777,7 @@ class GetPipelinePermissionLevelsResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GetPipelinePermissionLevelsResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> GetPipelinePermissionLevelsResponse:
         """Deserializes the GetPipelinePermissionLevelsResponse from a dictionary."""
         return cls(permission_levels=_repeated_dict(d, "permission_levels", PipelinePermissionsDescription))
 
@@ -879,7 +879,7 @@ class GetPipelineResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GetPipelineResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> GetPipelineResponse:
         """Deserializes the GetPipelineResponse from a dictionary."""
         return cls(
             cause=d.get("cause", None),
@@ -924,7 +924,7 @@ class GetUpdateResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GetUpdateResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> GetUpdateResponse:
         """Deserializes the GetUpdateResponse from a dictionary."""
         return cls(update=_from_dict(d, "update", UpdateInfo))
 
@@ -963,7 +963,7 @@ class IngestionConfig:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> IngestionConfig:
+    def from_dict(cls, d: Dict[str, Any]) -> IngestionConfig:
         """Deserializes the IngestionConfig from a dictionary."""
         return cls(
             report=_from_dict(d, "report", ReportSpec),
@@ -1024,7 +1024,7 @@ class IngestionGatewayPipelineDefinition:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> IngestionGatewayPipelineDefinition:
+    def from_dict(cls, d: Dict[str, Any]) -> IngestionGatewayPipelineDefinition:
         """Deserializes the IngestionGatewayPipelineDefinition from a dictionary."""
         return cls(
             connection_id=d.get("connection_id", None),
@@ -1079,7 +1079,7 @@ class IngestionPipelineDefinition:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> IngestionPipelineDefinition:
+    def from_dict(cls, d: Dict[str, Any]) -> IngestionPipelineDefinition:
         """Deserializes the IngestionPipelineDefinition from a dictionary."""
         return cls(
             connection_name=d.get("connection_name", None),
@@ -1123,7 +1123,7 @@ class ListPipelineEventsResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListPipelineEventsResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ListPipelineEventsResponse:
         """Deserializes the ListPipelineEventsResponse from a dictionary."""
         return cls(
             events=_repeated_dict(d, "events", PipelineEvent),
@@ -1159,7 +1159,7 @@ class ListPipelinesResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListPipelinesResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ListPipelinesResponse:
         """Deserializes the ListPipelinesResponse from a dictionary."""
         return cls(
             next_page_token=d.get("next_page_token", None), statuses=_repeated_dict(d, "statuses", PipelineStateInfo)
@@ -1200,7 +1200,7 @@ class ListUpdatesResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListUpdatesResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ListUpdatesResponse:
         """Deserializes the ListUpdatesResponse from a dictionary."""
         return cls(
             next_page_token=d.get("next_page_token", None),
@@ -1222,7 +1222,7 @@ class ManualTrigger:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ManualTrigger:
+    def from_dict(cls, d: Dict[str, Any]) -> ManualTrigger:
         """Deserializes the ManualTrigger from a dictionary."""
         return cls()
 
@@ -1255,7 +1255,7 @@ class NotebookLibrary:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> NotebookLibrary:
+    def from_dict(cls, d: Dict[str, Any]) -> NotebookLibrary:
         """Deserializes the NotebookLibrary from a dictionary."""
         return cls(path=d.get("path", None))
 
@@ -1292,7 +1292,7 @@ class Notifications:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> Notifications:
+    def from_dict(cls, d: Dict[str, Any]) -> Notifications:
         """Deserializes the Notifications from a dictionary."""
         return cls(alerts=d.get("alerts", None), email_recipients=d.get("email_recipients", None))
 
@@ -1430,7 +1430,7 @@ class Origin:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> Origin:
+    def from_dict(cls, d: Dict[str, Any]) -> Origin:
         """Deserializes the Origin from a dictionary."""
         return cls(
             batch_id=d.get("batch_id", None),
@@ -1494,7 +1494,7 @@ class PipelineAccessControlRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> PipelineAccessControlRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> PipelineAccessControlRequest:
         """Deserializes the PipelineAccessControlRequest from a dictionary."""
         return cls(
             group_name=d.get("group_name", None),
@@ -1552,7 +1552,7 @@ class PipelineAccessControlResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> PipelineAccessControlResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> PipelineAccessControlResponse:
         """Deserializes the PipelineAccessControlResponse from a dictionary."""
         return cls(
             all_permissions=_repeated_dict(d, "all_permissions", PipelinePermission),
@@ -1752,7 +1752,7 @@ class PipelineCluster:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> PipelineCluster:
+    def from_dict(cls, d: Dict[str, Any]) -> PipelineCluster:
         """Deserializes the PipelineCluster from a dictionary."""
         return cls(
             apply_policy_default_values=d.get("apply_policy_default_values", None),
@@ -1816,7 +1816,7 @@ class PipelineClusterAutoscale:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> PipelineClusterAutoscale:
+    def from_dict(cls, d: Dict[str, Any]) -> PipelineClusterAutoscale:
         """Deserializes the PipelineClusterAutoscale from a dictionary."""
         return cls(
             max_workers=d.get("max_workers", None),
@@ -1862,7 +1862,7 @@ class PipelineDeployment:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> PipelineDeployment:
+    def from_dict(cls, d: Dict[str, Any]) -> PipelineDeployment:
         """Deserializes the PipelineDeployment from a dictionary."""
         return cls(kind=_enum(d, "kind", DeploymentKind), metadata_file_path=d.get("metadata_file_path", None))
 
@@ -1943,7 +1943,7 @@ class PipelineEvent:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> PipelineEvent:
+    def from_dict(cls, d: Dict[str, Any]) -> PipelineEvent:
         """Deserializes the PipelineEvent from a dictionary."""
         return cls(
             error=_from_dict(d, "error", ErrorDetail),
@@ -2006,7 +2006,7 @@ class PipelineLibrary:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> PipelineLibrary:
+    def from_dict(cls, d: Dict[str, Any]) -> PipelineLibrary:
         """Deserializes the PipelineLibrary from a dictionary."""
         return cls(
             file=_from_dict(d, "file", FileLibrary),
@@ -2049,7 +2049,7 @@ class PipelinePermission:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> PipelinePermission:
+    def from_dict(cls, d: Dict[str, Any]) -> PipelinePermission:
         """Deserializes the PipelinePermission from a dictionary."""
         return cls(
             inherited=d.get("inherited", None),
@@ -2098,7 +2098,7 @@ class PipelinePermissions:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> PipelinePermissions:
+    def from_dict(cls, d: Dict[str, Any]) -> PipelinePermissions:
         """Deserializes the PipelinePermissions from a dictionary."""
         return cls(
             access_control_list=_repeated_dict(d, "access_control_list", PipelineAccessControlResponse),
@@ -2133,7 +2133,7 @@ class PipelinePermissionsDescription:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> PipelinePermissionsDescription:
+    def from_dict(cls, d: Dict[str, Any]) -> PipelinePermissionsDescription:
         """Deserializes the PipelinePermissionsDescription from a dictionary."""
         return cls(
             description=d.get("description", None),
@@ -2167,7 +2167,7 @@ class PipelinePermissionsRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> PipelinePermissionsRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> PipelinePermissionsRequest:
         """Deserializes the PipelinePermissionsRequest from a dictionary."""
         return cls(
             access_control_list=_repeated_dict(d, "access_control_list", PipelineAccessControlRequest),
@@ -2356,7 +2356,7 @@ class PipelineSpec:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> PipelineSpec:
+    def from_dict(cls, d: Dict[str, Any]) -> PipelineSpec:
         """Deserializes the PipelineSpec from a dictionary."""
         return cls(
             budget_policy_id=d.get("budget_policy_id", None),
@@ -2469,7 +2469,7 @@ class PipelineStateInfo:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> PipelineStateInfo:
+    def from_dict(cls, d: Dict[str, Any]) -> PipelineStateInfo:
         """Deserializes the PipelineStateInfo from a dictionary."""
         return cls(
             cluster_id=d.get("cluster_id", None),
@@ -2515,7 +2515,7 @@ class PipelineTrigger:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> PipelineTrigger:
+    def from_dict(cls, d: Dict[str, Any]) -> PipelineTrigger:
         """Deserializes the PipelineTrigger from a dictionary."""
         return cls(cron=_from_dict(d, "cron", CronTrigger), manual=_from_dict(d, "manual", ManualTrigger))
 
@@ -2569,7 +2569,7 @@ class ReportSpec:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ReportSpec:
+    def from_dict(cls, d: Dict[str, Any]) -> ReportSpec:
         """Deserializes the ReportSpec from a dictionary."""
         return cls(
             destination_catalog=d.get("destination_catalog", None),
@@ -2618,7 +2618,7 @@ class RestartWindow:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> RestartWindow:
+    def from_dict(cls, d: Dict[str, Any]) -> RestartWindow:
         """Deserializes the RestartWindow from a dictionary."""
         return cls(
             days_of_week=_repeated_enum(d, "days_of_week", DayOfWeek),
@@ -2662,7 +2662,7 @@ class RunAs:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> RunAs:
+    def from_dict(cls, d: Dict[str, Any]) -> RunAs:
         """Deserializes the RunAs from a dictionary."""
         return cls(service_principal_name=d.get("service_principal_name", None), user_name=d.get("user_name", None))
 
@@ -2719,7 +2719,7 @@ class SchemaSpec:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> SchemaSpec:
+    def from_dict(cls, d: Dict[str, Any]) -> SchemaSpec:
         """Deserializes the SchemaSpec from a dictionary."""
         return cls(
             destination_catalog=d.get("destination_catalog", None),
@@ -2757,7 +2757,7 @@ class Sequencing:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> Sequencing:
+    def from_dict(cls, d: Dict[str, Any]) -> Sequencing:
         """Deserializes the Sequencing from a dictionary."""
         return cls(
             control_plane_seq_no=d.get("control_plane_seq_no", None),
@@ -2799,7 +2799,7 @@ class SerializedException:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> SerializedException:
+    def from_dict(cls, d: Dict[str, Any]) -> SerializedException:
         """Deserializes the SerializedException from a dictionary."""
         return cls(
             class_name=d.get("class_name", None),
@@ -2849,7 +2849,7 @@ class StackFrame:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> StackFrame:
+    def from_dict(cls, d: Dict[str, Any]) -> StackFrame:
         """Deserializes the StackFrame from a dictionary."""
         return cls(
             declaring_class=d.get("declaring_class", None),
@@ -2917,7 +2917,7 @@ class StartUpdate:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> StartUpdate:
+    def from_dict(cls, d: Dict[str, Any]) -> StartUpdate:
         """Deserializes the StartUpdate from a dictionary."""
         return cls(
             cause=_enum(d, "cause", StartUpdateCause),
@@ -2958,7 +2958,7 @@ class StartUpdateResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> StartUpdateResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> StartUpdateResponse:
         """Deserializes the StartUpdateResponse from a dictionary."""
         return cls(update_id=d.get("update_id", None))
 
@@ -2976,7 +2976,7 @@ class StopPipelineResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> StopPipelineResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> StopPipelineResponse:
         """Deserializes the StopPipelineResponse from a dictionary."""
         return cls()
 
@@ -3045,7 +3045,7 @@ class TableSpec:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> TableSpec:
+    def from_dict(cls, d: Dict[str, Any]) -> TableSpec:
         """Deserializes the TableSpec from a dictionary."""
         return cls(
             destination_catalog=d.get("destination_catalog", None),
@@ -3101,7 +3101,7 @@ class TableSpecificConfig:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> TableSpecificConfig:
+    def from_dict(cls, d: Dict[str, Any]) -> TableSpecificConfig:
         """Deserializes the TableSpecificConfig from a dictionary."""
         return cls(
             primary_keys=d.get("primary_keys", None),
@@ -3214,7 +3214,7 @@ class UpdateInfo:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateInfo:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateInfo:
         """Deserializes the UpdateInfo from a dictionary."""
         return cls(
             cause=_enum(d, "cause", UpdateInfoCause),
@@ -3289,7 +3289,7 @@ class UpdateStateInfo:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateStateInfo:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateStateInfo:
         """Deserializes the UpdateStateInfo from a dictionary."""
         return cls(
             creation_time=d.get("creation_time", None),

--- a/databricks/sdk/service/provisioning.py
+++ b/databricks/sdk/service/provisioning.py
@@ -8,7 +8,7 @@ import time
 from dataclasses import dataclass
 from datetime import timedelta
 from enum import Enum
-from typing import Callable, Dict, Iterator, List, Optional
+from typing import Any, Callable, Dict, Iterator, List, Optional
 
 from ..errors import OperationFailed
 from ._internal import Wait, _enum, _from_dict, _repeated_dict, _repeated_enum
@@ -38,7 +38,7 @@ class AwsCredentials:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> AwsCredentials:
+    def from_dict(cls, d: Dict[str, Any]) -> AwsCredentials:
         """Deserializes the AwsCredentials from a dictionary."""
         return cls(sts_role=_from_dict(d, "sts_role", StsRole))
 
@@ -86,7 +86,7 @@ class AwsKeyInfo:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> AwsKeyInfo:
+    def from_dict(cls, d: Dict[str, Any]) -> AwsKeyInfo:
         """Deserializes the AwsKeyInfo from a dictionary."""
         return cls(
             key_alias=d.get("key_alias", None),
@@ -123,7 +123,7 @@ class AzureWorkspaceInfo:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> AzureWorkspaceInfo:
+    def from_dict(cls, d: Dict[str, Any]) -> AzureWorkspaceInfo:
         """Deserializes the AzureWorkspaceInfo from a dictionary."""
         return cls(resource_group=d.get("resource_group", None), subscription_id=d.get("subscription_id", None))
 
@@ -150,7 +150,7 @@ class CloudResourceContainer:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CloudResourceContainer:
+    def from_dict(cls, d: Dict[str, Any]) -> CloudResourceContainer:
         """Deserializes the CloudResourceContainer from a dictionary."""
         return cls(gcp=_from_dict(d, "gcp", CustomerFacingGcpCloudResourceContainer))
 
@@ -192,7 +192,7 @@ class CreateAwsKeyInfo:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateAwsKeyInfo:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateAwsKeyInfo:
         """Deserializes the CreateAwsKeyInfo from a dictionary."""
         return cls(
             key_alias=d.get("key_alias", None),
@@ -220,7 +220,7 @@ class CreateCredentialAwsCredentials:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateCredentialAwsCredentials:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateCredentialAwsCredentials:
         """Deserializes the CreateCredentialAwsCredentials from a dictionary."""
         return cls(sts_role=_from_dict(d, "sts_role", CreateCredentialStsRole))
 
@@ -251,7 +251,7 @@ class CreateCredentialRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateCredentialRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateCredentialRequest:
         """Deserializes the CreateCredentialRequest from a dictionary."""
         return cls(
             aws_credentials=_from_dict(d, "aws_credentials", CreateCredentialAwsCredentials),
@@ -279,7 +279,7 @@ class CreateCredentialStsRole:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateCredentialStsRole:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateCredentialStsRole:
         """Deserializes the CreateCredentialStsRole from a dictionary."""
         return cls(role_arn=d.get("role_arn", None))
 
@@ -316,7 +316,7 @@ class CreateCustomerManagedKeyRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateCustomerManagedKeyRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateCustomerManagedKeyRequest:
         """Deserializes the CreateCustomerManagedKeyRequest from a dictionary."""
         return cls(
             aws_key_info=_from_dict(d, "aws_key_info", CreateAwsKeyInfo),
@@ -345,7 +345,7 @@ class CreateGcpKeyInfo:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateGcpKeyInfo:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateGcpKeyInfo:
         """Deserializes the CreateGcpKeyInfo from a dictionary."""
         return cls(kms_key_id=d.get("kms_key_id", None))
 
@@ -412,7 +412,7 @@ class CreateNetworkRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateNetworkRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateNetworkRequest:
         """Deserializes the CreateNetworkRequest from a dictionary."""
         return cls(
             gcp_network_info=_from_dict(d, "gcp_network_info", GcpNetworkInfo),
@@ -451,7 +451,7 @@ class CreateStorageConfigurationRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateStorageConfigurationRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateStorageConfigurationRequest:
         """Deserializes the CreateStorageConfigurationRequest from a dictionary."""
         return cls(
             root_bucket_info=_from_dict(d, "root_bucket_info", RootBucketInfo),
@@ -500,7 +500,7 @@ class CreateVpcEndpointRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateVpcEndpointRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateVpcEndpointRequest:
         """Deserializes the CreateVpcEndpointRequest from a dictionary."""
         return cls(
             aws_vpc_endpoint_id=d.get("aws_vpc_endpoint_id", None),
@@ -698,7 +698,7 @@ class CreateWorkspaceRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateWorkspaceRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateWorkspaceRequest:
         """Deserializes the CreateWorkspaceRequest from a dictionary."""
         return cls(
             aws_region=d.get("aws_region", None),
@@ -768,7 +768,7 @@ class Credential:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> Credential:
+    def from_dict(cls, d: Dict[str, Any]) -> Credential:
         """Deserializes the Credential from a dictionary."""
         return cls(
             account_id=d.get("account_id", None),
@@ -805,7 +805,7 @@ class CustomerFacingGcpCloudResourceContainer:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CustomerFacingGcpCloudResourceContainer:
+    def from_dict(cls, d: Dict[str, Any]) -> CustomerFacingGcpCloudResourceContainer:
         """Deserializes the CustomerFacingGcpCloudResourceContainer from a dictionary."""
         return cls(project_id=d.get("project_id", None))
 
@@ -863,7 +863,7 @@ class CustomerManagedKey:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CustomerManagedKey:
+    def from_dict(cls, d: Dict[str, Any]) -> CustomerManagedKey:
         """Deserializes the CustomerManagedKey from a dictionary."""
         return cls(
             account_id=d.get("account_id", None),
@@ -888,7 +888,7 @@ class DeleteResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DeleteResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> DeleteResponse:
         """Deserializes the DeleteResponse from a dictionary."""
         return cls()
 
@@ -948,7 +948,7 @@ class ExternalCustomerInfo:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ExternalCustomerInfo:
+    def from_dict(cls, d: Dict[str, Any]) -> ExternalCustomerInfo:
         """Deserializes the ExternalCustomerInfo from a dictionary."""
         return cls(
             authoritative_user_email=d.get("authoritative_user_email", None),
@@ -977,7 +977,7 @@ class GcpKeyInfo:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GcpKeyInfo:
+    def from_dict(cls, d: Dict[str, Any]) -> GcpKeyInfo:
         """Deserializes the GcpKeyInfo from a dictionary."""
         return cls(kms_key_id=d.get("kms_key_id", None))
 
@@ -1039,7 +1039,7 @@ class GcpManagedNetworkConfig:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GcpManagedNetworkConfig:
+    def from_dict(cls, d: Dict[str, Any]) -> GcpManagedNetworkConfig:
         """Deserializes the GcpManagedNetworkConfig from a dictionary."""
         return cls(
             gke_cluster_pod_ip_range=d.get("gke_cluster_pod_ip_range", None),
@@ -1109,7 +1109,7 @@ class GcpNetworkInfo:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GcpNetworkInfo:
+    def from_dict(cls, d: Dict[str, Any]) -> GcpNetworkInfo:
         """Deserializes the GcpNetworkInfo from a dictionary."""
         return cls(
             network_project_id=d.get("network_project_id", None),
@@ -1171,7 +1171,7 @@ class GcpVpcEndpointInfo:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GcpVpcEndpointInfo:
+    def from_dict(cls, d: Dict[str, Any]) -> GcpVpcEndpointInfo:
         """Deserializes the GcpVpcEndpointInfo from a dictionary."""
         return cls(
             endpoint_region=d.get("endpoint_region", None),
@@ -1220,7 +1220,7 @@ class GkeConfig:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GkeConfig:
+    def from_dict(cls, d: Dict[str, Any]) -> GkeConfig:
         """Deserializes the GkeConfig from a dictionary."""
         return cls(
             connectivity_type=_enum(d, "connectivity_type", GkeConfigConnectivityType),
@@ -1358,7 +1358,7 @@ class Network:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> Network:
+    def from_dict(cls, d: Dict[str, Any]) -> Network:
         """Deserializes the Network from a dictionary."""
         return cls(
             account_id=d.get("account_id", None),
@@ -1405,7 +1405,7 @@ class NetworkHealth:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> NetworkHealth:
+    def from_dict(cls, d: Dict[str, Any]) -> NetworkHealth:
         """Deserializes the NetworkHealth from a dictionary."""
         return cls(error_message=d.get("error_message", None), error_type=_enum(d, "error_type", ErrorType))
 
@@ -1443,7 +1443,7 @@ class NetworkVpcEndpoints:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> NetworkVpcEndpoints:
+    def from_dict(cls, d: Dict[str, Any]) -> NetworkVpcEndpoints:
         """Deserializes the NetworkVpcEndpoints from a dictionary."""
         return cls(dataplane_relay=d.get("dataplane_relay", None), rest_api=d.get("rest_api", None))
 
@@ -1475,7 +1475,7 @@ class NetworkWarning:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> NetworkWarning:
+    def from_dict(cls, d: Dict[str, Any]) -> NetworkWarning:
         """Deserializes the NetworkWarning from a dictionary."""
         return cls(warning_message=d.get("warning_message", None), warning_type=_enum(d, "warning_type", WarningType))
 
@@ -1573,7 +1573,7 @@ class PrivateAccessSettings:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> PrivateAccessSettings:
+    def from_dict(cls, d: Dict[str, Any]) -> PrivateAccessSettings:
         """Deserializes the PrivateAccessSettings from a dictionary."""
         return cls(
             account_id=d.get("account_id", None),
@@ -1599,7 +1599,7 @@ class ReplaceResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ReplaceResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ReplaceResponse:
         """Deserializes the ReplaceResponse from a dictionary."""
         return cls()
 
@@ -1626,7 +1626,7 @@ class RootBucketInfo:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> RootBucketInfo:
+    def from_dict(cls, d: Dict[str, Any]) -> RootBucketInfo:
         """Deserializes the RootBucketInfo from a dictionary."""
         return cls(bucket_name=d.get("bucket_name", None))
 
@@ -1679,7 +1679,7 @@ class StorageConfiguration:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> StorageConfiguration:
+    def from_dict(cls, d: Dict[str, Any]) -> StorageConfiguration:
         """Deserializes the StorageConfiguration from a dictionary."""
         return cls(
             account_id=d.get("account_id", None),
@@ -1718,7 +1718,7 @@ class StsRole:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> StsRole:
+    def from_dict(cls, d: Dict[str, Any]) -> StsRole:
         """Deserializes the StsRole from a dictionary."""
         return cls(external_id=d.get("external_id", None), role_arn=d.get("role_arn", None))
 
@@ -1736,7 +1736,7 @@ class UpdateResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateResponse:
         """Deserializes the UpdateResponse from a dictionary."""
         return cls()
 
@@ -1833,7 +1833,7 @@ class UpdateWorkspaceRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateWorkspaceRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateWorkspaceRequest:
         """Deserializes the UpdateWorkspaceRequest from a dictionary."""
         return cls(
             aws_region=d.get("aws_region", None),
@@ -1922,7 +1922,7 @@ class UpsertPrivateAccessSettingsRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpsertPrivateAccessSettingsRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> UpsertPrivateAccessSettingsRequest:
         """Deserializes the UpsertPrivateAccessSettingsRequest from a dictionary."""
         return cls(
             allowed_vpc_endpoint_ids=d.get("allowed_vpc_endpoint_ids", None),
@@ -2029,7 +2029,7 @@ class VpcEndpoint:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> VpcEndpoint:
+    def from_dict(cls, d: Dict[str, Any]) -> VpcEndpoint:
         """Deserializes the VpcEndpoint from a dictionary."""
         return cls(
             account_id=d.get("account_id", None),
@@ -2277,7 +2277,7 @@ class Workspace:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> Workspace:
+    def from_dict(cls, d: Dict[str, Any]) -> Workspace:
         """Deserializes the Workspace from a dictionary."""
         return cls(
             account_id=d.get("account_id", None),

--- a/databricks/sdk/service/serving.py
+++ b/databricks/sdk/service/serving.py
@@ -52,7 +52,7 @@ class Ai21LabsConfig:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> Ai21LabsConfig:
+    def from_dict(cls, d: Dict[str, Any]) -> Ai21LabsConfig:
         """Deserializes the Ai21LabsConfig from a dictionary."""
         return cls(
             ai21labs_api_key=d.get("ai21labs_api_key", None),
@@ -104,7 +104,7 @@ class AiGatewayConfig:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> AiGatewayConfig:
+    def from_dict(cls, d: Dict[str, Any]) -> AiGatewayConfig:
         """Deserializes the AiGatewayConfig from a dictionary."""
         return cls(
             guardrails=_from_dict(d, "guardrails", AiGatewayGuardrails),
@@ -157,7 +157,7 @@ class AiGatewayGuardrailParameters:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> AiGatewayGuardrailParameters:
+    def from_dict(cls, d: Dict[str, Any]) -> AiGatewayGuardrailParameters:
         """Deserializes the AiGatewayGuardrailParameters from a dictionary."""
         return cls(
             invalid_keywords=d.get("invalid_keywords", None),
@@ -187,7 +187,7 @@ class AiGatewayGuardrailPiiBehavior:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> AiGatewayGuardrailPiiBehavior:
+    def from_dict(cls, d: Dict[str, Any]) -> AiGatewayGuardrailPiiBehavior:
         """Deserializes the AiGatewayGuardrailPiiBehavior from a dictionary."""
         return cls(behavior=_enum(d, "behavior", AiGatewayGuardrailPiiBehaviorBehavior))
 
@@ -225,7 +225,7 @@ class AiGatewayGuardrails:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> AiGatewayGuardrails:
+    def from_dict(cls, d: Dict[str, Any]) -> AiGatewayGuardrails:
         """Deserializes the AiGatewayGuardrails from a dictionary."""
         return cls(
             input=_from_dict(d, "input", AiGatewayGuardrailParameters),
@@ -277,7 +277,7 @@ class AiGatewayInferenceTableConfig:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> AiGatewayInferenceTableConfig:
+    def from_dict(cls, d: Dict[str, Any]) -> AiGatewayInferenceTableConfig:
         """Deserializes the AiGatewayInferenceTableConfig from a dictionary."""
         return cls(
             catalog_name=d.get("catalog_name", None),
@@ -322,7 +322,7 @@ class AiGatewayRateLimit:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> AiGatewayRateLimit:
+    def from_dict(cls, d: Dict[str, Any]) -> AiGatewayRateLimit:
         """Deserializes the AiGatewayRateLimit from a dictionary."""
         return cls(
             calls=d.get("calls", None),
@@ -362,7 +362,7 @@ class AiGatewayUsageTrackingConfig:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> AiGatewayUsageTrackingConfig:
+    def from_dict(cls, d: Dict[str, Any]) -> AiGatewayUsageTrackingConfig:
         """Deserializes the AiGatewayUsageTrackingConfig from a dictionary."""
         return cls(enabled=d.get("enabled", None))
 
@@ -435,7 +435,7 @@ class AmazonBedrockConfig:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> AmazonBedrockConfig:
+    def from_dict(cls, d: Dict[str, Any]) -> AmazonBedrockConfig:
         """Deserializes the AmazonBedrockConfig from a dictionary."""
         return cls(
             aws_access_key_id=d.get("aws_access_key_id", None),
@@ -486,7 +486,7 @@ class AnthropicConfig:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> AnthropicConfig:
+    def from_dict(cls, d: Dict[str, Any]) -> AnthropicConfig:
         """Deserializes the AnthropicConfig from a dictionary."""
         return cls(
             anthropic_api_key=d.get("anthropic_api_key", None),
@@ -538,7 +538,7 @@ class AutoCaptureConfigInput:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> AutoCaptureConfigInput:
+    def from_dict(cls, d: Dict[str, Any]) -> AutoCaptureConfigInput:
         """Deserializes the AutoCaptureConfigInput from a dictionary."""
         return cls(
             catalog_name=d.get("catalog_name", None),
@@ -598,7 +598,7 @@ class AutoCaptureConfigOutput:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> AutoCaptureConfigOutput:
+    def from_dict(cls, d: Dict[str, Any]) -> AutoCaptureConfigOutput:
         """Deserializes the AutoCaptureConfigOutput from a dictionary."""
         return cls(
             catalog_name=d.get("catalog_name", None),
@@ -628,7 +628,7 @@ class AutoCaptureState:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> AutoCaptureState:
+    def from_dict(cls, d: Dict[str, Any]) -> AutoCaptureState:
         """Deserializes the AutoCaptureState from a dictionary."""
         return cls(payload_table=_from_dict(d, "payload_table", PayloadTable))
 
@@ -653,7 +653,7 @@ class BuildLogsResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> BuildLogsResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> BuildLogsResponse:
         """Deserializes the BuildLogsResponse from a dictionary."""
         return cls(logs=d.get("logs", None))
 
@@ -685,7 +685,7 @@ class ChatMessage:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ChatMessage:
+    def from_dict(cls, d: Dict[str, Any]) -> ChatMessage:
         """Deserializes the ChatMessage from a dictionary."""
         return cls(content=d.get("content", None), role=_enum(d, "role", ChatMessageRole))
 
@@ -737,7 +737,7 @@ class CohereConfig:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CohereConfig:
+    def from_dict(cls, d: Dict[str, Any]) -> CohereConfig:
         """Deserializes the CohereConfig from a dictionary."""
         return cls(
             cohere_api_base=d.get("cohere_api_base", None),
@@ -804,7 +804,7 @@ class CreateServingEndpoint:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateServingEndpoint:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateServingEndpoint:
         """Deserializes the CreateServingEndpoint from a dictionary."""
         return cls(
             ai_gateway=_from_dict(d, "ai_gateway", AiGatewayConfig),
@@ -845,7 +845,7 @@ class DataPlaneInfo:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DataPlaneInfo:
+    def from_dict(cls, d: Dict[str, Any]) -> DataPlaneInfo:
         """Deserializes the DataPlaneInfo from a dictionary."""
         return cls(authorization_details=d.get("authorization_details", None), endpoint_url=d.get("endpoint_url", None))
 
@@ -893,7 +893,7 @@ class DatabricksModelServingConfig:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DatabricksModelServingConfig:
+    def from_dict(cls, d: Dict[str, Any]) -> DatabricksModelServingConfig:
         """Deserializes the DatabricksModelServingConfig from a dictionary."""
         return cls(
             databricks_api_token=d.get("databricks_api_token", None),
@@ -933,7 +933,7 @@ class DataframeSplitInput:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DataframeSplitInput:
+    def from_dict(cls, d: Dict[str, Any]) -> DataframeSplitInput:
         """Deserializes the DataframeSplitInput from a dictionary."""
         return cls(columns=d.get("columns", None), data=d.get("data", None), index=d.get("index", None))
 
@@ -951,7 +951,7 @@ class DeleteResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DeleteResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> DeleteResponse:
         """Deserializes the DeleteResponse from a dictionary."""
         return cls()
 
@@ -989,7 +989,7 @@ class EmbeddingsV1ResponseEmbeddingElement:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> EmbeddingsV1ResponseEmbeddingElement:
+    def from_dict(cls, d: Dict[str, Any]) -> EmbeddingsV1ResponseEmbeddingElement:
         """Deserializes the EmbeddingsV1ResponseEmbeddingElement from a dictionary."""
         return cls(
             embedding=d.get("embedding", None),
@@ -1056,7 +1056,7 @@ class EndpointCoreConfigInput:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> EndpointCoreConfigInput:
+    def from_dict(cls, d: Dict[str, Any]) -> EndpointCoreConfigInput:
         """Deserializes the EndpointCoreConfigInput from a dictionary."""
         return cls(
             auto_capture_config=_from_dict(d, "auto_capture_config", AutoCaptureConfigInput),
@@ -1119,7 +1119,7 @@ class EndpointCoreConfigOutput:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> EndpointCoreConfigOutput:
+    def from_dict(cls, d: Dict[str, Any]) -> EndpointCoreConfigOutput:
         """Deserializes the EndpointCoreConfigOutput from a dictionary."""
         return cls(
             auto_capture_config=_from_dict(d, "auto_capture_config", AutoCaptureConfigOutput),
@@ -1158,7 +1158,7 @@ class EndpointCoreConfigSummary:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> EndpointCoreConfigSummary:
+    def from_dict(cls, d: Dict[str, Any]) -> EndpointCoreConfigSummary:
         """Deserializes the EndpointCoreConfigSummary from a dictionary."""
         return cls(
             served_entities=_repeated_dict(d, "served_entities", ServedEntitySpec),
@@ -1225,7 +1225,7 @@ class EndpointPendingConfig:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> EndpointPendingConfig:
+    def from_dict(cls, d: Dict[str, Any]) -> EndpointPendingConfig:
         """Deserializes the EndpointPendingConfig from a dictionary."""
         return cls(
             auto_capture_config=_from_dict(d, "auto_capture_config", AutoCaptureConfigOutput),
@@ -1269,7 +1269,7 @@ class EndpointState:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> EndpointState:
+    def from_dict(cls, d: Dict[str, Any]) -> EndpointState:
         """Deserializes the EndpointState from a dictionary."""
         return cls(
             config_update=_enum(d, "config_update", EndpointStateConfigUpdate),
@@ -1318,7 +1318,7 @@ class EndpointTag:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> EndpointTag:
+    def from_dict(cls, d: Dict[str, Any]) -> EndpointTag:
         """Deserializes the EndpointTag from a dictionary."""
         return cls(key=d.get("key", None), value=d.get("value", None))
 
@@ -1342,7 +1342,7 @@ class EndpointTags:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> EndpointTags:
+    def from_dict(cls, d: Dict[str, Any]) -> EndpointTags:
         """Deserializes the EndpointTags from a dictionary."""
         return cls(tags=_repeated_dict(d, "tags", EndpointTag))
 
@@ -1366,7 +1366,7 @@ class ExportMetricsResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ExportMetricsResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ExportMetricsResponse:
         """Deserializes the ExportMetricsResponse from a dictionary."""
         return cls(contents=d.get("contents", None))
 
@@ -1429,7 +1429,7 @@ class ExternalFunctionRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ExternalFunctionRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> ExternalFunctionRequest:
         """Deserializes the ExternalFunctionRequest from a dictionary."""
         return cls(
             connection_name=d.get("connection_name", None),
@@ -1542,7 +1542,7 @@ class ExternalModel:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ExternalModel:
+    def from_dict(cls, d: Dict[str, Any]) -> ExternalModel:
         """Deserializes the ExternalModel from a dictionary."""
         return cls(
             ai21labs_config=_from_dict(d, "ai21labs_config", Ai21LabsConfig),
@@ -1607,7 +1607,7 @@ class ExternalModelUsageElement:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ExternalModelUsageElement:
+    def from_dict(cls, d: Dict[str, Any]) -> ExternalModelUsageElement:
         """Deserializes the ExternalModelUsageElement from a dictionary."""
         return cls(
             completion_tokens=d.get("completion_tokens", None),
@@ -1656,7 +1656,7 @@ class FoundationModel:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> FoundationModel:
+    def from_dict(cls, d: Dict[str, Any]) -> FoundationModel:
         """Deserializes the FoundationModel from a dictionary."""
         return cls(
             description=d.get("description", None),
@@ -1685,7 +1685,7 @@ class GetOpenApiResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GetOpenApiResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> GetOpenApiResponse:
         """Deserializes the GetOpenApiResponse from a dictionary."""
         return cls(contents=d.get("contents", None))
 
@@ -1710,7 +1710,7 @@ class GetServingEndpointPermissionLevelsResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GetServingEndpointPermissionLevelsResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> GetServingEndpointPermissionLevelsResponse:
         """Deserializes the GetServingEndpointPermissionLevelsResponse from a dictionary."""
         return cls(permission_levels=_repeated_dict(d, "permission_levels", ServingEndpointPermissionsDescription))
 
@@ -1771,7 +1771,7 @@ class GoogleCloudVertexAiConfig:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GoogleCloudVertexAiConfig:
+    def from_dict(cls, d: Dict[str, Any]) -> GoogleCloudVertexAiConfig:
         """Deserializes the GoogleCloudVertexAiConfig from a dictionary."""
         return cls(
             private_key=d.get("private_key", None),
@@ -1800,7 +1800,7 @@ class HttpRequestResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> HttpRequestResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> HttpRequestResponse:
         """Deserializes the HttpRequestResponse from a dictionary."""
         return cls(contents=d.get("contents", None))
 
@@ -1825,7 +1825,7 @@ class ListEndpointsResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListEndpointsResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ListEndpointsResponse:
         """Deserializes the ListEndpointsResponse from a dictionary."""
         return cls(endpoints=_repeated_dict(d, "endpoints", ServingEndpoint))
 
@@ -1853,7 +1853,7 @@ class ModelDataPlaneInfo:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ModelDataPlaneInfo:
+    def from_dict(cls, d: Dict[str, Any]) -> ModelDataPlaneInfo:
         """Deserializes the ModelDataPlaneInfo from a dictionary."""
         return cls(query_info=_from_dict(d, "query_info", DataPlaneInfo))
 
@@ -1968,7 +1968,7 @@ class OpenAiConfig:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> OpenAiConfig:
+    def from_dict(cls, d: Dict[str, Any]) -> OpenAiConfig:
         """Deserializes the OpenAiConfig from a dictionary."""
         return cls(
             microsoft_entra_client_id=d.get("microsoft_entra_client_id", None),
@@ -2016,7 +2016,7 @@ class PaLmConfig:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> PaLmConfig:
+    def from_dict(cls, d: Dict[str, Any]) -> PaLmConfig:
         """Deserializes the PaLmConfig from a dictionary."""
         return cls(
             palm_api_key=d.get("palm_api_key", None), palm_api_key_plaintext=d.get("palm_api_key_plaintext", None)
@@ -2057,7 +2057,7 @@ class PatchServingEndpointTags:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> PatchServingEndpointTags:
+    def from_dict(cls, d: Dict[str, Any]) -> PatchServingEndpointTags:
         """Deserializes the PatchServingEndpointTags from a dictionary."""
         return cls(
             add_tags=_repeated_dict(d, "add_tags", EndpointTag),
@@ -2097,7 +2097,7 @@ class PayloadTable:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> PayloadTable:
+    def from_dict(cls, d: Dict[str, Any]) -> PayloadTable:
         """Deserializes the PayloadTable from a dictionary."""
         return cls(name=d.get("name", None), status=d.get("status", None), status_message=d.get("status_message", None))
 
@@ -2153,7 +2153,7 @@ class PutAiGatewayRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> PutAiGatewayRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> PutAiGatewayRequest:
         """Deserializes the PutAiGatewayRequest from a dictionary."""
         return cls(
             guardrails=_from_dict(d, "guardrails", AiGatewayGuardrails),
@@ -2208,7 +2208,7 @@ class PutAiGatewayResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> PutAiGatewayResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> PutAiGatewayResponse:
         """Deserializes the PutAiGatewayResponse from a dictionary."""
         return cls(
             guardrails=_from_dict(d, "guardrails", AiGatewayGuardrails),
@@ -2245,7 +2245,7 @@ class PutRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> PutRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> PutRequest:
         """Deserializes the PutRequest from a dictionary."""
         return cls(name=d.get("name", None), rate_limits=_repeated_dict(d, "rate_limits", RateLimit))
 
@@ -2270,7 +2270,7 @@ class PutResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> PutResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> PutResponse:
         """Deserializes the PutResponse from a dictionary."""
         return cls(rate_limits=_repeated_dict(d, "rate_limits", RateLimit))
 
@@ -2402,7 +2402,7 @@ class QueryEndpointInput:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> QueryEndpointInput:
+    def from_dict(cls, d: Dict[str, Any]) -> QueryEndpointInput:
         """Deserializes the QueryEndpointInput from a dictionary."""
         return cls(
             dataframe_records=d.get("dataframe_records", None),
@@ -2506,7 +2506,7 @@ class QueryEndpointResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> QueryEndpointResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> QueryEndpointResponse:
         """Deserializes the QueryEndpointResponse from a dictionary."""
         return cls(
             choices=_repeated_dict(d, "choices", V1ResponseChoiceElement),
@@ -2565,7 +2565,7 @@ class RateLimit:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> RateLimit:
+    def from_dict(cls, d: Dict[str, Any]) -> RateLimit:
         """Deserializes the RateLimit from a dictionary."""
         return cls(
             calls=d.get("calls", None),
@@ -2613,7 +2613,7 @@ class Route:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> Route:
+    def from_dict(cls, d: Dict[str, Any]) -> Route:
         """Deserializes the Route from a dictionary."""
         return cls(
             served_model_name=d.get("served_model_name", None), traffic_percentage=d.get("traffic_percentage", None)
@@ -2733,7 +2733,7 @@ class ServedEntityInput:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ServedEntityInput:
+    def from_dict(cls, d: Dict[str, Any]) -> ServedEntityInput:
         """Deserializes the ServedEntityInput from a dictionary."""
         return cls(
             entity_name=d.get("entity_name", None),
@@ -2889,7 +2889,7 @@ class ServedEntityOutput:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ServedEntityOutput:
+    def from_dict(cls, d: Dict[str, Any]) -> ServedEntityOutput:
         """Deserializes the ServedEntityOutput from a dictionary."""
         return cls(
             creation_timestamp=d.get("creation_timestamp", None),
@@ -2955,7 +2955,7 @@ class ServedEntitySpec:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ServedEntitySpec:
+    def from_dict(cls, d: Dict[str, Any]) -> ServedEntitySpec:
         """Deserializes the ServedEntitySpec from a dictionary."""
         return cls(
             entity_name=d.get("entity_name", None),
@@ -3063,7 +3063,7 @@ class ServedModelInput:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ServedModelInput:
+    def from_dict(cls, d: Dict[str, Any]) -> ServedModelInput:
         """Deserializes the ServedModelInput from a dictionary."""
         return cls(
             environment_vars=d.get("environment_vars", None),
@@ -3196,7 +3196,7 @@ class ServedModelOutput:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ServedModelOutput:
+    def from_dict(cls, d: Dict[str, Any]) -> ServedModelOutput:
         """Deserializes the ServedModelOutput from a dictionary."""
         return cls(
             creation_timestamp=d.get("creation_timestamp", None),
@@ -3246,7 +3246,7 @@ class ServedModelSpec:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ServedModelSpec:
+    def from_dict(cls, d: Dict[str, Any]) -> ServedModelSpec:
         """Deserializes the ServedModelSpec from a dictionary."""
         return cls(
             model_name=d.get("model_name", None), model_version=d.get("model_version", None), name=d.get("name", None)
@@ -3278,7 +3278,7 @@ class ServedModelState:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ServedModelState:
+    def from_dict(cls, d: Dict[str, Any]) -> ServedModelState:
         """Deserializes the ServedModelState from a dictionary."""
         return cls(
             deployment=_enum(d, "deployment", ServedModelStateDeployment),
@@ -3315,7 +3315,7 @@ class ServerLogsResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ServerLogsResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ServerLogsResponse:
         """Deserializes the ServerLogsResponse from a dictionary."""
         return cls(logs=d.get("logs", None))
 
@@ -3404,7 +3404,7 @@ class ServingEndpoint:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ServingEndpoint:
+    def from_dict(cls, d: Dict[str, Any]) -> ServingEndpoint:
         """Deserializes the ServingEndpoint from a dictionary."""
         return cls(
             ai_gateway=_from_dict(d, "ai_gateway", AiGatewayConfig),
@@ -3461,7 +3461,7 @@ class ServingEndpointAccessControlRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ServingEndpointAccessControlRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> ServingEndpointAccessControlRequest:
         """Deserializes the ServingEndpointAccessControlRequest from a dictionary."""
         return cls(
             group_name=d.get("group_name", None),
@@ -3519,7 +3519,7 @@ class ServingEndpointAccessControlResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ServingEndpointAccessControlResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ServingEndpointAccessControlResponse:
         """Deserializes the ServingEndpointAccessControlResponse from a dictionary."""
         return cls(
             all_permissions=_repeated_dict(d, "all_permissions", ServingEndpointPermission),
@@ -3650,7 +3650,7 @@ class ServingEndpointDetailed:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ServingEndpointDetailed:
+    def from_dict(cls, d: Dict[str, Any]) -> ServingEndpointDetailed:
         """Deserializes the ServingEndpointDetailed from a dictionary."""
         return cls(
             ai_gateway=_from_dict(d, "ai_gateway", AiGatewayConfig),
@@ -3710,7 +3710,7 @@ class ServingEndpointPermission:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ServingEndpointPermission:
+    def from_dict(cls, d: Dict[str, Any]) -> ServingEndpointPermission:
         """Deserializes the ServingEndpointPermission from a dictionary."""
         return cls(
             inherited=d.get("inherited", None),
@@ -3758,7 +3758,7 @@ class ServingEndpointPermissions:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ServingEndpointPermissions:
+    def from_dict(cls, d: Dict[str, Any]) -> ServingEndpointPermissions:
         """Deserializes the ServingEndpointPermissions from a dictionary."""
         return cls(
             access_control_list=_repeated_dict(d, "access_control_list", ServingEndpointAccessControlResponse),
@@ -3793,7 +3793,7 @@ class ServingEndpointPermissionsDescription:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ServingEndpointPermissionsDescription:
+    def from_dict(cls, d: Dict[str, Any]) -> ServingEndpointPermissionsDescription:
         """Deserializes the ServingEndpointPermissionsDescription from a dictionary."""
         return cls(
             description=d.get("description", None),
@@ -3827,7 +3827,7 @@ class ServingEndpointPermissionsRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ServingEndpointPermissionsRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> ServingEndpointPermissionsRequest:
         """Deserializes the ServingEndpointPermissionsRequest from a dictionary."""
         return cls(
             access_control_list=_repeated_dict(d, "access_control_list", ServingEndpointAccessControlRequest),
@@ -3864,7 +3864,7 @@ class TrafficConfig:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> TrafficConfig:
+    def from_dict(cls, d: Dict[str, Any]) -> TrafficConfig:
         """Deserializes the TrafficConfig from a dictionary."""
         return cls(routes=_repeated_dict(d, "routes", Route))
 
@@ -3917,7 +3917,7 @@ class V1ResponseChoiceElement:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> V1ResponseChoiceElement:
+    def from_dict(cls, d: Dict[str, Any]) -> V1ResponseChoiceElement:
         """Deserializes the V1ResponseChoiceElement from a dictionary."""
         return cls(
             finish_reason=d.get("finishReason", None),

--- a/databricks/sdk/service/settings.py
+++ b/databricks/sdk/service/settings.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from enum import Enum
-from typing import Dict, Iterator, List, Optional
+from typing import Any, Dict, Iterator, List, Optional
 
 from ._internal import _enum, _from_dict, _repeated_dict, _repeated_enum
 
@@ -56,7 +56,7 @@ class AccountIpAccessEnable:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> AccountIpAccessEnable:
+    def from_dict(cls, d: Dict[str, Any]) -> AccountIpAccessEnable:
         """Deserializes the AccountIpAccessEnable from a dictionary."""
         return cls(
             acct_ip_acl_enable=_from_dict(d, "acct_ip_acl_enable", BooleanMessage),
@@ -84,7 +84,7 @@ class AibiDashboardEmbeddingAccessPolicy:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> AibiDashboardEmbeddingAccessPolicy:
+    def from_dict(cls, d: Dict[str, Any]) -> AibiDashboardEmbeddingAccessPolicy:
         """Deserializes the AibiDashboardEmbeddingAccessPolicy from a dictionary."""
         return cls(
             access_policy_type=_enum(d, "access_policy_type", AibiDashboardEmbeddingAccessPolicyAccessPolicyType)
@@ -139,7 +139,7 @@ class AibiDashboardEmbeddingAccessPolicySetting:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> AibiDashboardEmbeddingAccessPolicySetting:
+    def from_dict(cls, d: Dict[str, Any]) -> AibiDashboardEmbeddingAccessPolicySetting:
         """Deserializes the AibiDashboardEmbeddingAccessPolicySetting from a dictionary."""
         return cls(
             aibi_dashboard_embedding_access_policy=_from_dict(
@@ -169,7 +169,7 @@ class AibiDashboardEmbeddingApprovedDomains:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> AibiDashboardEmbeddingApprovedDomains:
+    def from_dict(cls, d: Dict[str, Any]) -> AibiDashboardEmbeddingApprovedDomains:
         """Deserializes the AibiDashboardEmbeddingApprovedDomains from a dictionary."""
         return cls(approved_domains=d.get("approved_domains", None))
 
@@ -215,7 +215,7 @@ class AibiDashboardEmbeddingApprovedDomainsSetting:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> AibiDashboardEmbeddingApprovedDomainsSetting:
+    def from_dict(cls, d: Dict[str, Any]) -> AibiDashboardEmbeddingApprovedDomainsSetting:
         """Deserializes the AibiDashboardEmbeddingApprovedDomainsSetting from a dictionary."""
         return cls(
             aibi_dashboard_embedding_approved_domains=_from_dict(
@@ -267,7 +267,7 @@ class AutomaticClusterUpdateSetting:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> AutomaticClusterUpdateSetting:
+    def from_dict(cls, d: Dict[str, Any]) -> AutomaticClusterUpdateSetting:
         """Deserializes the AutomaticClusterUpdateSetting from a dictionary."""
         return cls(
             automatic_cluster_update_workspace=_from_dict(
@@ -297,7 +297,7 @@ class BooleanMessage:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> BooleanMessage:
+    def from_dict(cls, d: Dict[str, Any]) -> BooleanMessage:
         """Deserializes the BooleanMessage from a dictionary."""
         return cls(value=d.get("value", None))
 
@@ -350,7 +350,7 @@ class ClusterAutoRestartMessage:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ClusterAutoRestartMessage:
+    def from_dict(cls, d: Dict[str, Any]) -> ClusterAutoRestartMessage:
         """Deserializes the ClusterAutoRestartMessage from a dictionary."""
         return cls(
             can_toggle=d.get("can_toggle", None),
@@ -402,7 +402,7 @@ class ClusterAutoRestartMessageEnablementDetails:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ClusterAutoRestartMessageEnablementDetails:
+    def from_dict(cls, d: Dict[str, Any]) -> ClusterAutoRestartMessageEnablementDetails:
         """Deserializes the ClusterAutoRestartMessageEnablementDetails from a dictionary."""
         return cls(
             forced_for_compliance_mode=d.get("forced_for_compliance_mode", None),
@@ -430,7 +430,7 @@ class ClusterAutoRestartMessageMaintenanceWindow:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ClusterAutoRestartMessageMaintenanceWindow:
+    def from_dict(cls, d: Dict[str, Any]) -> ClusterAutoRestartMessageMaintenanceWindow:
         """Deserializes the ClusterAutoRestartMessageMaintenanceWindow from a dictionary."""
         return cls(
             week_day_based_schedule=_from_dict(
@@ -481,7 +481,7 @@ class ClusterAutoRestartMessageMaintenanceWindowWeekDayBasedSchedule:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ClusterAutoRestartMessageMaintenanceWindowWeekDayBasedSchedule:
+    def from_dict(cls, d: Dict[str, Any]) -> ClusterAutoRestartMessageMaintenanceWindowWeekDayBasedSchedule:
         """Deserializes the ClusterAutoRestartMessageMaintenanceWindowWeekDayBasedSchedule from a dictionary."""
         return cls(
             day_of_week=_enum(d, "day_of_week", ClusterAutoRestartMessageMaintenanceWindowDayOfWeek),
@@ -528,7 +528,7 @@ class ClusterAutoRestartMessageMaintenanceWindowWindowStartTime:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ClusterAutoRestartMessageMaintenanceWindowWindowStartTime:
+    def from_dict(cls, d: Dict[str, Any]) -> ClusterAutoRestartMessageMaintenanceWindowWindowStartTime:
         """Deserializes the ClusterAutoRestartMessageMaintenanceWindowWindowStartTime from a dictionary."""
         return cls(hours=d.get("hours", None), minutes=d.get("minutes", None))
 
@@ -561,7 +561,7 @@ class ComplianceSecurityProfile:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ComplianceSecurityProfile:
+    def from_dict(cls, d: Dict[str, Any]) -> ComplianceSecurityProfile:
         """Deserializes the ComplianceSecurityProfile from a dictionary."""
         return cls(
             compliance_standards=_repeated_enum(d, "compliance_standards", ComplianceStandard),
@@ -611,7 +611,7 @@ class ComplianceSecurityProfileSetting:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ComplianceSecurityProfileSetting:
+    def from_dict(cls, d: Dict[str, Any]) -> ComplianceSecurityProfileSetting:
         """Deserializes the ComplianceSecurityProfileSetting from a dictionary."""
         return cls(
             compliance_security_profile_workspace=_from_dict(
@@ -682,7 +682,7 @@ class Config:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> Config:
+    def from_dict(cls, d: Dict[str, Any]) -> Config:
         """Deserializes the Config from a dictionary."""
         return cls(
             email=_from_dict(d, "email", EmailConfig),
@@ -731,7 +731,7 @@ class CreateIpAccessList:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateIpAccessList:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateIpAccessList:
         """Deserializes the CreateIpAccessList from a dictionary."""
         return cls(
             ip_addresses=d.get("ip_addresses", None),
@@ -762,7 +762,7 @@ class CreateIpAccessListResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateIpAccessListResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateIpAccessListResponse:
         """Deserializes the CreateIpAccessListResponse from a dictionary."""
         return cls(ip_access_list=_from_dict(d, "ip_access_list", IpAccessListInfo))
 
@@ -797,7 +797,7 @@ class CreateNetworkConnectivityConfigRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateNetworkConnectivityConfigRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateNetworkConnectivityConfigRequest:
         """Deserializes the CreateNetworkConnectivityConfigRequest from a dictionary."""
         return cls(name=d.get("name", None), region=d.get("region", None))
 
@@ -829,7 +829,7 @@ class CreateNotificationDestinationRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateNotificationDestinationRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateNotificationDestinationRequest:
         """Deserializes the CreateNotificationDestinationRequest from a dictionary."""
         return cls(config=_from_dict(d, "config", Config), display_name=d.get("display_name", None))
 
@@ -870,7 +870,7 @@ class CreateOboTokenRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateOboTokenRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateOboTokenRequest:
         """Deserializes the CreateOboTokenRequest from a dictionary."""
         return cls(
             application_id=d.get("application_id", None),
@@ -907,7 +907,7 @@ class CreateOboTokenResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateOboTokenResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateOboTokenResponse:
         """Deserializes the CreateOboTokenResponse from a dictionary."""
         return cls(token_info=_from_dict(d, "token_info", TokenInfo), token_value=d.get("token_value", None))
 
@@ -947,7 +947,7 @@ class CreatePrivateEndpointRuleRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreatePrivateEndpointRuleRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> CreatePrivateEndpointRuleRequest:
         """Deserializes the CreatePrivateEndpointRuleRequest from a dictionary."""
         return cls(
             group_id=_enum(d, "group_id", CreatePrivateEndpointRuleRequestGroupId),
@@ -995,7 +995,7 @@ class CreateTokenRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateTokenRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateTokenRequest:
         """Deserializes the CreateTokenRequest from a dictionary."""
         return cls(comment=d.get("comment", None), lifetime_seconds=d.get("lifetime_seconds", None))
 
@@ -1027,7 +1027,7 @@ class CreateTokenResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateTokenResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateTokenResponse:
         """Deserializes the CreateTokenResponse from a dictionary."""
         return cls(token_info=_from_dict(d, "token_info", PublicTokenInfo), token_value=d.get("token_value", None))
 
@@ -1062,7 +1062,7 @@ class CspEnablementAccount:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CspEnablementAccount:
+    def from_dict(cls, d: Dict[str, Any]) -> CspEnablementAccount:
         """Deserializes the CspEnablementAccount from a dictionary."""
         return cls(
             compliance_standards=_repeated_enum(d, "compliance_standards", ComplianceStandard),
@@ -1112,7 +1112,7 @@ class CspEnablementAccountSetting:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CspEnablementAccountSetting:
+    def from_dict(cls, d: Dict[str, Any]) -> CspEnablementAccountSetting:
         """Deserializes the CspEnablementAccountSetting from a dictionary."""
         return cls(
             csp_enablement_account=_from_dict(d, "csp_enablement_account", CspEnablementAccount),
@@ -1170,7 +1170,7 @@ class DefaultNamespaceSetting:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DefaultNamespaceSetting:
+    def from_dict(cls, d: Dict[str, Any]) -> DefaultNamespaceSetting:
         """Deserializes the DefaultNamespaceSetting from a dictionary."""
         return cls(
             etag=d.get("etag", None),
@@ -1206,7 +1206,7 @@ class DeleteAccountIpAccessEnableResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DeleteAccountIpAccessEnableResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> DeleteAccountIpAccessEnableResponse:
         """Deserializes the DeleteAccountIpAccessEnableResponse from a dictionary."""
         return cls(etag=d.get("etag", None))
 
@@ -1238,7 +1238,7 @@ class DeleteAibiDashboardEmbeddingAccessPolicySettingResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DeleteAibiDashboardEmbeddingAccessPolicySettingResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> DeleteAibiDashboardEmbeddingAccessPolicySettingResponse:
         """Deserializes the DeleteAibiDashboardEmbeddingAccessPolicySettingResponse from a dictionary."""
         return cls(etag=d.get("etag", None))
 
@@ -1270,7 +1270,7 @@ class DeleteAibiDashboardEmbeddingApprovedDomainsSettingResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DeleteAibiDashboardEmbeddingApprovedDomainsSettingResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> DeleteAibiDashboardEmbeddingApprovedDomainsSettingResponse:
         """Deserializes the DeleteAibiDashboardEmbeddingApprovedDomainsSettingResponse from a dictionary."""
         return cls(etag=d.get("etag", None))
 
@@ -1302,7 +1302,7 @@ class DeleteDefaultNamespaceSettingResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DeleteDefaultNamespaceSettingResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> DeleteDefaultNamespaceSettingResponse:
         """Deserializes the DeleteDefaultNamespaceSettingResponse from a dictionary."""
         return cls(etag=d.get("etag", None))
 
@@ -1334,7 +1334,7 @@ class DeleteDisableLegacyAccessResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DeleteDisableLegacyAccessResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> DeleteDisableLegacyAccessResponse:
         """Deserializes the DeleteDisableLegacyAccessResponse from a dictionary."""
         return cls(etag=d.get("etag", None))
 
@@ -1366,7 +1366,7 @@ class DeleteDisableLegacyDbfsResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DeleteDisableLegacyDbfsResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> DeleteDisableLegacyDbfsResponse:
         """Deserializes the DeleteDisableLegacyDbfsResponse from a dictionary."""
         return cls(etag=d.get("etag", None))
 
@@ -1398,7 +1398,7 @@ class DeleteDisableLegacyFeaturesResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DeleteDisableLegacyFeaturesResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> DeleteDisableLegacyFeaturesResponse:
         """Deserializes the DeleteDisableLegacyFeaturesResponse from a dictionary."""
         return cls(etag=d.get("etag", None))
 
@@ -1416,7 +1416,7 @@ class DeleteNetworkConnectivityConfigurationResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DeleteNetworkConnectivityConfigurationResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> DeleteNetworkConnectivityConfigurationResponse:
         """Deserializes the DeleteNetworkConnectivityConfigurationResponse from a dictionary."""
         return cls()
 
@@ -1448,7 +1448,7 @@ class DeletePersonalComputeSettingResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DeletePersonalComputeSettingResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> DeletePersonalComputeSettingResponse:
         """Deserializes the DeletePersonalComputeSettingResponse from a dictionary."""
         return cls(etag=d.get("etag", None))
 
@@ -1466,7 +1466,7 @@ class DeleteResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DeleteResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> DeleteResponse:
         """Deserializes the DeleteResponse from a dictionary."""
         return cls()
 
@@ -1498,7 +1498,7 @@ class DeleteRestrictWorkspaceAdminsSettingResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DeleteRestrictWorkspaceAdminsSettingResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> DeleteRestrictWorkspaceAdminsSettingResponse:
         """Deserializes the DeleteRestrictWorkspaceAdminsSettingResponse from a dictionary."""
         return cls(etag=d.get("etag", None))
 
@@ -1553,7 +1553,7 @@ class DisableLegacyAccess:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DisableLegacyAccess:
+    def from_dict(cls, d: Dict[str, Any]) -> DisableLegacyAccess:
         """Deserializes the DisableLegacyAccess from a dictionary."""
         return cls(
             disable_legacy_access=_from_dict(d, "disable_legacy_access", BooleanMessage),
@@ -1603,7 +1603,7 @@ class DisableLegacyDbfs:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DisableLegacyDbfs:
+    def from_dict(cls, d: Dict[str, Any]) -> DisableLegacyDbfs:
         """Deserializes the DisableLegacyDbfs from a dictionary."""
         return cls(
             disable_legacy_dbfs=_from_dict(d, "disable_legacy_dbfs", BooleanMessage),
@@ -1653,7 +1653,7 @@ class DisableLegacyFeatures:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DisableLegacyFeatures:
+    def from_dict(cls, d: Dict[str, Any]) -> DisableLegacyFeatures:
         """Deserializes the DisableLegacyFeatures from a dictionary."""
         return cls(
             disable_legacy_features=_from_dict(d, "disable_legacy_features", BooleanMessage),
@@ -1686,7 +1686,7 @@ class EgressNetworkPolicy:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> EgressNetworkPolicy:
+    def from_dict(cls, d: Dict[str, Any]) -> EgressNetworkPolicy:
         """Deserializes the EgressNetworkPolicy from a dictionary."""
         return cls(internet_access=_from_dict(d, "internet_access", EgressNetworkPolicyInternetAccessPolicy))
 
@@ -1734,7 +1734,7 @@ class EgressNetworkPolicyInternetAccessPolicy:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> EgressNetworkPolicyInternetAccessPolicy:
+    def from_dict(cls, d: Dict[str, Any]) -> EgressNetworkPolicyInternetAccessPolicy:
         """Deserializes the EgressNetworkPolicyInternetAccessPolicy from a dictionary."""
         return cls(
             allowed_internet_destinations=_repeated_dict(
@@ -1789,7 +1789,7 @@ class EgressNetworkPolicyInternetAccessPolicyInternetDestination:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> EgressNetworkPolicyInternetAccessPolicyInternetDestination:
+    def from_dict(cls, d: Dict[str, Any]) -> EgressNetworkPolicyInternetAccessPolicyInternetDestination:
         """Deserializes the EgressNetworkPolicyInternetAccessPolicyInternetDestination from a dictionary."""
         return cls(
             destination=d.get("destination", None),
@@ -1841,7 +1841,7 @@ class EgressNetworkPolicyInternetAccessPolicyLogOnlyMode:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> EgressNetworkPolicyInternetAccessPolicyLogOnlyMode:
+    def from_dict(cls, d: Dict[str, Any]) -> EgressNetworkPolicyInternetAccessPolicyLogOnlyMode:
         """Deserializes the EgressNetworkPolicyInternetAccessPolicyLogOnlyMode from a dictionary."""
         return cls(
             log_only_mode_type=_enum(
@@ -1939,7 +1939,7 @@ class EgressNetworkPolicyInternetAccessPolicyStorageDestination:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> EgressNetworkPolicyInternetAccessPolicyStorageDestination:
+    def from_dict(cls, d: Dict[str, Any]) -> EgressNetworkPolicyInternetAccessPolicyStorageDestination:
         """Deserializes the EgressNetworkPolicyInternetAccessPolicyStorageDestination from a dictionary."""
         return cls(
             allowed_paths=d.get("allowed_paths", None),
@@ -1981,7 +1981,7 @@ class EmailConfig:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> EmailConfig:
+    def from_dict(cls, d: Dict[str, Any]) -> EmailConfig:
         """Deserializes the EmailConfig from a dictionary."""
         return cls(addresses=d.get("addresses", None))
 
@@ -1999,7 +1999,7 @@ class Empty:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> Empty:
+    def from_dict(cls, d: Dict[str, Any]) -> Empty:
         """Deserializes the Empty from a dictionary."""
         return cls()
 
@@ -2025,7 +2025,7 @@ class EnhancedSecurityMonitoring:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> EnhancedSecurityMonitoring:
+    def from_dict(cls, d: Dict[str, Any]) -> EnhancedSecurityMonitoring:
         """Deserializes the EnhancedSecurityMonitoring from a dictionary."""
         return cls(is_enabled=d.get("is_enabled", None))
 
@@ -2072,7 +2072,7 @@ class EnhancedSecurityMonitoringSetting:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> EnhancedSecurityMonitoringSetting:
+    def from_dict(cls, d: Dict[str, Any]) -> EnhancedSecurityMonitoringSetting:
         """Deserializes the EnhancedSecurityMonitoringSetting from a dictionary."""
         return cls(
             enhanced_security_monitoring_workspace=_from_dict(
@@ -2104,7 +2104,7 @@ class EsmEnablementAccount:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> EsmEnablementAccount:
+    def from_dict(cls, d: Dict[str, Any]) -> EsmEnablementAccount:
         """Deserializes the EsmEnablementAccount from a dictionary."""
         return cls(is_enforced=d.get("is_enforced", None))
 
@@ -2151,7 +2151,7 @@ class EsmEnablementAccountSetting:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> EsmEnablementAccountSetting:
+    def from_dict(cls, d: Dict[str, Any]) -> EsmEnablementAccountSetting:
         """Deserializes the EsmEnablementAccountSetting from a dictionary."""
         return cls(
             esm_enablement_account=_from_dict(d, "esm_enablement_account", EsmEnablementAccount),
@@ -2210,7 +2210,7 @@ class ExchangeToken:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ExchangeToken:
+    def from_dict(cls, d: Dict[str, Any]) -> ExchangeToken:
         """Deserializes the ExchangeToken from a dictionary."""
         return cls(
             credential=d.get("credential", None),
@@ -2257,7 +2257,7 @@ class ExchangeTokenRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ExchangeTokenRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> ExchangeTokenRequest:
         """Deserializes the ExchangeTokenRequest from a dictionary."""
         return cls(
             partition_id=_from_dict(d, "partitionId", PartitionId),
@@ -2287,7 +2287,7 @@ class ExchangeTokenResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ExchangeTokenResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ExchangeTokenResponse:
         """Deserializes the ExchangeTokenResponse from a dictionary."""
         return cls(values=_repeated_dict(d, "values", ExchangeToken))
 
@@ -2314,7 +2314,7 @@ class FetchIpAccessListResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> FetchIpAccessListResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> FetchIpAccessListResponse:
         """Deserializes the FetchIpAccessListResponse from a dictionary."""
         return cls(ip_access_list=_from_dict(d, "ip_access_list", IpAccessListInfo))
 
@@ -2374,7 +2374,7 @@ class GenericWebhookConfig:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GenericWebhookConfig:
+    def from_dict(cls, d: Dict[str, Any]) -> GenericWebhookConfig:
         """Deserializes the GenericWebhookConfig from a dictionary."""
         return cls(
             password=d.get("password", None),
@@ -2406,7 +2406,7 @@ class GetIpAccessListResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GetIpAccessListResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> GetIpAccessListResponse:
         """Deserializes the GetIpAccessListResponse from a dictionary."""
         return cls(ip_access_list=_from_dict(d, "ip_access_list", IpAccessListInfo))
 
@@ -2432,7 +2432,7 @@ class GetIpAccessListsResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GetIpAccessListsResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> GetIpAccessListsResponse:
         """Deserializes the GetIpAccessListsResponse from a dictionary."""
         return cls(ip_access_lists=_repeated_dict(d, "ip_access_lists", IpAccessListInfo))
 
@@ -2457,7 +2457,7 @@ class GetTokenPermissionLevelsResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GetTokenPermissionLevelsResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> GetTokenPermissionLevelsResponse:
         """Deserializes the GetTokenPermissionLevelsResponse from a dictionary."""
         return cls(permission_levels=_repeated_dict(d, "permission_levels", TokenPermissionsDescription))
 
@@ -2483,7 +2483,7 @@ class GetTokenResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GetTokenResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> GetTokenResponse:
         """Deserializes the GetTokenResponse from a dictionary."""
         return cls(token_info=_from_dict(d, "token_info", TokenInfo))
 
@@ -2575,7 +2575,7 @@ class IpAccessListInfo:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> IpAccessListInfo:
+    def from_dict(cls, d: Dict[str, Any]) -> IpAccessListInfo:
         """Deserializes the IpAccessListInfo from a dictionary."""
         return cls(
             address_count=d.get("address_count", None),
@@ -2612,7 +2612,7 @@ class ListIpAccessListResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListIpAccessListResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ListIpAccessListResponse:
         """Deserializes the ListIpAccessListResponse from a dictionary."""
         return cls(ip_access_lists=_repeated_dict(d, "ip_access_lists", IpAccessListInfo))
 
@@ -2644,7 +2644,7 @@ class ListNccAzurePrivateEndpointRulesResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListNccAzurePrivateEndpointRulesResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ListNccAzurePrivateEndpointRulesResponse:
         """Deserializes the ListNccAzurePrivateEndpointRulesResponse from a dictionary."""
         return cls(
             items=_repeated_dict(d, "items", NccAzurePrivateEndpointRule),
@@ -2679,7 +2679,7 @@ class ListNetworkConnectivityConfigurationsResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListNetworkConnectivityConfigurationsResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ListNetworkConnectivityConfigurationsResponse:
         """Deserializes the ListNetworkConnectivityConfigurationsResponse from a dictionary."""
         return cls(
             items=_repeated_dict(d, "items", NetworkConnectivityConfiguration),
@@ -2713,7 +2713,7 @@ class ListNotificationDestinationsResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListNotificationDestinationsResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ListNotificationDestinationsResponse:
         """Deserializes the ListNotificationDestinationsResponse from a dictionary."""
         return cls(
             next_page_token=d.get("next_page_token", None),
@@ -2755,7 +2755,7 @@ class ListNotificationDestinationsResult:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListNotificationDestinationsResult:
+    def from_dict(cls, d: Dict[str, Any]) -> ListNotificationDestinationsResult:
         """Deserializes the ListNotificationDestinationsResult from a dictionary."""
         return cls(
             destination_type=_enum(d, "destination_type", DestinationType),
@@ -2784,7 +2784,7 @@ class ListPublicTokensResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListPublicTokensResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ListPublicTokensResponse:
         """Deserializes the ListPublicTokensResponse from a dictionary."""
         return cls(token_infos=_repeated_dict(d, "token_infos", PublicTokenInfo))
 
@@ -2811,7 +2811,7 @@ class ListTokensResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListTokensResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ListTokensResponse:
         """Deserializes the ListTokensResponse from a dictionary."""
         return cls(token_infos=_repeated_dict(d, "token_infos", TokenInfo))
 
@@ -2853,7 +2853,7 @@ class MicrosoftTeamsConfig:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> MicrosoftTeamsConfig:
+    def from_dict(cls, d: Dict[str, Any]) -> MicrosoftTeamsConfig:
         """Deserializes the MicrosoftTeamsConfig from a dictionary."""
         return cls(url=d.get("url", None), url_set=d.get("url_set", None))
 
@@ -2882,7 +2882,7 @@ class NccAwsStableIpRule:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> NccAwsStableIpRule:
+    def from_dict(cls, d: Dict[str, Any]) -> NccAwsStableIpRule:
         """Deserializes the NccAwsStableIpRule from a dictionary."""
         return cls(cidr_blocks=d.get("cidr_blocks", None))
 
@@ -2981,7 +2981,7 @@ class NccAzurePrivateEndpointRule:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> NccAzurePrivateEndpointRule:
+    def from_dict(cls, d: Dict[str, Any]) -> NccAzurePrivateEndpointRule:
         """Deserializes the NccAzurePrivateEndpointRule from a dictionary."""
         return cls(
             connection_state=_enum(d, "connection_state", NccAzurePrivateEndpointRuleConnectionState),
@@ -3064,7 +3064,7 @@ class NccAzureServiceEndpointRule:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> NccAzureServiceEndpointRule:
+    def from_dict(cls, d: Dict[str, Any]) -> NccAzureServiceEndpointRule:
         """Deserializes the NccAzureServiceEndpointRule from a dictionary."""
         return cls(
             subnets=d.get("subnets", None),
@@ -3106,7 +3106,7 @@ class NccEgressConfig:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> NccEgressConfig:
+    def from_dict(cls, d: Dict[str, Any]) -> NccEgressConfig:
         """Deserializes the NccEgressConfig from a dictionary."""
         return cls(
             default_rules=_from_dict(d, "default_rules", NccEgressDefaultRules),
@@ -3147,7 +3147,7 @@ class NccEgressDefaultRules:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> NccEgressDefaultRules:
+    def from_dict(cls, d: Dict[str, Any]) -> NccEgressDefaultRules:
         """Deserializes the NccEgressDefaultRules from a dictionary."""
         return cls(
             aws_stable_ip_rule=_from_dict(d, "aws_stable_ip_rule", NccAwsStableIpRule),
@@ -3177,7 +3177,7 @@ class NccEgressTargetRules:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> NccEgressTargetRules:
+    def from_dict(cls, d: Dict[str, Any]) -> NccEgressTargetRules:
         """Deserializes the NccEgressTargetRules from a dictionary."""
         return cls(
             azure_private_endpoint_rules=_repeated_dict(d, "azure_private_endpoint_rules", NccAzurePrivateEndpointRule)
@@ -3250,7 +3250,7 @@ class NetworkConnectivityConfiguration:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> NetworkConnectivityConfiguration:
+    def from_dict(cls, d: Dict[str, Any]) -> NetworkConnectivityConfiguration:
         """Deserializes the NetworkConnectivityConfiguration from a dictionary."""
         return cls(
             account_id=d.get("account_id", None),
@@ -3305,7 +3305,7 @@ class NotificationDestination:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> NotificationDestination:
+    def from_dict(cls, d: Dict[str, Any]) -> NotificationDestination:
         """Deserializes the NotificationDestination from a dictionary."""
         return cls(
             config=_from_dict(d, "config", Config),
@@ -3342,7 +3342,7 @@ class PagerdutyConfig:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> PagerdutyConfig:
+    def from_dict(cls, d: Dict[str, Any]) -> PagerdutyConfig:
         """Deserializes the PagerdutyConfig from a dictionary."""
         return cls(
             integration_key=d.get("integration_key", None), integration_key_set=d.get("integration_key_set", None)
@@ -3371,7 +3371,7 @@ class PartitionId:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> PartitionId:
+    def from_dict(cls, d: Dict[str, Any]) -> PartitionId:
         """Deserializes the PartitionId from a dictionary."""
         return cls(workspace_id=d.get("workspaceId", None))
 
@@ -3400,7 +3400,7 @@ class PersonalComputeMessage:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> PersonalComputeMessage:
+    def from_dict(cls, d: Dict[str, Any]) -> PersonalComputeMessage:
         """Deserializes the PersonalComputeMessage from a dictionary."""
         return cls(value=_enum(d, "value", PersonalComputeMessageEnum))
 
@@ -3457,7 +3457,7 @@ class PersonalComputeSetting:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> PersonalComputeSetting:
+    def from_dict(cls, d: Dict[str, Any]) -> PersonalComputeSetting:
         """Deserializes the PersonalComputeSetting from a dictionary."""
         return cls(
             etag=d.get("etag", None),
@@ -3507,7 +3507,7 @@ class PublicTokenInfo:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> PublicTokenInfo:
+    def from_dict(cls, d: Dict[str, Any]) -> PublicTokenInfo:
         """Deserializes the PublicTokenInfo from a dictionary."""
         return cls(
             comment=d.get("comment", None),
@@ -3569,7 +3569,7 @@ class ReplaceIpAccessList:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ReplaceIpAccessList:
+    def from_dict(cls, d: Dict[str, Any]) -> ReplaceIpAccessList:
         """Deserializes the ReplaceIpAccessList from a dictionary."""
         return cls(
             enabled=d.get("enabled", None),
@@ -3593,7 +3593,7 @@ class ReplaceResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ReplaceResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ReplaceResponse:
         """Deserializes the ReplaceResponse from a dictionary."""
         return cls()
 
@@ -3617,7 +3617,7 @@ class RestrictWorkspaceAdminsMessage:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> RestrictWorkspaceAdminsMessage:
+    def from_dict(cls, d: Dict[str, Any]) -> RestrictWorkspaceAdminsMessage:
         """Deserializes the RestrictWorkspaceAdminsMessage from a dictionary."""
         return cls(status=_enum(d, "status", RestrictWorkspaceAdminsMessageStatus))
 
@@ -3669,7 +3669,7 @@ class RestrictWorkspaceAdminsSetting:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> RestrictWorkspaceAdminsSetting:
+    def from_dict(cls, d: Dict[str, Any]) -> RestrictWorkspaceAdminsSetting:
         """Deserializes the RestrictWorkspaceAdminsSetting from a dictionary."""
         return cls(
             etag=d.get("etag", None),
@@ -3698,7 +3698,7 @@ class RevokeTokenRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> RevokeTokenRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> RevokeTokenRequest:
         """Deserializes the RevokeTokenRequest from a dictionary."""
         return cls(token_id=d.get("token_id", None))
 
@@ -3716,7 +3716,7 @@ class RevokeTokenResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> RevokeTokenResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> RevokeTokenResponse:
         """Deserializes the RevokeTokenResponse from a dictionary."""
         return cls()
 
@@ -3734,7 +3734,7 @@ class SetStatusResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> SetStatusResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> SetStatusResponse:
         """Deserializes the SetStatusResponse from a dictionary."""
         return cls()
 
@@ -3766,7 +3766,7 @@ class SlackConfig:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> SlackConfig:
+    def from_dict(cls, d: Dict[str, Any]) -> SlackConfig:
         """Deserializes the SlackConfig from a dictionary."""
         return cls(url=d.get("url", None), url_set=d.get("url_set", None))
 
@@ -3791,7 +3791,7 @@ class StringMessage:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> StringMessage:
+    def from_dict(cls, d: Dict[str, Any]) -> StringMessage:
         """Deserializes the StringMessage from a dictionary."""
         return cls(value=d.get("value", None))
 
@@ -3837,7 +3837,7 @@ class TokenAccessControlRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> TokenAccessControlRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> TokenAccessControlRequest:
         """Deserializes the TokenAccessControlRequest from a dictionary."""
         return cls(
             group_name=d.get("group_name", None),
@@ -3895,7 +3895,7 @@ class TokenAccessControlResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> TokenAccessControlResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> TokenAccessControlResponse:
         """Deserializes the TokenAccessControlResponse from a dictionary."""
         return cls(
             all_permissions=_repeated_dict(d, "all_permissions", TokenPermission),
@@ -3982,7 +3982,7 @@ class TokenInfo:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> TokenInfo:
+    def from_dict(cls, d: Dict[str, Any]) -> TokenInfo:
         """Deserializes the TokenInfo from a dictionary."""
         return cls(
             comment=d.get("comment", None),
@@ -4029,7 +4029,7 @@ class TokenPermission:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> TokenPermission:
+    def from_dict(cls, d: Dict[str, Any]) -> TokenPermission:
         """Deserializes the TokenPermission from a dictionary."""
         return cls(
             inherited=d.get("inherited", None),
@@ -4075,7 +4075,7 @@ class TokenPermissions:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> TokenPermissions:
+    def from_dict(cls, d: Dict[str, Any]) -> TokenPermissions:
         """Deserializes the TokenPermissions from a dictionary."""
         return cls(
             access_control_list=_repeated_dict(d, "access_control_list", TokenAccessControlResponse),
@@ -4110,7 +4110,7 @@ class TokenPermissionsDescription:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> TokenPermissionsDescription:
+    def from_dict(cls, d: Dict[str, Any]) -> TokenPermissionsDescription:
         """Deserializes the TokenPermissionsDescription from a dictionary."""
         return cls(
             description=d.get("description", None), permission_level=_enum(d, "permission_level", TokenPermissionLevel)
@@ -4136,7 +4136,7 @@ class TokenPermissionsRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> TokenPermissionsRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> TokenPermissionsRequest:
         """Deserializes the TokenPermissionsRequest from a dictionary."""
         return cls(access_control_list=_repeated_dict(d, "access_control_list", TokenAccessControlRequest))
 
@@ -4192,7 +4192,7 @@ class UpdateAccountIpAccessEnableRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateAccountIpAccessEnableRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateAccountIpAccessEnableRequest:
         """Deserializes the UpdateAccountIpAccessEnableRequest from a dictionary."""
         return cls(
             allow_missing=d.get("allow_missing", None),
@@ -4244,7 +4244,7 @@ class UpdateAibiDashboardEmbeddingAccessPolicySettingRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateAibiDashboardEmbeddingAccessPolicySettingRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateAibiDashboardEmbeddingAccessPolicySettingRequest:
         """Deserializes the UpdateAibiDashboardEmbeddingAccessPolicySettingRequest from a dictionary."""
         return cls(
             allow_missing=d.get("allow_missing", None),
@@ -4296,7 +4296,7 @@ class UpdateAibiDashboardEmbeddingApprovedDomainsSettingRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateAibiDashboardEmbeddingApprovedDomainsSettingRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateAibiDashboardEmbeddingApprovedDomainsSettingRequest:
         """Deserializes the UpdateAibiDashboardEmbeddingApprovedDomainsSettingRequest from a dictionary."""
         return cls(
             allow_missing=d.get("allow_missing", None),
@@ -4348,7 +4348,7 @@ class UpdateAutomaticClusterUpdateSettingRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateAutomaticClusterUpdateSettingRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateAutomaticClusterUpdateSettingRequest:
         """Deserializes the UpdateAutomaticClusterUpdateSettingRequest from a dictionary."""
         return cls(
             allow_missing=d.get("allow_missing", None),
@@ -4400,7 +4400,7 @@ class UpdateComplianceSecurityProfileSettingRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateComplianceSecurityProfileSettingRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateComplianceSecurityProfileSettingRequest:
         """Deserializes the UpdateComplianceSecurityProfileSettingRequest from a dictionary."""
         return cls(
             allow_missing=d.get("allow_missing", None),
@@ -4452,7 +4452,7 @@ class UpdateCspEnablementAccountSettingRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateCspEnablementAccountSettingRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateCspEnablementAccountSettingRequest:
         """Deserializes the UpdateCspEnablementAccountSettingRequest from a dictionary."""
         return cls(
             allow_missing=d.get("allow_missing", None),
@@ -4511,7 +4511,7 @@ class UpdateDefaultNamespaceSettingRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateDefaultNamespaceSettingRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateDefaultNamespaceSettingRequest:
         """Deserializes the UpdateDefaultNamespaceSettingRequest from a dictionary."""
         return cls(
             allow_missing=d.get("allow_missing", None),
@@ -4563,7 +4563,7 @@ class UpdateDisableLegacyAccessRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateDisableLegacyAccessRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateDisableLegacyAccessRequest:
         """Deserializes the UpdateDisableLegacyAccessRequest from a dictionary."""
         return cls(
             allow_missing=d.get("allow_missing", None),
@@ -4615,7 +4615,7 @@ class UpdateDisableLegacyDbfsRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateDisableLegacyDbfsRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateDisableLegacyDbfsRequest:
         """Deserializes the UpdateDisableLegacyDbfsRequest from a dictionary."""
         return cls(
             allow_missing=d.get("allow_missing", None),
@@ -4667,7 +4667,7 @@ class UpdateDisableLegacyFeaturesRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateDisableLegacyFeaturesRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateDisableLegacyFeaturesRequest:
         """Deserializes the UpdateDisableLegacyFeaturesRequest from a dictionary."""
         return cls(
             allow_missing=d.get("allow_missing", None),
@@ -4719,7 +4719,7 @@ class UpdateEnhancedSecurityMonitoringSettingRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateEnhancedSecurityMonitoringSettingRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateEnhancedSecurityMonitoringSettingRequest:
         """Deserializes the UpdateEnhancedSecurityMonitoringSettingRequest from a dictionary."""
         return cls(
             allow_missing=d.get("allow_missing", None),
@@ -4771,7 +4771,7 @@ class UpdateEsmEnablementAccountSettingRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateEsmEnablementAccountSettingRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateEsmEnablementAccountSettingRequest:
         """Deserializes the UpdateEsmEnablementAccountSettingRequest from a dictionary."""
         return cls(
             allow_missing=d.get("allow_missing", None),
@@ -4832,7 +4832,7 @@ class UpdateIpAccessList:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateIpAccessList:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateIpAccessList:
         """Deserializes the UpdateIpAccessList from a dictionary."""
         return cls(
             enabled=d.get("enabled", None),
@@ -4877,7 +4877,7 @@ class UpdateNotificationDestinationRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateNotificationDestinationRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateNotificationDestinationRequest:
         """Deserializes the UpdateNotificationDestinationRequest from a dictionary."""
         return cls(
             config=_from_dict(d, "config", Config), display_name=d.get("display_name", None), id=d.get("id", None)
@@ -4927,7 +4927,7 @@ class UpdatePersonalComputeSettingRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdatePersonalComputeSettingRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdatePersonalComputeSettingRequest:
         """Deserializes the UpdatePersonalComputeSettingRequest from a dictionary."""
         return cls(
             allow_missing=d.get("allow_missing", None),
@@ -4949,7 +4949,7 @@ class UpdateResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateResponse:
         """Deserializes the UpdateResponse from a dictionary."""
         return cls()
 
@@ -4997,7 +4997,7 @@ class UpdateRestrictWorkspaceAdminsSettingRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateRestrictWorkspaceAdminsSettingRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateRestrictWorkspaceAdminsSettingRequest:
         """Deserializes the UpdateRestrictWorkspaceAdminsSettingRequest from a dictionary."""
         return cls(
             allow_missing=d.get("allow_missing", None),

--- a/databricks/sdk/service/sharing.py
+++ b/databricks/sdk/service/sharing.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from enum import Enum
-from typing import Dict, Iterator, List, Optional
+from typing import Any, Dict, Iterator, List, Optional
 
 from ._internal import _enum, _from_dict, _repeated_dict, _repeated_enum
 
@@ -66,7 +66,7 @@ class CreateProvider:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateProvider:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateProvider:
         """Deserializes the CreateProvider from a dictionary."""
         return cls(
             authentication_type=_enum(d, "authentication_type", AuthenticationType),
@@ -157,7 +157,7 @@ class CreateRecipient:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateRecipient:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateRecipient:
         """Deserializes the CreateRecipient from a dictionary."""
         return cls(
             authentication_type=_enum(d, "authentication_type", AuthenticationType),
@@ -206,7 +206,7 @@ class CreateShare:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateShare:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateShare:
         """Deserializes the CreateShare from a dictionary."""
         return cls(comment=d.get("comment", None), name=d.get("name", None), storage_root=d.get("storage_root", None))
 
@@ -224,7 +224,7 @@ class DeleteResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DeleteResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> DeleteResponse:
         """Deserializes the DeleteResponse from a dictionary."""
         return cls()
 
@@ -242,7 +242,7 @@ class GetActivationUrlInfoResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GetActivationUrlInfoResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> GetActivationUrlInfoResponse:
         """Deserializes the GetActivationUrlInfoResponse from a dictionary."""
         return cls()
 
@@ -275,7 +275,7 @@ class GetRecipientSharePermissionsResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GetRecipientSharePermissionsResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> GetRecipientSharePermissionsResponse:
         """Deserializes the GetRecipientSharePermissionsResponse from a dictionary."""
         return cls(
             next_page_token=d.get("next_page_token", None),
@@ -303,7 +303,7 @@ class IpAccessList:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> IpAccessList:
+    def from_dict(cls, d: Dict[str, Any]) -> IpAccessList:
         """Deserializes the IpAccessList from a dictionary."""
         return cls(allowed_ip_addresses=d.get("allowed_ip_addresses", None))
 
@@ -336,7 +336,7 @@ class ListProviderSharesResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListProviderSharesResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ListProviderSharesResponse:
         """Deserializes the ListProviderSharesResponse from a dictionary."""
         return cls(next_page_token=d.get("next_page_token", None), shares=_repeated_dict(d, "shares", ProviderShare))
 
@@ -369,7 +369,7 @@ class ListProvidersResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListProvidersResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ListProvidersResponse:
         """Deserializes the ListProvidersResponse from a dictionary."""
         return cls(
             next_page_token=d.get("next_page_token", None), providers=_repeated_dict(d, "providers", ProviderInfo)
@@ -404,7 +404,7 @@ class ListRecipientsResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListRecipientsResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ListRecipientsResponse:
         """Deserializes the ListRecipientsResponse from a dictionary."""
         return cls(
             next_page_token=d.get("next_page_token", None), recipients=_repeated_dict(d, "recipients", RecipientInfo)
@@ -439,7 +439,7 @@ class ListSharesResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListSharesResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ListSharesResponse:
         """Deserializes the ListSharesResponse from a dictionary."""
         return cls(next_page_token=d.get("next_page_token", None), shares=_repeated_dict(d, "shares", ShareInfo))
 
@@ -464,7 +464,7 @@ class Partition:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> Partition:
+    def from_dict(cls, d: Dict[str, Any]) -> Partition:
         """Deserializes the Partition from a dictionary."""
         return cls(values=_repeated_dict(d, "values", PartitionValue))
 
@@ -489,7 +489,7 @@ class PartitionSpecificationPartition:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> PartitionSpecificationPartition:
+    def from_dict(cls, d: Dict[str, Any]) -> PartitionSpecificationPartition:
         """Deserializes the PartitionSpecificationPartition from a dictionary."""
         return cls(values=_repeated_dict(d, "values", PartitionValue))
 
@@ -537,7 +537,7 @@ class PartitionValue:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> PartitionValue:
+    def from_dict(cls, d: Dict[str, Any]) -> PartitionValue:
         """Deserializes the PartitionValue from a dictionary."""
         return cls(
             name=d.get("name", None),
@@ -629,7 +629,7 @@ class PrivilegeAssignment:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> PrivilegeAssignment:
+    def from_dict(cls, d: Dict[str, Any]) -> PrivilegeAssignment:
         """Deserializes the PrivilegeAssignment from a dictionary."""
         return cls(principal=d.get("principal", None), privileges=_repeated_enum(d, "privileges", Privilege))
 
@@ -752,7 +752,7 @@ class ProviderInfo:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ProviderInfo:
+    def from_dict(cls, d: Dict[str, Any]) -> ProviderInfo:
         """Deserializes the ProviderInfo from a dictionary."""
         return cls(
             authentication_type=_enum(d, "authentication_type", AuthenticationType),
@@ -792,7 +792,7 @@ class ProviderShare:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ProviderShare:
+    def from_dict(cls, d: Dict[str, Any]) -> ProviderShare:
         """Deserializes the ProviderShare from a dictionary."""
         return cls(name=d.get("name", None))
 
@@ -952,7 +952,7 @@ class RecipientInfo:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> RecipientInfo:
+    def from_dict(cls, d: Dict[str, Any]) -> RecipientInfo:
         """Deserializes the RecipientInfo from a dictionary."""
         return cls(
             activated=d.get("activated", None),
@@ -1011,7 +1011,7 @@ class RecipientProfile:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> RecipientProfile:
+    def from_dict(cls, d: Dict[str, Any]) -> RecipientProfile:
         """Deserializes the RecipientProfile from a dictionary."""
         return cls(
             bearer_token=d.get("bearer_token", None),
@@ -1083,7 +1083,7 @@ class RecipientTokenInfo:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> RecipientTokenInfo:
+    def from_dict(cls, d: Dict[str, Any]) -> RecipientTokenInfo:
         """Deserializes the RecipientTokenInfo from a dictionary."""
         return cls(
             activation_url=d.get("activation_url", None),
@@ -1137,7 +1137,7 @@ class RetrieveTokenResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> RetrieveTokenResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> RetrieveTokenResponse:
         """Deserializes the RetrieveTokenResponse from a dictionary."""
         return cls(
             bearer_token=d.get("bearerToken", None),
@@ -1176,7 +1176,7 @@ class RotateRecipientToken:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> RotateRecipientToken:
+    def from_dict(cls, d: Dict[str, Any]) -> RotateRecipientToken:
         """Deserializes the RotateRecipientToken from a dictionary."""
         return cls(
             existing_token_expire_in_seconds=d.get("existing_token_expire_in_seconds", None), name=d.get("name", None)
@@ -1205,7 +1205,7 @@ class SecurablePropertiesKvPairs:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> SecurablePropertiesKvPairs:
+    def from_dict(cls, d: Dict[str, Any]) -> SecurablePropertiesKvPairs:
         """Deserializes the SecurablePropertiesKvPairs from a dictionary."""
         return cls(properties=d.get("properties", None))
 
@@ -1293,7 +1293,7 @@ class ShareInfo:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ShareInfo:
+    def from_dict(cls, d: Dict[str, Any]) -> ShareInfo:
         """Deserializes the ShareInfo from a dictionary."""
         return cls(
             comment=d.get("comment", None),
@@ -1336,7 +1336,7 @@ class ShareToPrivilegeAssignment:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ShareToPrivilegeAssignment:
+    def from_dict(cls, d: Dict[str, Any]) -> ShareToPrivilegeAssignment:
         """Deserializes the ShareToPrivilegeAssignment from a dictionary."""
         return cls(
             privilege_assignments=_repeated_dict(d, "privilege_assignments", PrivilegeAssignment),
@@ -1463,7 +1463,7 @@ class SharedDataObject:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> SharedDataObject:
+    def from_dict(cls, d: Dict[str, Any]) -> SharedDataObject:
         """Deserializes the SharedDataObject from a dictionary."""
         return cls(
             added_at=d.get("added_at", None),
@@ -1540,7 +1540,7 @@ class SharedDataObjectUpdate:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> SharedDataObjectUpdate:
+    def from_dict(cls, d: Dict[str, Any]) -> SharedDataObjectUpdate:
         """Deserializes the SharedDataObjectUpdate from a dictionary."""
         return cls(
             action=_enum(d, "action", SharedDataObjectUpdateAction),
@@ -1569,7 +1569,7 @@ class UpdatePermissionsResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdatePermissionsResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdatePermissionsResponse:
         """Deserializes the UpdatePermissionsResponse from a dictionary."""
         return cls()
 
@@ -1623,7 +1623,7 @@ class UpdateProvider:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateProvider:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateProvider:
         """Deserializes the UpdateProvider from a dictionary."""
         return cls(
             comment=d.get("comment", None),
@@ -1698,7 +1698,7 @@ class UpdateRecipient:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateRecipient:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateRecipient:
         """Deserializes the UpdateRecipient from a dictionary."""
         return cls(
             comment=d.get("comment", None),
@@ -1766,7 +1766,7 @@ class UpdateShare:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateShare:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateShare:
         """Deserializes the UpdateShare from a dictionary."""
         return cls(
             comment=d.get("comment", None),
@@ -1825,7 +1825,7 @@ class UpdateSharePermissions:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateSharePermissions:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateSharePermissions:
         """Deserializes the UpdateSharePermissions from a dictionary."""
         return cls(
             changes=_repeated_dict(d, "changes", catalog.PermissionsChange),

--- a/databricks/sdk/service/sql.py
+++ b/databricks/sdk/service/sql.py
@@ -52,7 +52,7 @@ class AccessControl:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> AccessControl:
+    def from_dict(cls, d: Dict[str, Any]) -> AccessControl:
         """Deserializes the AccessControl from a dictionary."""
         return cls(
             group_name=d.get("group_name", None),
@@ -186,7 +186,7 @@ class Alert:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> Alert:
+    def from_dict(cls, d: Dict[str, Any]) -> Alert:
         """Deserializes the Alert from a dictionary."""
         return cls(
             condition=_from_dict(d, "condition", AlertCondition),
@@ -248,7 +248,7 @@ class AlertCondition:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> AlertCondition:
+    def from_dict(cls, d: Dict[str, Any]) -> AlertCondition:
         """Deserializes the AlertCondition from a dictionary."""
         return cls(
             empty_result_state=_enum(d, "empty_result_state", AlertState),
@@ -277,7 +277,7 @@ class AlertConditionOperand:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> AlertConditionOperand:
+    def from_dict(cls, d: Dict[str, Any]) -> AlertConditionOperand:
         """Deserializes the AlertConditionOperand from a dictionary."""
         return cls(column=_from_dict(d, "column", AlertOperandColumn))
 
@@ -301,7 +301,7 @@ class AlertConditionThreshold:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> AlertConditionThreshold:
+    def from_dict(cls, d: Dict[str, Any]) -> AlertConditionThreshold:
         """Deserializes the AlertConditionThreshold from a dictionary."""
         return cls(value=_from_dict(d, "value", AlertOperandValue))
 
@@ -325,7 +325,7 @@ class AlertOperandColumn:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> AlertOperandColumn:
+    def from_dict(cls, d: Dict[str, Any]) -> AlertOperandColumn:
         """Deserializes the AlertOperandColumn from a dictionary."""
         return cls(name=d.get("name", None))
 
@@ -361,7 +361,7 @@ class AlertOperandValue:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> AlertOperandValue:
+    def from_dict(cls, d: Dict[str, Any]) -> AlertOperandValue:
         """Deserializes the AlertOperandValue from a dictionary."""
         return cls(
             bool_value=d.get("bool_value", None),
@@ -452,7 +452,7 @@ class AlertOptions:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> AlertOptions:
+    def from_dict(cls, d: Dict[str, Any]) -> AlertOptions:
         """Deserializes the AlertOptions from a dictionary."""
         return cls(
             column=d.get("column", None),
@@ -583,7 +583,7 @@ class AlertQuery:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> AlertQuery:
+    def from_dict(cls, d: Dict[str, Any]) -> AlertQuery:
         """Deserializes the AlertQuery from a dictionary."""
         return cls(
             created_at=d.get("created_at", None),
@@ -654,7 +654,7 @@ class BaseChunkInfo:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> BaseChunkInfo:
+    def from_dict(cls, d: Dict[str, Any]) -> BaseChunkInfo:
         """Deserializes the BaseChunkInfo from a dictionary."""
         return cls(
             byte_count=d.get("byte_count", None),
@@ -677,7 +677,7 @@ class CancelExecutionResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CancelExecutionResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> CancelExecutionResponse:
         """Deserializes the CancelExecutionResponse from a dictionary."""
         return cls()
 
@@ -710,7 +710,7 @@ class Channel:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> Channel:
+    def from_dict(cls, d: Dict[str, Any]) -> Channel:
         """Deserializes the Channel from a dictionary."""
         return cls(dbsql_version=d.get("dbsql_version", None), name=_enum(d, "name", ChannelName))
 
@@ -744,7 +744,7 @@ class ChannelInfo:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ChannelInfo:
+    def from_dict(cls, d: Dict[str, Any]) -> ChannelInfo:
         """Deserializes the ChannelInfo from a dictionary."""
         return cls(dbsql_version=d.get("dbsql_version", None), name=_enum(d, "name", ChannelName))
 
@@ -830,7 +830,7 @@ class ClientConfig:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ClientConfig:
+    def from_dict(cls, d: Dict[str, Any]) -> ClientConfig:
         """Deserializes the ClientConfig from a dictionary."""
         return cls(
             allow_custom_js_visualizations=d.get("allow_custom_js_visualizations", None),
@@ -910,7 +910,7 @@ class ColumnInfo:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ColumnInfo:
+    def from_dict(cls, d: Dict[str, Any]) -> ColumnInfo:
         """Deserializes the ColumnInfo from a dictionary."""
         return cls(
             name=d.get("name", None),
@@ -997,7 +997,7 @@ class CreateAlert:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateAlert:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateAlert:
         """Deserializes the CreateAlert from a dictionary."""
         return cls(
             name=d.get("name", None),
@@ -1027,7 +1027,7 @@ class CreateAlertRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateAlertRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateAlertRequest:
         """Deserializes the CreateAlertRequest from a dictionary."""
         return cls(alert=_from_dict(d, "alert", CreateAlertRequestAlert))
 
@@ -1107,7 +1107,7 @@ class CreateAlertRequestAlert:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateAlertRequestAlert:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateAlertRequestAlert:
         """Deserializes the CreateAlertRequestAlert from a dictionary."""
         return cls(
             condition=_from_dict(d, "condition", AlertCondition),
@@ -1140,7 +1140,7 @@ class CreateQueryRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateQueryRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateQueryRequest:
         """Deserializes the CreateQueryRequest from a dictionary."""
         return cls(query=_from_dict(d, "query", CreateQueryRequestQuery))
 
@@ -1234,7 +1234,7 @@ class CreateQueryRequestQuery:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateQueryRequestQuery:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateQueryRequestQuery:
         """Deserializes the CreateQueryRequestQuery from a dictionary."""
         return cls(
             apply_auto_limit=d.get("apply_auto_limit", None),
@@ -1270,7 +1270,7 @@ class CreateVisualizationRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateVisualizationRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateVisualizationRequest:
         """Deserializes the CreateVisualizationRequest from a dictionary."""
         return cls(visualization=_from_dict(d, "visualization", CreateVisualizationRequestVisualization))
 
@@ -1325,7 +1325,7 @@ class CreateVisualizationRequestVisualization:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateVisualizationRequestVisualization:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateVisualizationRequestVisualization:
         """Deserializes the CreateVisualizationRequestVisualization from a dictionary."""
         return cls(
             display_name=d.get("display_name", None),
@@ -1470,7 +1470,7 @@ class CreateWarehouseRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateWarehouseRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateWarehouseRequest:
         """Deserializes the CreateWarehouseRequest from a dictionary."""
         return cls(
             auto_stop_mins=d.get("auto_stop_mins", None),
@@ -1518,7 +1518,7 @@ class CreateWarehouseResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateWarehouseResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateWarehouseResponse:
         """Deserializes the CreateWarehouseResponse from a dictionary."""
         return cls(id=d.get("id", None))
 
@@ -1578,7 +1578,7 @@ class CreateWidget:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateWidget:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateWidget:
         """Deserializes the CreateWidget from a dictionary."""
         return cls(
             dashboard_id=d.get("dashboard_id", None),
@@ -1726,7 +1726,7 @@ class Dashboard:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> Dashboard:
+    def from_dict(cls, d: Dict[str, Any]) -> Dashboard:
         """Deserializes the Dashboard from a dictionary."""
         return cls(
             can_edit=d.get("can_edit", None),
@@ -1789,7 +1789,7 @@ class DashboardEditContent:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DashboardEditContent:
+    def from_dict(cls, d: Dict[str, Any]) -> DashboardEditContent:
         """Deserializes the DashboardEditContent from a dictionary."""
         return cls(
             dashboard_id=d.get("dashboard_id", None),
@@ -1820,7 +1820,7 @@ class DashboardOptions:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DashboardOptions:
+    def from_dict(cls, d: Dict[str, Any]) -> DashboardOptions:
         """Deserializes the DashboardOptions from a dictionary."""
         return cls(moved_to_trash_at=d.get("moved_to_trash_at", None))
 
@@ -1880,7 +1880,7 @@ class DashboardPostContent:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DashboardPostContent:
+    def from_dict(cls, d: Dict[str, Any]) -> DashboardPostContent:
         """Deserializes the DashboardPostContent from a dictionary."""
         return cls(
             dashboard_filters_enabled=d.get("dashboard_filters_enabled", None),
@@ -1974,7 +1974,7 @@ class DataSource:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DataSource:
+    def from_dict(cls, d: Dict[str, Any]) -> DataSource:
         """Deserializes the DataSource from a dictionary."""
         return cls(
             id=d.get("id", None),
@@ -2021,7 +2021,7 @@ class DateRange:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DateRange:
+    def from_dict(cls, d: Dict[str, Any]) -> DateRange:
         """Deserializes the DateRange from a dictionary."""
         return cls(end=d.get("end", None), start=d.get("start", None))
 
@@ -2067,7 +2067,7 @@ class DateRangeValue:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DateRangeValue:
+    def from_dict(cls, d: Dict[str, Any]) -> DateRangeValue:
         """Deserializes the DateRangeValue from a dictionary."""
         return cls(
             date_range_value=_from_dict(d, "date_range_value", DateRange),
@@ -2133,7 +2133,7 @@ class DateValue:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DateValue:
+    def from_dict(cls, d: Dict[str, Any]) -> DateValue:
         """Deserializes the DateValue from a dictionary."""
         return cls(
             date_value=d.get("date_value", None),
@@ -2161,7 +2161,7 @@ class DeleteResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DeleteResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> DeleteResponse:
         """Deserializes the DeleteResponse from a dictionary."""
         return cls()
 
@@ -2179,7 +2179,7 @@ class DeleteWarehouseResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DeleteWarehouseResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> DeleteWarehouseResponse:
         """Deserializes the DeleteWarehouseResponse from a dictionary."""
         return cls()
 
@@ -2238,7 +2238,7 @@ class EditAlert:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> EditAlert:
+    def from_dict(cls, d: Dict[str, Any]) -> EditAlert:
         """Deserializes the EditAlert from a dictionary."""
         return cls(
             alert_id=d.get("alert_id", None),
@@ -2389,7 +2389,7 @@ class EditWarehouseRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> EditWarehouseRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> EditWarehouseRequest:
         """Deserializes the EditWarehouseRequest from a dictionary."""
         return cls(
             auto_stop_mins=d.get("auto_stop_mins", None),
@@ -2431,7 +2431,7 @@ class EditWarehouseResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> EditWarehouseResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> EditWarehouseResponse:
         """Deserializes the EditWarehouseResponse from a dictionary."""
         return cls()
 
@@ -2452,7 +2452,7 @@ class Empty:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> Empty:
+    def from_dict(cls, d: Dict[str, Any]) -> Empty:
         """Deserializes the Empty from a dictionary."""
         return cls()
 
@@ -2482,7 +2482,7 @@ class EndpointConfPair:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> EndpointConfPair:
+    def from_dict(cls, d: Dict[str, Any]) -> EndpointConfPair:
         """Deserializes the EndpointConfPair from a dictionary."""
         return cls(key=d.get("key", None), value=d.get("value", None))
 
@@ -2536,7 +2536,7 @@ class EndpointHealth:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> EndpointHealth:
+    def from_dict(cls, d: Dict[str, Any]) -> EndpointHealth:
         """Deserializes the EndpointHealth from a dictionary."""
         return cls(
             details=d.get("details", None),
@@ -2729,7 +2729,7 @@ class EndpointInfo:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> EndpointInfo:
+    def from_dict(cls, d: Dict[str, Any]) -> EndpointInfo:
         """Deserializes the EndpointInfo from a dictionary."""
         return cls(
             auto_stop_mins=d.get("auto_stop_mins", None),
@@ -2789,7 +2789,7 @@ class EndpointTagPair:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> EndpointTagPair:
+    def from_dict(cls, d: Dict[str, Any]) -> EndpointTagPair:
         """Deserializes the EndpointTagPair from a dictionary."""
         return cls(key=d.get("key", None), value=d.get("value", None))
 
@@ -2813,7 +2813,7 @@ class EndpointTags:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> EndpointTags:
+    def from_dict(cls, d: Dict[str, Any]) -> EndpointTags:
         """Deserializes the EndpointTags from a dictionary."""
         return cls(custom_tags=_repeated_dict(d, "custom_tags", EndpointTagPair))
 
@@ -2852,7 +2852,7 @@ class EnumValue:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> EnumValue:
+    def from_dict(cls, d: Dict[str, Any]) -> EnumValue:
         """Deserializes the EnumValue from a dictionary."""
         return cls(
             enum_options=d.get("enum_options", None),
@@ -3033,7 +3033,7 @@ class ExecuteStatementRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ExecuteStatementRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> ExecuteStatementRequest:
         """Deserializes the ExecuteStatementRequest from a dictionary."""
         return cls(
             byte_limit=d.get("byte_limit", None),
@@ -3146,7 +3146,7 @@ class ExternalLink:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ExternalLink:
+    def from_dict(cls, d: Dict[str, Any]) -> ExternalLink:
         """Deserializes the ExternalLink from a dictionary."""
         return cls(
             byte_count=d.get("byte_count", None),
@@ -3201,7 +3201,7 @@ class GetResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GetResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> GetResponse:
         """Deserializes the GetResponse from a dictionary."""
         return cls(
             access_control_list=_repeated_dict(d, "access_control_list", AccessControl),
@@ -3230,7 +3230,7 @@ class GetWarehousePermissionLevelsResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GetWarehousePermissionLevelsResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> GetWarehousePermissionLevelsResponse:
         """Deserializes the GetWarehousePermissionLevelsResponse from a dictionary."""
         return cls(permission_levels=_repeated_dict(d, "permission_levels", WarehousePermissionsDescription))
 
@@ -3417,7 +3417,7 @@ class GetWarehouseResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GetWarehouseResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> GetWarehouseResponse:
         """Deserializes the GetWarehouseResponse from a dictionary."""
         return cls(
             auto_stop_mins=d.get("auto_stop_mins", None),
@@ -3533,7 +3533,7 @@ class GetWorkspaceWarehouseConfigResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GetWorkspaceWarehouseConfigResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> GetWorkspaceWarehouseConfigResponse:
         """Deserializes the GetWorkspaceWarehouseConfigResponse from a dictionary."""
         return cls(
             channel=_from_dict(d, "channel", Channel),
@@ -3646,7 +3646,7 @@ class LegacyAlert:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> LegacyAlert:
+    def from_dict(cls, d: Dict[str, Any]) -> LegacyAlert:
         """Deserializes the LegacyAlert from a dictionary."""
         return cls(
             created_at=d.get("created_at", None),
@@ -3860,7 +3860,7 @@ class LegacyQuery:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> LegacyQuery:
+    def from_dict(cls, d: Dict[str, Any]) -> LegacyQuery:
         """Deserializes the LegacyQuery from a dictionary."""
         return cls(
             can_edit=d.get("can_edit", None),
@@ -3962,7 +3962,7 @@ class LegacyVisualization:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> LegacyVisualization:
+    def from_dict(cls, d: Dict[str, Any]) -> LegacyVisualization:
         """Deserializes the LegacyVisualization from a dictionary."""
         return cls(
             created_at=d.get("created_at", None),
@@ -4007,7 +4007,7 @@ class ListAlertsResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListAlertsResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ListAlertsResponse:
         """Deserializes the ListAlertsResponse from a dictionary."""
         return cls(
             next_page_token=d.get("next_page_token", None),
@@ -4133,7 +4133,7 @@ class ListAlertsResponseAlert:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListAlertsResponseAlert:
+    def from_dict(cls, d: Dict[str, Any]) -> ListAlertsResponseAlert:
         """Deserializes the ListAlertsResponseAlert from a dictionary."""
         return cls(
             condition=_from_dict(d, "condition", AlertCondition),
@@ -4192,7 +4192,7 @@ class ListQueriesResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListQueriesResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ListQueriesResponse:
         """Deserializes the ListQueriesResponse from a dictionary."""
         return cls(
             has_next_page=d.get("has_next_page", None),
@@ -4226,7 +4226,7 @@ class ListQueryObjectsResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListQueryObjectsResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ListQueryObjectsResponse:
         """Deserializes the ListQueryObjectsResponse from a dictionary."""
         return cls(
             next_page_token=d.get("next_page_token", None),
@@ -4358,7 +4358,7 @@ class ListQueryObjectsResponseQuery:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListQueryObjectsResponseQuery:
+    def from_dict(cls, d: Dict[str, Any]) -> ListQueryObjectsResponseQuery:
         """Deserializes the ListQueryObjectsResponseQuery from a dictionary."""
         return cls(
             apply_auto_limit=d.get("apply_auto_limit", None),
@@ -4421,7 +4421,7 @@ class ListResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ListResponse:
         """Deserializes the ListResponse from a dictionary."""
         return cls(
             count=d.get("count", None),
@@ -4456,7 +4456,7 @@ class ListVisualizationsForQueryResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListVisualizationsForQueryResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ListVisualizationsForQueryResponse:
         """Deserializes the ListVisualizationsForQueryResponse from a dictionary."""
         return cls(next_page_token=d.get("next_page_token", None), results=_repeated_dict(d, "results", Visualization))
 
@@ -4481,7 +4481,7 @@ class ListWarehousesResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListWarehousesResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ListWarehousesResponse:
         """Deserializes the ListWarehousesResponse from a dictionary."""
         return cls(warehouses=_repeated_dict(d, "warehouses", EndpointInfo))
 
@@ -4520,7 +4520,7 @@ class MultiValuesOptions:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> MultiValuesOptions:
+    def from_dict(cls, d: Dict[str, Any]) -> MultiValuesOptions:
         """Deserializes the MultiValuesOptions from a dictionary."""
         return cls(prefix=d.get("prefix", None), separator=d.get("separator", None), suffix=d.get("suffix", None))
 
@@ -4544,7 +4544,7 @@ class NumericValue:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> NumericValue:
+    def from_dict(cls, d: Dict[str, Any]) -> NumericValue:
         """Deserializes the NumericValue from a dictionary."""
         return cls(value=d.get("value", None))
 
@@ -4604,7 +4604,7 @@ class OdbcParams:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> OdbcParams:
+    def from_dict(cls, d: Dict[str, Any]) -> OdbcParams:
         """Deserializes the OdbcParams from a dictionary."""
         return cls(
             hostname=d.get("hostname", None),
@@ -4686,7 +4686,7 @@ class Parameter:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> Parameter:
+    def from_dict(cls, d: Dict[str, Any]) -> Parameter:
         """Deserializes the Parameter from a dictionary."""
         return cls(
             enum_options=d.get("enumOptions", None),
@@ -4861,7 +4861,7 @@ class Query:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> Query:
+    def from_dict(cls, d: Dict[str, Any]) -> Query:
         """Deserializes the Query from a dictionary."""
         return cls(
             apply_auto_limit=d.get("apply_auto_limit", None),
@@ -4918,7 +4918,7 @@ class QueryBackedValue:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> QueryBackedValue:
+    def from_dict(cls, d: Dict[str, Any]) -> QueryBackedValue:
         """Deserializes the QueryBackedValue from a dictionary."""
         return cls(
             multi_values_options=_from_dict(d, "multi_values_options", MultiValuesOptions),
@@ -5000,7 +5000,7 @@ class QueryEditContent:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> QueryEditContent:
+    def from_dict(cls, d: Dict[str, Any]) -> QueryEditContent:
         """Deserializes the QueryEditContent from a dictionary."""
         return cls(
             data_source_id=d.get("data_source_id", None),
@@ -5061,7 +5061,7 @@ class QueryFilter:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> QueryFilter:
+    def from_dict(cls, d: Dict[str, Any]) -> QueryFilter:
         """Deserializes the QueryFilter from a dictionary."""
         return cls(
             query_start_time_range=_from_dict(d, "query_start_time_range", TimeRange),
@@ -5243,7 +5243,7 @@ class QueryInfo:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> QueryInfo:
+    def from_dict(cls, d: Dict[str, Any]) -> QueryInfo:
         """Deserializes the QueryInfo from a dictionary."""
         return cls(
             channel_used=_from_dict(d, "channel_used", ChannelInfo),
@@ -5312,7 +5312,7 @@ class QueryList:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> QueryList:
+    def from_dict(cls, d: Dict[str, Any]) -> QueryList:
         """Deserializes the QueryList from a dictionary."""
         return cls(
             count=d.get("count", None),
@@ -5495,7 +5495,7 @@ class QueryMetrics:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> QueryMetrics:
+    def from_dict(cls, d: Dict[str, Any]) -> QueryMetrics:
         """Deserializes the QueryMetrics from a dictionary."""
         return cls(
             compilation_time_ms=d.get("compilation_time_ms", None),
@@ -5564,7 +5564,7 @@ class QueryOptions:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> QueryOptions:
+    def from_dict(cls, d: Dict[str, Any]) -> QueryOptions:
         """Deserializes the QueryOptions from a dictionary."""
         return cls(
             catalog=d.get("catalog", None),
@@ -5644,7 +5644,7 @@ class QueryParameter:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> QueryParameter:
+    def from_dict(cls, d: Dict[str, Any]) -> QueryParameter:
         """Deserializes the QueryParameter from a dictionary."""
         return cls(
             date_range_value=_from_dict(d, "date_range_value", DateRangeValue),
@@ -5732,7 +5732,7 @@ class QueryPostContent:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> QueryPostContent:
+    def from_dict(cls, d: Dict[str, Any]) -> QueryPostContent:
         """Deserializes the QueryPostContent from a dictionary."""
         return cls(
             data_source_id=d.get("data_source_id", None),
@@ -5811,7 +5811,7 @@ class RepeatedEndpointConfPairs:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> RepeatedEndpointConfPairs:
+    def from_dict(cls, d: Dict[str, Any]) -> RepeatedEndpointConfPairs:
         """Deserializes the RepeatedEndpointConfPairs from a dictionary."""
         return cls(
             config_pair=_repeated_dict(d, "config_pair", EndpointConfPair),
@@ -5832,7 +5832,7 @@ class RestoreResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> RestoreResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> RestoreResponse:
         """Deserializes the RestoreResponse from a dictionary."""
         return cls()
 
@@ -5911,7 +5911,7 @@ class ResultData:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ResultData:
+    def from_dict(cls, d: Dict[str, Any]) -> ResultData:
         """Deserializes the ResultData from a dictionary."""
         return cls(
             byte_count=d.get("byte_count", None),
@@ -5989,7 +5989,7 @@ class ResultManifest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ResultManifest:
+    def from_dict(cls, d: Dict[str, Any]) -> ResultManifest:
         """Deserializes the ResultManifest from a dictionary."""
         return cls(
             chunks=_repeated_dict(d, "chunks", BaseChunkInfo),
@@ -6029,7 +6029,7 @@ class ResultSchema:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ResultSchema:
+    def from_dict(cls, d: Dict[str, Any]) -> ResultSchema:
         """Deserializes the ResultSchema from a dictionary."""
         return cls(column_count=d.get("column_count", None), columns=_repeated_dict(d, "columns", ColumnInfo))
 
@@ -6074,7 +6074,7 @@ class ServiceError:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ServiceError:
+    def from_dict(cls, d: Dict[str, Any]) -> ServiceError:
         """Deserializes the ServiceError from a dictionary."""
         return cls(error_code=_enum(d, "error_code", ServiceErrorCode), message=d.get("message", None))
 
@@ -6130,7 +6130,7 @@ class SetResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> SetResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> SetResponse:
         """Deserializes the SetResponse from a dictionary."""
         return cls(
             access_control_list=_repeated_dict(d, "access_control_list", AccessControl),
@@ -6220,7 +6220,7 @@ class SetWorkspaceWarehouseConfigRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> SetWorkspaceWarehouseConfigRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> SetWorkspaceWarehouseConfigRequest:
         """Deserializes the SetWorkspaceWarehouseConfigRequest from a dictionary."""
         return cls(
             channel=_from_dict(d, "channel", Channel),
@@ -6256,7 +6256,7 @@ class SetWorkspaceWarehouseConfigResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> SetWorkspaceWarehouseConfigResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> SetWorkspaceWarehouseConfigResponse:
         """Deserializes the SetWorkspaceWarehouseConfigResponse from a dictionary."""
         return cls()
 
@@ -6282,7 +6282,7 @@ class StartWarehouseResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> StartWarehouseResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> StartWarehouseResponse:
         """Deserializes the StartWarehouseResponse from a dictionary."""
         return cls()
 
@@ -6337,7 +6337,7 @@ class StatementParameterListItem:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> StatementParameterListItem:
+    def from_dict(cls, d: Dict[str, Any]) -> StatementParameterListItem:
         """Deserializes the StatementParameterListItem from a dictionary."""
         return cls(name=d.get("name", None), type=d.get("type", None), value=d.get("value", None))
 
@@ -6383,7 +6383,7 @@ class StatementResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> StatementResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> StatementResponse:
         """Deserializes the StatementResponse from a dictionary."""
         return cls(
             manifest=_from_dict(d, "manifest", ResultManifest),
@@ -6440,7 +6440,7 @@ class StatementStatus:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> StatementStatus:
+    def from_dict(cls, d: Dict[str, Any]) -> StatementStatus:
         """Deserializes the StatementStatus from a dictionary."""
         return cls(error=_from_dict(d, "error", ServiceError), state=_enum(d, "state", StatementState))
 
@@ -6467,7 +6467,7 @@ class StopWarehouseResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> StopWarehouseResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> StopWarehouseResponse:
         """Deserializes the StopWarehouseResponse from a dictionary."""
         return cls()
 
@@ -6491,7 +6491,7 @@ class Success:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> Success:
+    def from_dict(cls, d: Dict[str, Any]) -> Success:
         """Deserializes the Success from a dictionary."""
         return cls(message=_enum(d, "message", SuccessMessage))
 
@@ -6535,7 +6535,7 @@ class TerminationReason:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> TerminationReason:
+    def from_dict(cls, d: Dict[str, Any]) -> TerminationReason:
         """Deserializes the TerminationReason from a dictionary."""
         return cls(
             code=_enum(d, "code", TerminationReasonCode),
@@ -6656,7 +6656,7 @@ class TextValue:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> TextValue:
+    def from_dict(cls, d: Dict[str, Any]) -> TextValue:
         """Deserializes the TextValue from a dictionary."""
         return cls(value=d.get("value", None))
 
@@ -6688,7 +6688,7 @@ class TimeRange:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> TimeRange:
+    def from_dict(cls, d: Dict[str, Any]) -> TimeRange:
         """Deserializes the TimeRange from a dictionary."""
         return cls(end_time_ms=d.get("end_time_ms", None), start_time_ms=d.get("start_time_ms", None))
 
@@ -6713,7 +6713,7 @@ class TransferOwnershipObjectId:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> TransferOwnershipObjectId:
+    def from_dict(cls, d: Dict[str, Any]) -> TransferOwnershipObjectId:
         """Deserializes the TransferOwnershipObjectId from a dictionary."""
         return cls(new_owner=d.get("new_owner", None))
 
@@ -6758,7 +6758,7 @@ class UpdateAlertRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateAlertRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateAlertRequest:
         """Deserializes the UpdateAlertRequest from a dictionary."""
         return cls(
             alert=_from_dict(d, "alert", UpdateAlertRequestAlert),
@@ -6842,7 +6842,7 @@ class UpdateAlertRequestAlert:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateAlertRequestAlert:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateAlertRequestAlert:
         """Deserializes the UpdateAlertRequestAlert from a dictionary."""
         return cls(
             condition=_from_dict(d, "condition", AlertCondition),
@@ -6896,7 +6896,7 @@ class UpdateQueryRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateQueryRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateQueryRequest:
         """Deserializes the UpdateQueryRequest from a dictionary."""
         return cls(
             id=d.get("id", None),
@@ -6994,7 +6994,7 @@ class UpdateQueryRequestQuery:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateQueryRequestQuery:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateQueryRequestQuery:
         """Deserializes the UpdateQueryRequestQuery from a dictionary."""
         return cls(
             apply_auto_limit=d.get("apply_auto_limit", None),
@@ -7024,7 +7024,7 @@ class UpdateResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateResponse:
         """Deserializes the UpdateResponse from a dictionary."""
         return cls()
 
@@ -7069,7 +7069,7 @@ class UpdateVisualizationRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateVisualizationRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateVisualizationRequest:
         """Deserializes the UpdateVisualizationRequest from a dictionary."""
         return cls(
             id=d.get("id", None),
@@ -7121,7 +7121,7 @@ class UpdateVisualizationRequestVisualization:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateVisualizationRequestVisualization:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateVisualizationRequestVisualization:
         """Deserializes the UpdateVisualizationRequestVisualization from a dictionary."""
         return cls(
             display_name=d.get("display_name", None),
@@ -7162,7 +7162,7 @@ class User:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> User:
+    def from_dict(cls, d: Dict[str, Any]) -> User:
         """Deserializes the User from a dictionary."""
         return cls(email=d.get("email", None), id=d.get("id", None), name=d.get("name", None))
 
@@ -7238,7 +7238,7 @@ class Visualization:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> Visualization:
+    def from_dict(cls, d: Dict[str, Any]) -> Visualization:
         """Deserializes the Visualization from a dictionary."""
         return cls(
             create_time=d.get("create_time", None),
@@ -7293,7 +7293,7 @@ class WarehouseAccessControlRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> WarehouseAccessControlRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> WarehouseAccessControlRequest:
         """Deserializes the WarehouseAccessControlRequest from a dictionary."""
         return cls(
             group_name=d.get("group_name", None),
@@ -7351,7 +7351,7 @@ class WarehouseAccessControlResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> WarehouseAccessControlResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> WarehouseAccessControlResponse:
         """Deserializes the WarehouseAccessControlResponse from a dictionary."""
         return cls(
             all_permissions=_repeated_dict(d, "all_permissions", WarehousePermission),
@@ -7394,7 +7394,7 @@ class WarehousePermission:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> WarehousePermission:
+    def from_dict(cls, d: Dict[str, Any]) -> WarehousePermission:
         """Deserializes the WarehousePermission from a dictionary."""
         return cls(
             inherited=d.get("inherited", None),
@@ -7443,7 +7443,7 @@ class WarehousePermissions:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> WarehousePermissions:
+    def from_dict(cls, d: Dict[str, Any]) -> WarehousePermissions:
         """Deserializes the WarehousePermissions from a dictionary."""
         return cls(
             access_control_list=_repeated_dict(d, "access_control_list", WarehouseAccessControlResponse),
@@ -7478,7 +7478,7 @@ class WarehousePermissionsDescription:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> WarehousePermissionsDescription:
+    def from_dict(cls, d: Dict[str, Any]) -> WarehousePermissionsDescription:
         """Deserializes the WarehousePermissionsDescription from a dictionary."""
         return cls(
             description=d.get("description", None),
@@ -7512,7 +7512,7 @@ class WarehousePermissionsRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> WarehousePermissionsRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> WarehousePermissionsRequest:
         """Deserializes the WarehousePermissionsRequest from a dictionary."""
         return cls(
             access_control_list=_repeated_dict(d, "access_control_list", WarehouseAccessControlRequest),
@@ -7548,7 +7548,7 @@ class WarehouseTypePair:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> WarehouseTypePair:
+    def from_dict(cls, d: Dict[str, Any]) -> WarehouseTypePair:
         """Deserializes the WarehouseTypePair from a dictionary."""
         return cls(
             enabled=d.get("enabled", None), warehouse_type=_enum(d, "warehouse_type", WarehouseTypePairWarehouseType)
@@ -7606,7 +7606,7 @@ class Widget:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> Widget:
+    def from_dict(cls, d: Dict[str, Any]) -> Widget:
         """Deserializes the Widget from a dictionary."""
         return cls(
             id=d.get("id", None),
@@ -7680,7 +7680,7 @@ class WidgetOptions:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> WidgetOptions:
+    def from_dict(cls, d: Dict[str, Any]) -> WidgetOptions:
         """Deserializes the WidgetOptions from a dictionary."""
         return cls(
             created_at=d.get("created_at", None),
@@ -7744,7 +7744,7 @@ class WidgetPosition:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> WidgetPosition:
+    def from_dict(cls, d: Dict[str, Any]) -> WidgetPosition:
         """Deserializes the WidgetPosition from a dictionary."""
         return cls(
             auto_height=d.get("autoHeight", None),

--- a/databricks/sdk/service/vectorsearch.py
+++ b/databricks/sdk/service/vectorsearch.py
@@ -8,7 +8,7 @@ import time
 from dataclasses import dataclass
 from datetime import timedelta
 from enum import Enum
-from typing import Callable, Dict, Iterator, List, Optional
+from typing import Any, Callable, Dict, Iterator, List, Optional
 
 from ..errors import OperationFailed
 from ._internal import Wait, _enum, _from_dict, _repeated_dict
@@ -39,7 +39,7 @@ class ColumnInfo:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ColumnInfo:
+    def from_dict(cls, d: Dict[str, Any]) -> ColumnInfo:
         """Deserializes the ColumnInfo from a dictionary."""
         return cls(name=d.get("name", None))
 
@@ -71,7 +71,7 @@ class CreateEndpoint:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateEndpoint:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateEndpoint:
         """Deserializes the CreateEndpoint from a dictionary."""
         return cls(endpoint_type=_enum(d, "endpoint_type", EndpointType), name=d.get("name", None))
 
@@ -136,7 +136,7 @@ class CreateVectorIndexRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateVectorIndexRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateVectorIndexRequest:
         """Deserializes the CreateVectorIndexRequest from a dictionary."""
         return cls(
             delta_sync_index_spec=_from_dict(d, "delta_sync_index_spec", DeltaSyncVectorIndexSpecRequest),
@@ -167,7 +167,7 @@ class CreateVectorIndexResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateVectorIndexResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateVectorIndexResponse:
         """Deserializes the CreateVectorIndexResponse from a dictionary."""
         return cls(vector_index=_from_dict(d, "vector_index", VectorIndex))
 
@@ -201,7 +201,7 @@ class DeleteDataResult:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DeleteDataResult:
+    def from_dict(cls, d: Dict[str, Any]) -> DeleteDataResult:
         """Deserializes the DeleteDataResult from a dictionary."""
         return cls(
             failed_primary_keys=d.get("failed_primary_keys", None), success_row_count=d.get("success_row_count", None)
@@ -245,7 +245,7 @@ class DeleteDataVectorIndexRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DeleteDataVectorIndexRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> DeleteDataVectorIndexRequest:
         """Deserializes the DeleteDataVectorIndexRequest from a dictionary."""
         return cls(index_name=d.get("index_name", None), primary_keys=d.get("primary_keys", None))
 
@@ -279,7 +279,7 @@ class DeleteDataVectorIndexResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DeleteDataVectorIndexResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> DeleteDataVectorIndexResponse:
         """Deserializes the DeleteDataVectorIndexResponse from a dictionary."""
         return cls(result=_from_dict(d, "result", DeleteDataResult), status=_enum(d, "status", DeleteDataStatus))
 
@@ -297,7 +297,7 @@ class DeleteEndpointResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DeleteEndpointResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> DeleteEndpointResponse:
         """Deserializes the DeleteEndpointResponse from a dictionary."""
         return cls()
 
@@ -315,7 +315,7 @@ class DeleteIndexResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DeleteIndexResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> DeleteIndexResponse:
         """Deserializes the DeleteIndexResponse from a dictionary."""
         return cls()
 
@@ -384,7 +384,7 @@ class DeltaSyncVectorIndexSpecRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DeltaSyncVectorIndexSpecRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> DeltaSyncVectorIndexSpecRequest:
         """Deserializes the DeltaSyncVectorIndexSpecRequest from a dictionary."""
         return cls(
             columns_to_sync=d.get("columns_to_sync", None),
@@ -457,7 +457,7 @@ class DeltaSyncVectorIndexSpecResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DeltaSyncVectorIndexSpecResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> DeltaSyncVectorIndexSpecResponse:
         """Deserializes the DeltaSyncVectorIndexSpecResponse from a dictionary."""
         return cls(
             embedding_source_columns=_repeated_dict(d, "embedding_source_columns", EmbeddingSourceColumn),
@@ -507,7 +507,7 @@ class DirectAccessVectorIndexSpec:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DirectAccessVectorIndexSpec:
+    def from_dict(cls, d: Dict[str, Any]) -> DirectAccessVectorIndexSpec:
         """Deserializes the DirectAccessVectorIndexSpec from a dictionary."""
         return cls(
             embedding_source_columns=_repeated_dict(d, "embedding_source_columns", EmbeddingSourceColumn),
@@ -543,7 +543,7 @@ class EmbeddingSourceColumn:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> EmbeddingSourceColumn:
+    def from_dict(cls, d: Dict[str, Any]) -> EmbeddingSourceColumn:
         """Deserializes the EmbeddingSourceColumn from a dictionary."""
         return cls(embedding_model_endpoint_name=d.get("embedding_model_endpoint_name", None), name=d.get("name", None))
 
@@ -575,7 +575,7 @@ class EmbeddingVectorColumn:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> EmbeddingVectorColumn:
+    def from_dict(cls, d: Dict[str, Any]) -> EmbeddingVectorColumn:
         """Deserializes the EmbeddingVectorColumn from a dictionary."""
         return cls(embedding_dimension=d.get("embedding_dimension", None), name=d.get("name", None))
 
@@ -656,7 +656,7 @@ class EndpointInfo:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> EndpointInfo:
+    def from_dict(cls, d: Dict[str, Any]) -> EndpointInfo:
         """Deserializes the EndpointInfo from a dictionary."""
         return cls(
             creation_timestamp=d.get("creation_timestamp", None),
@@ -700,7 +700,7 @@ class EndpointStatus:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> EndpointStatus:
+    def from_dict(cls, d: Dict[str, Any]) -> EndpointStatus:
         """Deserializes the EndpointStatus from a dictionary."""
         return cls(message=d.get("message", None), state=_enum(d, "state", EndpointStatusState))
 
@@ -747,7 +747,7 @@ class ListEndpointResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListEndpointResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ListEndpointResponse:
         """Deserializes the ListEndpointResponse from a dictionary."""
         return cls(
             endpoints=_repeated_dict(d, "endpoints", EndpointInfo), next_page_token=d.get("next_page_token", None)
@@ -773,7 +773,7 @@ class ListValue:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListValue:
+    def from_dict(cls, d: Dict[str, Any]) -> ListValue:
         """Deserializes the ListValue from a dictionary."""
         return cls(values=_repeated_dict(d, "values", Value))
 
@@ -805,7 +805,7 @@ class ListVectorIndexesResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListVectorIndexesResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ListVectorIndexesResponse:
         """Deserializes the ListVectorIndexesResponse from a dictionary."""
         return cls(
             next_page_token=d.get("next_page_token", None),
@@ -842,7 +842,7 @@ class MapStringValueEntry:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> MapStringValueEntry:
+    def from_dict(cls, d: Dict[str, Any]) -> MapStringValueEntry:
         """Deserializes the MapStringValueEntry from a dictionary."""
         return cls(key=d.get("key", None), value=_from_dict(d, "value", Value))
 
@@ -900,7 +900,7 @@ class MiniVectorIndex:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> MiniVectorIndex:
+    def from_dict(cls, d: Dict[str, Any]) -> MiniVectorIndex:
         """Deserializes the MiniVectorIndex from a dictionary."""
         return cls(
             creator=d.get("creator", None),
@@ -960,7 +960,7 @@ class QueryVectorIndexNextPageRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> QueryVectorIndexNextPageRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> QueryVectorIndexNextPageRequest:
         """Deserializes the QueryVectorIndexNextPageRequest from a dictionary."""
         return cls(
             endpoint_name=d.get("endpoint_name", None),
@@ -1043,7 +1043,7 @@ class QueryVectorIndexRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> QueryVectorIndexRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> QueryVectorIndexRequest:
         """Deserializes the QueryVectorIndexRequest from a dictionary."""
         return cls(
             columns=d.get("columns", None),
@@ -1093,7 +1093,7 @@ class QueryVectorIndexResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> QueryVectorIndexResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> QueryVectorIndexResponse:
         """Deserializes the QueryVectorIndexResponse from a dictionary."""
         return cls(
             manifest=_from_dict(d, "manifest", ResultManifest),
@@ -1131,7 +1131,7 @@ class ResultData:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ResultData:
+    def from_dict(cls, d: Dict[str, Any]) -> ResultData:
         """Deserializes the ResultData from a dictionary."""
         return cls(data_array=d.get("data_array", None), row_count=d.get("row_count", None))
 
@@ -1165,7 +1165,7 @@ class ResultManifest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ResultManifest:
+    def from_dict(cls, d: Dict[str, Any]) -> ResultManifest:
         """Deserializes the ResultManifest from a dictionary."""
         return cls(column_count=d.get("column_count", None), columns=_repeated_dict(d, "columns", ColumnInfo))
 
@@ -1206,7 +1206,7 @@ class ScanVectorIndexRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ScanVectorIndexRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> ScanVectorIndexRequest:
         """Deserializes the ScanVectorIndexRequest from a dictionary."""
         return cls(
             index_name=d.get("index_name", None),
@@ -1244,7 +1244,7 @@ class ScanVectorIndexResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ScanVectorIndexResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ScanVectorIndexResponse:
         """Deserializes the ScanVectorIndexResponse from a dictionary."""
         return cls(data=_repeated_dict(d, "data", Struct), last_primary_key=d.get("last_primary_key", None))
 
@@ -1269,7 +1269,7 @@ class Struct:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> Struct:
+    def from_dict(cls, d: Dict[str, Any]) -> Struct:
         """Deserializes the Struct from a dictionary."""
         return cls(fields=_repeated_dict(d, "fields", MapStringValueEntry))
 
@@ -1287,7 +1287,7 @@ class SyncIndexResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> SyncIndexResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> SyncIndexResponse:
         """Deserializes the SyncIndexResponse from a dictionary."""
         return cls()
 
@@ -1321,7 +1321,7 @@ class UpsertDataResult:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpsertDataResult:
+    def from_dict(cls, d: Dict[str, Any]) -> UpsertDataResult:
         """Deserializes the UpsertDataResult from a dictionary."""
         return cls(
             failed_primary_keys=d.get("failed_primary_keys", None), success_row_count=d.get("success_row_count", None)
@@ -1365,7 +1365,7 @@ class UpsertDataVectorIndexRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpsertDataVectorIndexRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> UpsertDataVectorIndexRequest:
         """Deserializes the UpsertDataVectorIndexRequest from a dictionary."""
         return cls(index_name=d.get("index_name", None), inputs_json=d.get("inputs_json", None))
 
@@ -1399,7 +1399,7 @@ class UpsertDataVectorIndexResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpsertDataVectorIndexResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> UpsertDataVectorIndexResponse:
         """Deserializes the UpsertDataVectorIndexResponse from a dictionary."""
         return cls(result=_from_dict(d, "result", UpsertDataResult), status=_enum(d, "status", UpsertDataStatus))
 
@@ -1453,7 +1453,7 @@ class Value:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> Value:
+    def from_dict(cls, d: Dict[str, Any]) -> Value:
         """Deserializes the Value from a dictionary."""
         return cls(
             bool_value=d.get("bool_value", None),
@@ -1536,7 +1536,7 @@ class VectorIndex:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> VectorIndex:
+    def from_dict(cls, d: Dict[str, Any]) -> VectorIndex:
         """Deserializes the VectorIndex from a dictionary."""
         return cls(
             creator=d.get("creator", None),
@@ -1591,7 +1591,7 @@ class VectorIndexStatus:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> VectorIndexStatus:
+    def from_dict(cls, d: Dict[str, Any]) -> VectorIndexStatus:
         """Deserializes the VectorIndexStatus from a dictionary."""
         return cls(
             index_url=d.get("index_url", None),

--- a/databricks/sdk/service/workspace.py
+++ b/databricks/sdk/service/workspace.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from enum import Enum
-from typing import Dict, Iterator, List, Optional
+from typing import Any, Dict, Iterator, List, Optional
 
 from ._internal import _enum, _from_dict, _repeated_dict
 
@@ -42,7 +42,7 @@ class AclItem:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> AclItem:
+    def from_dict(cls, d: Dict[str, Any]) -> AclItem:
         """Deserializes the AclItem from a dictionary."""
         return cls(permission=_enum(d, "permission", AclPermission), principal=d.get("principal", None))
 
@@ -81,7 +81,7 @@ class AzureKeyVaultSecretScopeMetadata:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> AzureKeyVaultSecretScopeMetadata:
+    def from_dict(cls, d: Dict[str, Any]) -> AzureKeyVaultSecretScopeMetadata:
         """Deserializes the AzureKeyVaultSecretScopeMetadata from a dictionary."""
         return cls(dns_name=d.get("dns_name", None), resource_id=d.get("resource_id", None))
 
@@ -129,7 +129,7 @@ class CreateCredentialsRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateCredentialsRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateCredentialsRequest:
         """Deserializes the CreateCredentialsRequest from a dictionary."""
         return cls(
             git_provider=d.get("git_provider", None),
@@ -173,7 +173,7 @@ class CreateCredentialsResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateCredentialsResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateCredentialsResponse:
         """Deserializes the CreateCredentialsResponse from a dictionary."""
         return cls(
             credential_id=d.get("credential_id", None),
@@ -227,7 +227,7 @@ class CreateRepoRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateRepoRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateRepoRequest:
         """Deserializes the CreateRepoRequest from a dictionary."""
         return cls(
             path=d.get("path", None),
@@ -299,7 +299,7 @@ class CreateRepoResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateRepoResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateRepoResponse:
         """Deserializes the CreateRepoResponse from a dictionary."""
         return cls(
             branch=d.get("branch", None),
@@ -353,7 +353,7 @@ class CreateScope:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateScope:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateScope:
         """Deserializes the CreateScope from a dictionary."""
         return cls(
             backend_azure_keyvault=_from_dict(d, "backend_azure_keyvault", AzureKeyVaultSecretScopeMetadata),
@@ -376,7 +376,7 @@ class CreateScopeResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CreateScopeResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> CreateScopeResponse:
         """Deserializes the CreateScopeResponse from a dictionary."""
         return cls()
 
@@ -416,7 +416,7 @@ class CredentialInfo:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> CredentialInfo:
+    def from_dict(cls, d: Dict[str, Any]) -> CredentialInfo:
         """Deserializes the CredentialInfo from a dictionary."""
         return cls(
             credential_id=d.get("credential_id", None),
@@ -454,7 +454,7 @@ class Delete:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> Delete:
+    def from_dict(cls, d: Dict[str, Any]) -> Delete:
         """Deserializes the Delete from a dictionary."""
         return cls(path=d.get("path", None), recursive=d.get("recursive", None))
 
@@ -486,7 +486,7 @@ class DeleteAcl:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DeleteAcl:
+    def from_dict(cls, d: Dict[str, Any]) -> DeleteAcl:
         """Deserializes the DeleteAcl from a dictionary."""
         return cls(principal=d.get("principal", None), scope=d.get("scope", None))
 
@@ -504,7 +504,7 @@ class DeleteAclResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DeleteAclResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> DeleteAclResponse:
         """Deserializes the DeleteAclResponse from a dictionary."""
         return cls()
 
@@ -522,7 +522,7 @@ class DeleteCredentialsResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DeleteCredentialsResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> DeleteCredentialsResponse:
         """Deserializes the DeleteCredentialsResponse from a dictionary."""
         return cls()
 
@@ -540,7 +540,7 @@ class DeleteRepoResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DeleteRepoResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> DeleteRepoResponse:
         """Deserializes the DeleteRepoResponse from a dictionary."""
         return cls()
 
@@ -558,7 +558,7 @@ class DeleteResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DeleteResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> DeleteResponse:
         """Deserializes the DeleteResponse from a dictionary."""
         return cls()
 
@@ -583,7 +583,7 @@ class DeleteScope:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DeleteScope:
+    def from_dict(cls, d: Dict[str, Any]) -> DeleteScope:
         """Deserializes the DeleteScope from a dictionary."""
         return cls(scope=d.get("scope", None))
 
@@ -601,7 +601,7 @@ class DeleteScopeResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DeleteScopeResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> DeleteScopeResponse:
         """Deserializes the DeleteScopeResponse from a dictionary."""
         return cls()
 
@@ -633,7 +633,7 @@ class DeleteSecret:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DeleteSecret:
+    def from_dict(cls, d: Dict[str, Any]) -> DeleteSecret:
         """Deserializes the DeleteSecret from a dictionary."""
         return cls(key=d.get("key", None), scope=d.get("scope", None))
 
@@ -651,7 +651,7 @@ class DeleteSecretResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> DeleteSecretResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> DeleteSecretResponse:
         """Deserializes the DeleteSecretResponse from a dictionary."""
         return cls()
 
@@ -694,7 +694,7 @@ class ExportResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ExportResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ExportResponse:
         """Deserializes the ExportResponse from a dictionary."""
         return cls(content=d.get("content", None), file_type=d.get("file_type", None))
 
@@ -734,7 +734,7 @@ class GetCredentialsResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GetCredentialsResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> GetCredentialsResponse:
         """Deserializes the GetCredentialsResponse from a dictionary."""
         return cls(
             credential_id=d.get("credential_id", None),
@@ -763,7 +763,7 @@ class GetRepoPermissionLevelsResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GetRepoPermissionLevelsResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> GetRepoPermissionLevelsResponse:
         """Deserializes the GetRepoPermissionLevelsResponse from a dictionary."""
         return cls(permission_levels=_repeated_dict(d, "permission_levels", RepoPermissionsDescription))
 
@@ -830,7 +830,7 @@ class GetRepoResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GetRepoResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> GetRepoResponse:
         """Deserializes the GetRepoResponse from a dictionary."""
         return cls(
             branch=d.get("branch", None),
@@ -870,7 +870,7 @@ class GetSecretResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GetSecretResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> GetSecretResponse:
         """Deserializes the GetSecretResponse from a dictionary."""
         return cls(key=d.get("key", None), value=d.get("value", None))
 
@@ -895,7 +895,7 @@ class GetWorkspaceObjectPermissionLevelsResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> GetWorkspaceObjectPermissionLevelsResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> GetWorkspaceObjectPermissionLevelsResponse:
         """Deserializes the GetWorkspaceObjectPermissionLevelsResponse from a dictionary."""
         return cls(permission_levels=_repeated_dict(d, "permission_levels", WorkspaceObjectPermissionsDescription))
 
@@ -963,7 +963,7 @@ class Import:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> Import:
+    def from_dict(cls, d: Dict[str, Any]) -> Import:
         """Deserializes the Import from a dictionary."""
         return cls(
             content=d.get("content", None),
@@ -1009,7 +1009,7 @@ class ImportResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ImportResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ImportResponse:
         """Deserializes the ImportResponse from a dictionary."""
         return cls()
 
@@ -1043,7 +1043,7 @@ class ListAclsResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListAclsResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ListAclsResponse:
         """Deserializes the ListAclsResponse from a dictionary."""
         return cls(items=_repeated_dict(d, "items", AclItem))
 
@@ -1068,7 +1068,7 @@ class ListCredentialsResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListCredentialsResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ListCredentialsResponse:
         """Deserializes the ListCredentialsResponse from a dictionary."""
         return cls(credentials=_repeated_dict(d, "credentials", CredentialInfo))
 
@@ -1101,7 +1101,7 @@ class ListReposResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListReposResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ListReposResponse:
         """Deserializes the ListReposResponse from a dictionary."""
         return cls(next_page_token=d.get("next_page_token", None), repos=_repeated_dict(d, "repos", RepoInfo))
 
@@ -1126,7 +1126,7 @@ class ListResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ListResponse:
         """Deserializes the ListResponse from a dictionary."""
         return cls(objects=_repeated_dict(d, "objects", ObjectInfo))
 
@@ -1151,7 +1151,7 @@ class ListScopesResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListScopesResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ListScopesResponse:
         """Deserializes the ListScopesResponse from a dictionary."""
         return cls(scopes=_repeated_dict(d, "scopes", SecretScope))
 
@@ -1176,7 +1176,7 @@ class ListSecretsResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ListSecretsResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> ListSecretsResponse:
         """Deserializes the ListSecretsResponse from a dictionary."""
         return cls(secrets=_repeated_dict(d, "secrets", SecretMetadata))
 
@@ -1202,7 +1202,7 @@ class Mkdirs:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> Mkdirs:
+    def from_dict(cls, d: Dict[str, Any]) -> Mkdirs:
         """Deserializes the Mkdirs from a dictionary."""
         return cls(path=d.get("path", None))
 
@@ -1220,7 +1220,7 @@ class MkdirsResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> MkdirsResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> MkdirsResponse:
         """Deserializes the MkdirsResponse from a dictionary."""
         return cls()
 
@@ -1298,7 +1298,7 @@ class ObjectInfo:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> ObjectInfo:
+    def from_dict(cls, d: Dict[str, Any]) -> ObjectInfo:
         """Deserializes the ObjectInfo from a dictionary."""
         return cls(
             created_at=d.get("created_at", None),
@@ -1361,7 +1361,7 @@ class PutAcl:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> PutAcl:
+    def from_dict(cls, d: Dict[str, Any]) -> PutAcl:
         """Deserializes the PutAcl from a dictionary."""
         return cls(
             permission=_enum(d, "permission", AclPermission),
@@ -1383,7 +1383,7 @@ class PutAclResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> PutAclResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> PutAclResponse:
         """Deserializes the PutAclResponse from a dictionary."""
         return cls()
 
@@ -1429,7 +1429,7 @@ class PutSecret:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> PutSecret:
+    def from_dict(cls, d: Dict[str, Any]) -> PutSecret:
         """Deserializes the PutSecret from a dictionary."""
         return cls(
             bytes_value=d.get("bytes_value", None),
@@ -1452,7 +1452,7 @@ class PutSecretResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> PutSecretResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> PutSecretResponse:
         """Deserializes the PutSecretResponse from a dictionary."""
         return cls()
 
@@ -1498,7 +1498,7 @@ class RepoAccessControlRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> RepoAccessControlRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> RepoAccessControlRequest:
         """Deserializes the RepoAccessControlRequest from a dictionary."""
         return cls(
             group_name=d.get("group_name", None),
@@ -1556,7 +1556,7 @@ class RepoAccessControlResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> RepoAccessControlResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> RepoAccessControlResponse:
         """Deserializes the RepoAccessControlResponse from a dictionary."""
         return cls(
             all_permissions=_repeated_dict(d, "all_permissions", RepoPermission),
@@ -1631,7 +1631,7 @@ class RepoInfo:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> RepoInfo:
+    def from_dict(cls, d: Dict[str, Any]) -> RepoInfo:
         """Deserializes the RepoInfo from a dictionary."""
         return cls(
             branch=d.get("branch", None),
@@ -1676,7 +1676,7 @@ class RepoPermission:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> RepoPermission:
+    def from_dict(cls, d: Dict[str, Any]) -> RepoPermission:
         """Deserializes the RepoPermission from a dictionary."""
         return cls(
             inherited=d.get("inherited", None),
@@ -1725,7 +1725,7 @@ class RepoPermissions:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> RepoPermissions:
+    def from_dict(cls, d: Dict[str, Any]) -> RepoPermissions:
         """Deserializes the RepoPermissions from a dictionary."""
         return cls(
             access_control_list=_repeated_dict(d, "access_control_list", RepoAccessControlResponse),
@@ -1760,7 +1760,7 @@ class RepoPermissionsDescription:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> RepoPermissionsDescription:
+    def from_dict(cls, d: Dict[str, Any]) -> RepoPermissionsDescription:
         """Deserializes the RepoPermissionsDescription from a dictionary."""
         return cls(
             description=d.get("description", None), permission_level=_enum(d, "permission_level", RepoPermissionLevel)
@@ -1793,7 +1793,7 @@ class RepoPermissionsRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> RepoPermissionsRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> RepoPermissionsRequest:
         """Deserializes the RepoPermissionsRequest from a dictionary."""
         return cls(
             access_control_list=_repeated_dict(d, "access_control_list", RepoAccessControlRequest),
@@ -1834,7 +1834,7 @@ class SecretMetadata:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> SecretMetadata:
+    def from_dict(cls, d: Dict[str, Any]) -> SecretMetadata:
         """Deserializes the SecretMetadata from a dictionary."""
         return cls(key=d.get("key", None), last_updated_timestamp=d.get("last_updated_timestamp", None))
 
@@ -1873,7 +1873,7 @@ class SecretScope:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> SecretScope:
+    def from_dict(cls, d: Dict[str, Any]) -> SecretScope:
         """Deserializes the SecretScope from a dictionary."""
         return cls(
             backend_type=_enum(d, "backend_type", ScopeBackendType),
@@ -1906,7 +1906,7 @@ class SparseCheckout:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> SparseCheckout:
+    def from_dict(cls, d: Dict[str, Any]) -> SparseCheckout:
         """Deserializes the SparseCheckout from a dictionary."""
         return cls(patterns=d.get("patterns", None))
 
@@ -1935,7 +1935,7 @@ class SparseCheckoutUpdate:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> SparseCheckoutUpdate:
+    def from_dict(cls, d: Dict[str, Any]) -> SparseCheckoutUpdate:
         """Deserializes the SparseCheckoutUpdate from a dictionary."""
         return cls(patterns=d.get("patterns", None))
 
@@ -1990,7 +1990,7 @@ class UpdateCredentialsRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateCredentialsRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateCredentialsRequest:
         """Deserializes the UpdateCredentialsRequest from a dictionary."""
         return cls(
             credential_id=d.get("credential_id", None),
@@ -2013,7 +2013,7 @@ class UpdateCredentialsResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateCredentialsResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateCredentialsResponse:
         """Deserializes the UpdateCredentialsResponse from a dictionary."""
         return cls()
 
@@ -2062,7 +2062,7 @@ class UpdateRepoRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateRepoRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateRepoRequest:
         """Deserializes the UpdateRepoRequest from a dictionary."""
         return cls(
             branch=d.get("branch", None),
@@ -2085,7 +2085,7 @@ class UpdateRepoResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> UpdateRepoResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateRepoResponse:
         """Deserializes the UpdateRepoResponse from a dictionary."""
         return cls()
 
@@ -2131,7 +2131,7 @@ class WorkspaceObjectAccessControlRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> WorkspaceObjectAccessControlRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> WorkspaceObjectAccessControlRequest:
         """Deserializes the WorkspaceObjectAccessControlRequest from a dictionary."""
         return cls(
             group_name=d.get("group_name", None),
@@ -2189,7 +2189,7 @@ class WorkspaceObjectAccessControlResponse:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> WorkspaceObjectAccessControlResponse:
+    def from_dict(cls, d: Dict[str, Any]) -> WorkspaceObjectAccessControlResponse:
         """Deserializes the WorkspaceObjectAccessControlResponse from a dictionary."""
         return cls(
             all_permissions=_repeated_dict(d, "all_permissions", WorkspaceObjectPermission),
@@ -2232,7 +2232,7 @@ class WorkspaceObjectPermission:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> WorkspaceObjectPermission:
+    def from_dict(cls, d: Dict[str, Any]) -> WorkspaceObjectPermission:
         """Deserializes the WorkspaceObjectPermission from a dictionary."""
         return cls(
             inherited=d.get("inherited", None),
@@ -2281,7 +2281,7 @@ class WorkspaceObjectPermissions:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> WorkspaceObjectPermissions:
+    def from_dict(cls, d: Dict[str, Any]) -> WorkspaceObjectPermissions:
         """Deserializes the WorkspaceObjectPermissions from a dictionary."""
         return cls(
             access_control_list=_repeated_dict(d, "access_control_list", WorkspaceObjectAccessControlResponse),
@@ -2316,7 +2316,7 @@ class WorkspaceObjectPermissionsDescription:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> WorkspaceObjectPermissionsDescription:
+    def from_dict(cls, d: Dict[str, Any]) -> WorkspaceObjectPermissionsDescription:
         """Deserializes the WorkspaceObjectPermissionsDescription from a dictionary."""
         return cls(
             description=d.get("description", None),
@@ -2357,7 +2357,7 @@ class WorkspaceObjectPermissionsRequest:
         return body
 
     @classmethod
-    def from_dict(cls, d: Dict[str, any]) -> WorkspaceObjectPermissionsRequest:
+    def from_dict(cls, d: Dict[str, Any]) -> WorkspaceObjectPermissionsRequest:
         """Deserializes the WorkspaceObjectPermissionsRequest from a dictionary."""
         return cls(
             access_control_list=_repeated_dict(d, "access_control_list", WorkspaceObjectAccessControlRequest),


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR is a no-op that replaces incorrect `any` type hints with `Any`.

## How is this tested?

No change to unit tests and integration tests.