### PR TITLE
Add Service Modules Imports to __init__.py

### DIFF
--- a/databricks/sdk/service/__init__.py
+++ b/databricks/sdk/service/__init__.py
@@ -1,31 +1,16 @@
 # Import all service modules
-from databricks.sdk.service import apps
-from databricks.sdk.service import billing
-from databricks.sdk.service import catalog
-from databricks.sdk.service import cleanrooms
-from databricks.sdk.service import compute
-from databricks.sdk.service import dashboards
-from databricks.sdk.service import files
-from databricks.sdk.service import iam
-from databricks.sdk.service import jobs
-from databricks.sdk.service import marketplace
-from databricks.sdk.service import ml
-from databricks.sdk.service import oauth2
-from databricks.sdk.service import pipelines
-from databricks.sdk.service import provisioning
-from databricks.sdk.service import serving
-from databricks.sdk.service import settings
-from databricks.sdk.service import sharing
-from databricks.sdk.service import sql
-from databricks.sdk.service import vectorsearch
-from databricks.sdk.service import workspace
+from databricks.sdk.service import (apps, billing, catalog, cleanrooms,
+                                    compute, dashboards, files, iam, jobs,
+                                    marketplace, ml, oauth2, pipelines,
+                                    provisioning, serving, settings, sharing,
+                                    sql, vectorsearch, workspace)
 
 # Re-export all modules
 __all__ = [
     "apps",
     "billing",
     "catalog",
-    "cleanrooms", 
+    "cleanrooms",
     "compute",
     "dashboards",
     "files",
@@ -41,5 +26,5 @@ __all__ = [
     "sharing",
     "sql",
     "vectorsearch",
-    "workspace"
+    "workspace",
 ]

--- a/databricks/sdk/service/__init__.py
+++ b/databricks/sdk/service/__init__.py
@@ -1,0 +1,45 @@
+# Import all service modules
+from databricks.sdk.service import apps
+from databricks.sdk.service import billing
+from databricks.sdk.service import catalog
+from databricks.sdk.service import cleanrooms
+from databricks.sdk.service import compute
+from databricks.sdk.service import dashboards
+from databricks.sdk.service import files
+from databricks.sdk.service import iam
+from databricks.sdk.service import jobs
+from databricks.sdk.service import marketplace
+from databricks.sdk.service import ml
+from databricks.sdk.service import oauth2
+from databricks.sdk.service import pipelines
+from databricks.sdk.service import provisioning
+from databricks.sdk.service import serving
+from databricks.sdk.service import settings
+from databricks.sdk.service import sharing
+from databricks.sdk.service import sql
+from databricks.sdk.service import vectorsearch
+from databricks.sdk.service import workspace
+
+# Re-export all modules
+__all__ = [
+    "apps",
+    "billing",
+    "catalog",
+    "cleanrooms", 
+    "compute",
+    "dashboards",
+    "files",
+    "iam",
+    "jobs",
+    "marketplace",
+    "ml",
+    "oauth2",
+    "pipelines",
+    "provisioning",
+    "serving",
+    "settings",
+    "sharing",
+    "sql",
+    "vectorsearch",
+    "workspace"
+]


### PR DESCRIPTION
## What changes are proposed in this pull request?

What - This PR updates the `__init__.py` file in the `databricks/sdk/service` directory to import and re-export all service modules. 

Why - This change will make the modules accessible directly from the `databricks.sdk.service` namespace without requiring users to import each service module individually. We access services through `databricks.sdk.service` while creating workspace and account client but we don't export it.
```
        self._access_control = service.iam.AccountAccessControlAPI(self._api_client)
        self._billable_usage = service.billing.BillableUsageAPI(self._api_client)
```

## How is this tested?
Existing Tests.
NO_CHANGELOG=true