### PR TITLE
Ensure ucacct tests are marked as integration tests

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -39,7 +39,7 @@ def pytest_configure(config):
 
 def pytest_collection_modifyitems(items):
     # safer to refer to fixture fns instead of strings
-    client_fixtures = [x.__name__ for x in [a, w, ucws]]
+    client_fixtures = [x.__name__ for x in [a, w, ucws, ucacct]]
     for item in items:
         current_fixtures = getattr(item, "fixturenames", ())
         for requires_client in client_fixtures:


### PR DESCRIPTION
## What changes are proposed in this pull request?

Integration tests for the Python SDK are run once for each environment (a grid covering cloud, account/workspace, and with or without UC). All tests are executed by the test runner in each environment, even though most tests only work in a specific context (e.g. you can't run a test that depends on a catalog in a workspace with no catalog).

Each test uses pytest fixtures to express its dependencies. One of these is the Databricks client to use for the test. There are four options, depending on whether the test is meant to be run at the workspace/account level and with or without UC: `w` for workspace-level without UC, `ucws` for workspace-level with UC, `a` for account-level without UC, and `ucacct` for account-level with UC. Any test that uses these clients in the `tests/integration` directory will have a marker called `integration` automatically added to it. `make integration` runs these tests.

However, currently, tests using the `ucacct` client are skipped. In this case, this is happening by pytest itself because these tests are not annotated with the `integration` marker. This is fixed by adding `ucacct` to the list of fixtures whose presence indicates that they are integration tests.

## How is this tested?

- [ ] Run integration tests, and verify that ucacct tests are executed after this change.

NO_CHANGELOG=true