### PR TITLE
Update job id datatype for consistency

### DIFF
--- a/databricks/sdk/service/jobs.py
+++ b/databricks/sdk/service/jobs.py
@@ -9752,7 +9752,7 @@ class JobsAPI:
         self._api.do("POST", "/api/2.2/jobs/update", body=body, headers=headers)
 
     def update_permissions(
-        self, job_id: str, *, access_control_list: Optional[List[JobAccessControlRequest]] = None
+        self, job_id: int, *, access_control_list: Optional[List[JobAccessControlRequest]] = None
     ) -> JobPermissions:
         """Update job permissions.
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR updates the datatype of job_id parameter in the jobs API's update_permissions to be consistent with the other parts of the same API

## How is this tested?

Unit tests