### PR TITLE
Adding an example to show how to use api_client to make generic api calls. 

### DIFF
--- a/examples/generic_restapi.py
+++ b/examples/generic_restapi.py
@@ -1,21 +1,20 @@
 from databricks.sdk import WorkspaceClient
-import logging
-logging.basicConfig(level=logging.DEBUG)
 
-w = WorkspaceClient()
+if __name__ == "__main__":
 
+    w = WorkspaceClient()
 
-# Make a GET request to list users
-response = w.api_client.do(
-    method="GET",
-    path="/api/2.0/account/scim/v2/Users",
-    headers={
-        "Accept": "application/json"
-    }
-)
+    # Make a GET request to list cluster policies
+    response = w.api_client.do(
+        method="GET",
+        path="/api/2.0/policies/clusters/list",
+        headers={
+            "Accept": "application/json"
+        }
+    )
 
-# Print the response
-print(response)
+    # Print the response
+    print(response)
 
 
 

--- a/examples/generic_restapi.py
+++ b/examples/generic_restapi.py
@@ -1,0 +1,21 @@
+from databricks.sdk import WorkspaceClient
+import logging
+logging.basicConfig(level=logging.DEBUG)
+
+w = WorkspaceClient()
+
+
+# Make a GET request to list users
+response = w.api_client.do(
+    method="GET",
+    path="/api/2.0/account/scim/v2/Users",
+    headers={
+        "Accept": "application/json"
+    }
+)
+
+# Print the response
+print(response)
+
+
+


### PR DESCRIPTION
## What changes are proposed in this pull request?

I am adding one example under `examples`.  It is to demonstrate how to use `api_client` for making generic REST API calls. This serves as an example for users who need to interact with REST endpoints that are not yet wrapped by the Python SDK.

## How is this tested?

 - [x] make test run locally
 - [x] make fmt applied
 - [x] relevant integration tests applied
