### PR TITLE
Ensure that refresh tokens are returned when using the `external-browser` credentials strategy

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Bug Fixes
 
+ * Ensure that refresh tokens are returned when using the `external-browser` credentials strategy.
+
 ### Documentation
 
 ### Internal Changes

--- a/databricks/sdk/oauth.py
+++ b/databricks/sdk/oauth.py
@@ -629,7 +629,11 @@ class OAuthClient:
     ):
 
         if not scopes:
-            scopes = ["all-apis"]
+            # all-apis ensures that the returned OAuth token can be used with all APIs, aside
+            # from direct-to-dataplane APIs.
+            # offline_access ensures that the response from the Authorization server includes
+            # a refresh token.
+            scopes = ["all-apis", "offline_access"]
 
         self.redirect_url = redirect_url
         self._client_id = client_id

--- a/databricks/sdk/oauth.py
+++ b/databricks/sdk/oauth.py
@@ -658,8 +658,6 @@ class OAuthClient:
             return lambda: {}
 
         config = Config(host=host, credentials_strategy=noop_credentials)
-        if not scopes:
-            scopes = ["all-apis"]
         oidc = config.oidc_endpoints
         if not oidc:
             raise ValueError(f"{host} does not support OAuth")


### PR DESCRIPTION
## What changes are proposed in this pull request?

Today, the `external-browser` credentials strategy allows users to dynamically fetch an OAuth token without depending on external tools like the Databricks CLI. However, the requested scope is hard-coded to always be `all-apis`. As a result, after successfully authenticating, the authorization server will return only an access token and no refresh token. The access token will expire after an hour, and attempts to refresh the token will fail.

This PR adds the `offline_access` scope to the default requested scopes during this flow. This matches the request made by the CLI in the `databricks auth login` flow. The resulting token includes a refresh token.

## How is this tested?

I manually tested this by deleting the token cache at `~/.config/databricks-sdk-py/oauth` and then running the following script:

```py
from databricks.sdk import WorkspaceClient

w = WorkspaceClient(host="https://adb-2548836972759138.18.azuredatabricks.net", auth_type="external-browser")
print(w.current_user.me())
```

The resulting token is saved to the OAuth cache. This token includes the refresh token.

```
{"token": {"access_token": "eyJraWQiOiIy...", "token_type": "Bearer", "expiry": "2025-03-20T11:00:25.242011", "refresh_token": "doau6c1a..."}}
```

To force a refresh, I manually updated the expiry time to be in the past and reran the script. The token was refreshed and the script succeeded:

```
DEBUG:databricks.sdk.oauth:Retrieving token for databricks-cli
DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): adb-2548836972759138.18.azuredatabricks.net:443
DEBUG:urllib3.connectionpool:https://adb-2548836972759138.18.azuredatabricks.net:443 "POST /oidc/v1/token HTTP/1.1" 200 None
```