### PR TITLE
Structured outputs

### DIFF
--- a/databricks/sdk/service/serving.py
+++ b/databricks/sdk/service/serving.py
@@ -4699,6 +4699,8 @@ class ServingEndpointsAPI:
             body["stream"] = stream
         if temperature is not None:
             body["temperature"] = temperature
+        if response_format is not None:
+            body["response_format"] = response_format
         headers = {
             "Accept": "application/json",
             "Content-Type": "application/json",
@@ -4972,6 +4974,8 @@ class ServingEndpointsDataPlaneAPI:
             body["stream"] = stream
         if temperature is not None:
             body["temperature"] = temperature
+        if response_format is not None:
+            body["response_format"] = response_format
         data_plane_info = self._data_plane_info_query(
             name=name,
         )

--- a/databricks/sdk/service/serving.py
+++ b/databricks/sdk/service/serving.py
@@ -4623,6 +4623,7 @@ class ServingEndpointsAPI:
         stop: Optional[List[str]] = None,
         stream: Optional[bool] = None,
         temperature: Optional[float] = None,
+        response_format: Optional[dict] = None,
     ) -> QueryEndpointResponse:
         """Query a serving endpoint.
 
@@ -4898,6 +4899,7 @@ class ServingEndpointsDataPlaneAPI:
         stop: Optional[List[str]] = None,
         stream: Optional[bool] = None,
         temperature: Optional[float] = None,
+        response_format: Optional[dict] = None,
     ) -> QueryEndpointResponse:
         """Query a serving endpoint.
 


### PR DESCRIPTION
# Adding response_format to allow for Structure Output when using some OpenAi models

## What changes are proposed in this pull request?

Adding a variable `response_format `to allow `response_format `to be passed to openAI models such as gpt4o.

Example: https://community.openai.com/t/how-do-i-use-the-new-json-mode/475890/2

Specifically, try to answer the two following questions:

- **WHAT** changes are being made in the PR? This should be a summary of the 
  major changes to allow the reader to quickly understand the PR without having
  to look at the code. 
A variable `response_format `has been added to both `query `functions. If statements have been added to both `query `functions to handle the case when `response_format `is not passed.
- **WHY** are these changes needed? This should provide the context that the 
  reader might be missing. For example, were there any decisions behind the 
  change that are not reflected in the code itself? 
Adding the `response_format `variable in this way will allow a `response_format `to be passed to openAI models such as gpt4o.

The “why part” is the most important of the two as it usually cannot be 
inferred from the code itself. A well-written PR description will help future
developers (including your future self) to know how to interact and update your
code.

## How is this tested?

Describe any tests you have done; especially if test tests are not part of
the unit tests (e.g. local tests).

I have **NOT** tested this edit.

**ALWAYS ANSWER THIS QUESTION:** Answer with "N/A" if tests are not applicable
to your PR (e.g. if the PR only modifies comments). Do not be afraid of 
answering "Not tested" if the PR has not been tested. Being clear about what 
has been done and not done provides important context to the reviewers. 