### PR TITLE
Add Waiters for long-running operations

### DIFF
--- a/.codegen/_openapi_sha
+++ b/.codegen/_openapi_sha
@@ -1,1 +1,1 @@
-e6971360e2752b3513d44a25d25f6cc5448056c8
+universe:/home/parth.bansal/universetwo

--- a/.codegen/_openapi_sha
+++ b/.codegen/_openapi_sha
@@ -1,1 +1,1 @@
-universe:/home/parth.bansal/universetwo
+28e61a3e6657d349b135445af2a0f03ddfa8c3fc

--- a/databricks/sdk/apps/v2/apps.py
+++ b/databricks/sdk/apps/v2/apps.py
@@ -1267,7 +1267,7 @@ class AppsAPI:
         }
 
         op_response = self._api.do("POST", "/api/2.0/apps", query=query, body=body, headers=headers)
-        return AppsCreateWaiter(service=self, response=App.from_dict(op_response), name=op_response["name"])
+        return AppsCreateWaiter(service=self, raw_response=App.from_dict(op_response), name=op_response["name"])
 
     def delete(self, name: str) -> App:
         """Delete an app.
@@ -1309,7 +1309,7 @@ class AppsAPI:
         op_response = self._api.do("POST", f"/api/2.0/apps/{app_name}/deployments", body=body, headers=headers)
         return AppsDeployWaiter(
             service=self,
-            response=AppDeployment.from_dict(op_response),
+            raw_response=AppDeployment.from_dict(op_response),
             app_name=app_name,
             deployment_id=op_response["deployment_id"],
         )
@@ -1498,7 +1498,7 @@ class AppsAPI:
         }
 
         op_response = self._api.do("POST", f"/api/2.0/apps/{name}/start", headers=headers)
-        return AppsStartWaiter(service=self, response=App.from_dict(op_response), name=op_response["name"])
+        return AppsStartWaiter(service=self, raw_response=App.from_dict(op_response), name=op_response["name"])
 
     def stop(self, name: str) -> AppsStopWaiter:
         """Stop an app.
@@ -1519,7 +1519,7 @@ class AppsAPI:
         }
 
         op_response = self._api.do("POST", f"/api/2.0/apps/{name}/stop", headers=headers)
-        return AppsStopWaiter(service=self, response=App.from_dict(op_response), name=op_response["name"])
+        return AppsStopWaiter(service=self, raw_response=App.from_dict(op_response), name=op_response["name"])
 
     def update(self, name: str, *, app: Optional[App] = None) -> App:
         """Update an app.

--- a/databricks/sdk/catalog/v2/catalog.py
+++ b/databricks/sdk/catalog/v2/catalog.py
@@ -12351,7 +12351,7 @@ class OnlineTablesAPI:
 
         op_response = self._api.do("POST", "/api/2.0/online-tables", body=body, headers=headers)
         return OnlineTablesCreateWaiter(
-            service=self, response=OnlineTable.from_dict(op_response), name=op_response["name"]
+            service=self, raw_response=OnlineTable.from_dict(op_response), name=op_response["name"]
         )
 
     def delete(self, name: str):

--- a/databricks/sdk/cleanrooms/v2/cleanrooms.py
+++ b/databricks/sdk/cleanrooms/v2/cleanrooms.py
@@ -837,10 +837,11 @@ class CleanRoomTaskRunState:
 
     life_cycle_state: Optional[CleanRoomTaskRunLifeCycleState] = None
     """A value indicating the run's current lifecycle state. This field is always available in the
-    response."""
+    response. Note: Additional states might be introduced in future releases."""
 
     result_state: Optional[CleanRoomTaskRunResultState] = None
-    """A value indicating the run's result. This field is only available for terminal lifecycle states."""
+    """A value indicating the run's result. This field is only available for terminal lifecycle states.
+    Note: Additional states might be introduced in future releases."""
 
     def as_dict(self) -> dict:
         """Serializes the CleanRoomTaskRunState into a dictionary suitable for use as a JSON request body."""
@@ -1153,6 +1154,7 @@ class ComplianceStandard(Enum):
     IRAP_PROTECTED = "IRAP_PROTECTED"
     ISMAP = "ISMAP"
     ITAR_EAR = "ITAR_EAR"
+    K_FSI = "K_FSI"
     NONE = "NONE"
     PCI_DSS = "PCI_DSS"
 

--- a/databricks/sdk/compute/v2/compute.py
+++ b/databricks/sdk/compute/v2/compute.py
@@ -7581,6 +7581,9 @@ class LogSyncStatus:
         return cls(last_attempted=d.get("last_attempted", None), last_exception=d.get("last_exception", None))
 
 
+MapAny = Dict[str, Any]
+
+
 @dataclass
 class MavenLibrary:
     coordinates: str

--- a/databricks/sdk/compute/v2/compute.py
+++ b/databricks/sdk/compute/v2/compute.py
@@ -10602,7 +10602,9 @@ class ClustersAPI:
 
         op_response = self._api.do("POST", "/api/2.1/clusters/create", body=body, headers=headers)
         return ClustersCreateWaiter(
-            service=self, response=CreateClusterResponse.from_dict(op_response), cluster_id=op_response["cluster_id"]
+            service=self,
+            raw_response=CreateClusterResponse.from_dict(op_response),
+            cluster_id=op_response["cluster_id"],
         )
 
     def delete(self, cluster_id: str) -> ClustersDeleteWaiter:
@@ -10629,7 +10631,7 @@ class ClustersAPI:
 
         op_response = self._api.do("POST", "/api/2.1/clusters/delete", body=body, headers=headers)
         return ClustersDeleteWaiter(
-            service=self, response=DeleteClusterResponse.from_dict(op_response), cluster_id=cluster_id
+            service=self, raw_response=DeleteClusterResponse.from_dict(op_response), cluster_id=cluster_id
         )
 
     def edit(
@@ -10917,7 +10919,7 @@ class ClustersAPI:
 
         op_response = self._api.do("POST", "/api/2.1/clusters/edit", body=body, headers=headers)
         return ClustersEditWaiter(
-            service=self, response=EditClusterResponse.from_dict(op_response), cluster_id=cluster_id
+            service=self, raw_response=EditClusterResponse.from_dict(op_response), cluster_id=cluster_id
         )
 
     def events(
@@ -11207,7 +11209,7 @@ class ClustersAPI:
 
         op_response = self._api.do("POST", "/api/2.1/clusters/resize", body=body, headers=headers)
         return ClustersResizeWaiter(
-            service=self, response=ResizeClusterResponse.from_dict(op_response), cluster_id=cluster_id
+            service=self, raw_response=ResizeClusterResponse.from_dict(op_response), cluster_id=cluster_id
         )
 
     def restart(self, cluster_id: str, *, restart_user: Optional[str] = None) -> ClustersRestartWaiter:
@@ -11236,7 +11238,7 @@ class ClustersAPI:
 
         op_response = self._api.do("POST", "/api/2.1/clusters/restart", body=body, headers=headers)
         return ClustersRestartWaiter(
-            service=self, response=RestartClusterResponse.from_dict(op_response), cluster_id=cluster_id
+            service=self, raw_response=RestartClusterResponse.from_dict(op_response), cluster_id=cluster_id
         )
 
     def set_permissions(
@@ -11305,7 +11307,7 @@ class ClustersAPI:
 
         op_response = self._api.do("POST", "/api/2.1/clusters/start", body=body, headers=headers)
         return ClustersStartWaiter(
-            service=self, response=StartClusterResponse.from_dict(op_response), cluster_id=cluster_id
+            service=self, raw_response=StartClusterResponse.from_dict(op_response), cluster_id=cluster_id
         )
 
     def unpin(self, cluster_id: str):
@@ -11379,7 +11381,7 @@ class ClustersAPI:
 
         op_response = self._api.do("POST", "/api/2.1/clusters/update", body=body, headers=headers)
         return ClustersUpdateWaiter(
-            service=self, response=UpdateClusterResponse.from_dict(op_response), cluster_id=cluster_id
+            service=self, raw_response=UpdateClusterResponse.from_dict(op_response), cluster_id=cluster_id
         )
 
     def update_permissions(
@@ -11594,7 +11596,7 @@ class CommandExecutionAPI:
         op_response = self._api.do("POST", "/api/1.2/commands/cancel", body=body, headers=headers)
         return CommandExecutionCancelWaiter(
             service=self,
-            response=CancelResponse.from_dict(op_response),
+            raw_response=CancelResponse.from_dict(op_response),
             cluster_id=cluster_id,
             command_id=command_id,
             context_id=context_id,
@@ -11680,7 +11682,10 @@ class CommandExecutionAPI:
 
         op_response = self._api.do("POST", "/api/1.2/contexts/create", body=body, headers=headers)
         return CommandExecutionCreateWaiter(
-            service=self, response=Created.from_dict(op_response), cluster_id=cluster_id, context_id=op_response["id"]
+            service=self,
+            raw_response=Created.from_dict(op_response),
+            cluster_id=cluster_id,
+            context_id=op_response["id"],
         )
 
     def destroy(self, cluster_id: str, context_id: str):
@@ -11748,7 +11753,7 @@ class CommandExecutionAPI:
         op_response = self._api.do("POST", "/api/1.2/commands/execute", body=body, headers=headers)
         return CommandExecutionExecuteWaiter(
             service=self,
-            response=Created.from_dict(op_response),
+            raw_response=Created.from_dict(op_response),
             cluster_id=cluster_id,
             command_id=op_response["id"],
             context_id=context_id,

--- a/databricks/sdk/compute/v2/compute.py
+++ b/databricks/sdk/compute/v2/compute.py
@@ -4458,6 +4458,10 @@ class EditInstancePool:
     min_idle_instances: Optional[int] = None
     """Minimum number of idle instances to keep in the instance pool"""
 
+    node_type_flexibility: Optional[NodeTypeFlexibility] = None
+    """For Fleet-pool V2, this object contains the information about the alternate node type ids to use
+    when attempting to launch a cluster if the node type id is not available."""
+
     def as_dict(self) -> dict:
         """Serializes the EditInstancePool into a dictionary suitable for use as a JSON request body."""
         body = {}
@@ -4473,6 +4477,8 @@ class EditInstancePool:
             body["max_capacity"] = self.max_capacity
         if self.min_idle_instances is not None:
             body["min_idle_instances"] = self.min_idle_instances
+        if self.node_type_flexibility:
+            body["node_type_flexibility"] = self.node_type_flexibility.as_dict()
         if self.node_type_id is not None:
             body["node_type_id"] = self.node_type_id
         return body
@@ -4492,6 +4498,8 @@ class EditInstancePool:
             body["max_capacity"] = self.max_capacity
         if self.min_idle_instances is not None:
             body["min_idle_instances"] = self.min_idle_instances
+        if self.node_type_flexibility:
+            body["node_type_flexibility"] = self.node_type_flexibility
         if self.node_type_id is not None:
             body["node_type_id"] = self.node_type_id
         return body
@@ -4506,6 +4514,7 @@ class EditInstancePool:
             instance_pool_name=d.get("instance_pool_name", None),
             max_capacity=d.get("max_capacity", None),
             min_idle_instances=d.get("min_idle_instances", None),
+            node_type_flexibility=_from_dict(d, "node_type_flexibility", NodeTypeFlexibility),
             node_type_id=d.get("node_type_id", None),
         )
 
@@ -5343,6 +5352,10 @@ class GetInstancePool:
     min_idle_instances: Optional[int] = None
     """Minimum number of idle instances to keep in the instance pool"""
 
+    node_type_flexibility: Optional[NodeTypeFlexibility] = None
+    """For Fleet-pool V2, this object contains the information about the alternate node type ids to use
+    when attempting to launch a cluster if the node type id is not available."""
+
     node_type_id: Optional[str] = None
     """This field encodes, through a single value, the resources available to each of the Spark nodes
     in this cluster. For example, the Spark nodes can be provisioned and optimized for memory or
@@ -5393,6 +5406,8 @@ class GetInstancePool:
             body["max_capacity"] = self.max_capacity
         if self.min_idle_instances is not None:
             body["min_idle_instances"] = self.min_idle_instances
+        if self.node_type_flexibility:
+            body["node_type_flexibility"] = self.node_type_flexibility.as_dict()
         if self.node_type_id is not None:
             body["node_type_id"] = self.node_type_id
         if self.preloaded_docker_images:
@@ -5434,6 +5449,8 @@ class GetInstancePool:
             body["max_capacity"] = self.max_capacity
         if self.min_idle_instances is not None:
             body["min_idle_instances"] = self.min_idle_instances
+        if self.node_type_flexibility:
+            body["node_type_flexibility"] = self.node_type_flexibility
         if self.node_type_id is not None:
             body["node_type_id"] = self.node_type_id
         if self.preloaded_docker_images:
@@ -5464,6 +5481,7 @@ class GetInstancePool:
             instance_pool_name=d.get("instance_pool_name", None),
             max_capacity=d.get("max_capacity", None),
             min_idle_instances=d.get("min_idle_instances", None),
+            node_type_flexibility=_from_dict(d, "node_type_flexibility", NodeTypeFlexibility),
             node_type_id=d.get("node_type_id", None),
             preloaded_docker_images=_repeated_dict(d, "preloaded_docker_images", DockerImage),
             preloaded_spark_versions=d.get("preloaded_spark_versions", None),
@@ -6298,6 +6316,10 @@ class InstancePoolAndStats:
     min_idle_instances: Optional[int] = None
     """Minimum number of idle instances to keep in the instance pool"""
 
+    node_type_flexibility: Optional[NodeTypeFlexibility] = None
+    """For Fleet-pool V2, this object contains the information about the alternate node type ids to use
+    when attempting to launch a cluster if the node type id is not available."""
+
     node_type_id: Optional[str] = None
     """This field encodes, through a single value, the resources available to each of the Spark nodes
     in this cluster. For example, the Spark nodes can be provisioned and optimized for memory or
@@ -6348,6 +6370,8 @@ class InstancePoolAndStats:
             body["max_capacity"] = self.max_capacity
         if self.min_idle_instances is not None:
             body["min_idle_instances"] = self.min_idle_instances
+        if self.node_type_flexibility:
+            body["node_type_flexibility"] = self.node_type_flexibility.as_dict()
         if self.node_type_id is not None:
             body["node_type_id"] = self.node_type_id
         if self.preloaded_docker_images:
@@ -6389,6 +6413,8 @@ class InstancePoolAndStats:
             body["max_capacity"] = self.max_capacity
         if self.min_idle_instances is not None:
             body["min_idle_instances"] = self.min_idle_instances
+        if self.node_type_flexibility:
+            body["node_type_flexibility"] = self.node_type_flexibility
         if self.node_type_id is not None:
             body["node_type_id"] = self.node_type_id
         if self.preloaded_docker_images:
@@ -6419,6 +6445,7 @@ class InstancePoolAndStats:
             instance_pool_name=d.get("instance_pool_name", None),
             max_capacity=d.get("max_capacity", None),
             min_idle_instances=d.get("min_idle_instances", None),
+            node_type_flexibility=_from_dict(d, "node_type_flexibility", NodeTypeFlexibility),
             node_type_id=d.get("node_type_id", None),
             preloaded_docker_images=_repeated_dict(d, "preloaded_docker_images", DockerImage),
             preloaded_spark_versions=d.get("preloaded_spark_versions", None),
@@ -7879,6 +7906,28 @@ class NodeType:
             support_ebs_volumes=d.get("support_ebs_volumes", None),
             support_port_forwarding=d.get("support_port_forwarding", None),
         )
+
+
+@dataclass
+class NodeTypeFlexibility:
+    """For Fleet-V2 using classic clusters, this object contains the information about the alternate
+    node type ids to use when attempting to launch a cluster. It can be used with both the driver
+    and worker node types."""
+
+    def as_dict(self) -> dict:
+        """Serializes the NodeTypeFlexibility into a dictionary suitable for use as a JSON request body."""
+        body = {}
+        return body
+
+    def as_shallow_dict(self) -> dict:
+        """Serializes the NodeTypeFlexibility into a shallow dictionary of its immediate attributes."""
+        body = {}
+        return body
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, Any]) -> NodeTypeFlexibility:
+        """Deserializes the NodeTypeFlexibility from a dictionary."""
+        return cls()
 
 
 @dataclass
@@ -12068,6 +12117,7 @@ class InstancePoolsAPI:
         idle_instance_autotermination_minutes: Optional[int] = None,
         max_capacity: Optional[int] = None,
         min_idle_instances: Optional[int] = None,
+        node_type_flexibility: Optional[NodeTypeFlexibility] = None,
     ):
         """Edit an existing instance pool.
 
@@ -12100,6 +12150,9 @@ class InstancePoolsAPI:
           upsize requests.
         :param min_idle_instances: int (optional)
           Minimum number of idle instances to keep in the instance pool
+        :param node_type_flexibility: :class:`NodeTypeFlexibility` (optional)
+          For Fleet-pool V2, this object contains the information about the alternate node type ids to use
+          when attempting to launch a cluster if the node type id is not available.
 
 
         """
@@ -12116,6 +12169,8 @@ class InstancePoolsAPI:
             body["max_capacity"] = max_capacity
         if min_idle_instances is not None:
             body["min_idle_instances"] = min_idle_instances
+        if node_type_flexibility is not None:
+            body["node_type_flexibility"] = node_type_flexibility.as_dict()
         if node_type_id is not None:
             body["node_type_id"] = node_type_id
         headers = {

--- a/databricks/sdk/compute/v2/compute.py
+++ b/databricks/sdk/compute/v2/compute.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 import logging
+import random
+import time
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Dict, Iterator, List, Optional
 
-from ...service._internal import (_enum, _from_dict, _repeated_dict,
-                                  _repeated_enum)
+from ...databricks.errors import OperationFailed
+from ...service._internal import (WaitUntilDoneOptions, _enum, _from_dict,
+                                  _repeated_dict, _repeated_enum)
 
 _LOG = logging.getLogger("databricks.sdk")
 
@@ -9970,6 +9973,297 @@ class ClusterPoliciesAPI:
         return ClusterPolicyPermissions.from_dict(res)
 
 
+class ClustersCreateWaiter:
+    raw_response: CreateClusterResponse
+    """raw_response is the raw response of the Create call."""
+    _service: ClustersAPI
+    _cluster_id: str
+
+    def __init__(self, raw_response: CreateClusterResponse, service: ClustersAPI, cluster_id: str):
+        self._service = service
+        self.raw_response = raw_response
+        self._cluster_id = cluster_id
+
+    def WaitUntilDone(self, opts: Optional[WaitUntilDoneOptions] = None) -> ClusterDetails:
+        if opts is None:
+            opts = WaitUntilDoneOptions()
+        deadline = time.time() + opts.timeout.total_seconds()
+        target_states = (State.RUNNING,)
+        failure_states = (
+            State.ERROR,
+            State.TERMINATED,
+        )
+        status_message = "polling..."
+        attempt = 1
+        while time.time() < deadline:
+            poll = self._service.get(cluster_id=self._cluster_id)
+            status = poll.state
+            status_message = f"current status: {status}"
+            if status in target_states:
+                return poll
+            if status in failure_states:
+                msg = f"failed to reach RUNNING, got {status}: {status_message}"
+                raise OperationFailed(msg)
+            prefix = f"cluster_id={self._cluster_id}"
+            sleep = attempt
+            if sleep > 10:
+                # sleep 10s max per attempt
+                sleep = 10
+            _LOG.debug(f"{prefix}: ({status}) {status_message} (sleeping ~{sleep}s)")
+            time.sleep(sleep + random.random())
+            attempt += 1
+        raise TimeoutError(f"timed out after {opts.timeout}: {status_message}")
+
+
+class ClustersDeleteWaiter:
+    raw_response: DeleteClusterResponse
+    """raw_response is the raw response of the Delete call."""
+    _service: ClustersAPI
+    _cluster_id: str
+
+    def __init__(self, raw_response: DeleteClusterResponse, service: ClustersAPI, cluster_id: str):
+        self._service = service
+        self.raw_response = raw_response
+        self._cluster_id = cluster_id
+
+    def WaitUntilDone(self, opts: Optional[WaitUntilDoneOptions] = None) -> ClusterDetails:
+        if opts is None:
+            opts = WaitUntilDoneOptions()
+        deadline = time.time() + opts.timeout.total_seconds()
+        target_states = (State.TERMINATED,)
+        failure_states = (State.ERROR,)
+        status_message = "polling..."
+        attempt = 1
+        while time.time() < deadline:
+            poll = self._service.get(cluster_id=self._cluster_id)
+            status = poll.state
+            status_message = f"current status: {status}"
+            if status in target_states:
+                return poll
+            if status in failure_states:
+                msg = f"failed to reach TERMINATED, got {status}: {status_message}"
+                raise OperationFailed(msg)
+            prefix = f"cluster_id={self._cluster_id}"
+            sleep = attempt
+            if sleep > 10:
+                # sleep 10s max per attempt
+                sleep = 10
+            _LOG.debug(f"{prefix}: ({status}) {status_message} (sleeping ~{sleep}s)")
+            time.sleep(sleep + random.random())
+            attempt += 1
+        raise TimeoutError(f"timed out after {opts.timeout}: {status_message}")
+
+
+class ClustersEditWaiter:
+    raw_response: EditClusterResponse
+    """raw_response is the raw response of the Edit call."""
+    _service: ClustersAPI
+    _cluster_id: str
+
+    def __init__(self, raw_response: EditClusterResponse, service: ClustersAPI, cluster_id: str):
+        self._service = service
+        self.raw_response = raw_response
+        self._cluster_id = cluster_id
+
+    def WaitUntilDone(self, opts: Optional[WaitUntilDoneOptions] = None) -> ClusterDetails:
+        if opts is None:
+            opts = WaitUntilDoneOptions()
+        deadline = time.time() + opts.timeout.total_seconds()
+        target_states = (State.RUNNING,)
+        failure_states = (
+            State.ERROR,
+            State.TERMINATED,
+        )
+        status_message = "polling..."
+        attempt = 1
+        while time.time() < deadline:
+            poll = self._service.get(cluster_id=self._cluster_id)
+            status = poll.state
+            status_message = f"current status: {status}"
+            if status in target_states:
+                return poll
+            if status in failure_states:
+                msg = f"failed to reach RUNNING, got {status}: {status_message}"
+                raise OperationFailed(msg)
+            prefix = f"cluster_id={self._cluster_id}"
+            sleep = attempt
+            if sleep > 10:
+                # sleep 10s max per attempt
+                sleep = 10
+            _LOG.debug(f"{prefix}: ({status}) {status_message} (sleeping ~{sleep}s)")
+            time.sleep(sleep + random.random())
+            attempt += 1
+        raise TimeoutError(f"timed out after {opts.timeout}: {status_message}")
+
+
+class ClustersResizeWaiter:
+    raw_response: ResizeClusterResponse
+    """raw_response is the raw response of the Resize call."""
+    _service: ClustersAPI
+    _cluster_id: str
+
+    def __init__(self, raw_response: ResizeClusterResponse, service: ClustersAPI, cluster_id: str):
+        self._service = service
+        self.raw_response = raw_response
+        self._cluster_id = cluster_id
+
+    def WaitUntilDone(self, opts: Optional[WaitUntilDoneOptions] = None) -> ClusterDetails:
+        if opts is None:
+            opts = WaitUntilDoneOptions()
+        deadline = time.time() + opts.timeout.total_seconds()
+        target_states = (State.RUNNING,)
+        failure_states = (
+            State.ERROR,
+            State.TERMINATED,
+        )
+        status_message = "polling..."
+        attempt = 1
+        while time.time() < deadline:
+            poll = self._service.get(cluster_id=self._cluster_id)
+            status = poll.state
+            status_message = f"current status: {status}"
+            if status in target_states:
+                return poll
+            if status in failure_states:
+                msg = f"failed to reach RUNNING, got {status}: {status_message}"
+                raise OperationFailed(msg)
+            prefix = f"cluster_id={self._cluster_id}"
+            sleep = attempt
+            if sleep > 10:
+                # sleep 10s max per attempt
+                sleep = 10
+            _LOG.debug(f"{prefix}: ({status}) {status_message} (sleeping ~{sleep}s)")
+            time.sleep(sleep + random.random())
+            attempt += 1
+        raise TimeoutError(f"timed out after {opts.timeout}: {status_message}")
+
+
+class ClustersRestartWaiter:
+    raw_response: RestartClusterResponse
+    """raw_response is the raw response of the Restart call."""
+    _service: ClustersAPI
+    _cluster_id: str
+
+    def __init__(self, raw_response: RestartClusterResponse, service: ClustersAPI, cluster_id: str):
+        self._service = service
+        self.raw_response = raw_response
+        self._cluster_id = cluster_id
+
+    def WaitUntilDone(self, opts: Optional[WaitUntilDoneOptions] = None) -> ClusterDetails:
+        if opts is None:
+            opts = WaitUntilDoneOptions()
+        deadline = time.time() + opts.timeout.total_seconds()
+        target_states = (State.RUNNING,)
+        failure_states = (
+            State.ERROR,
+            State.TERMINATED,
+        )
+        status_message = "polling..."
+        attempt = 1
+        while time.time() < deadline:
+            poll = self._service.get(cluster_id=self._cluster_id)
+            status = poll.state
+            status_message = f"current status: {status}"
+            if status in target_states:
+                return poll
+            if status in failure_states:
+                msg = f"failed to reach RUNNING, got {status}: {status_message}"
+                raise OperationFailed(msg)
+            prefix = f"cluster_id={self._cluster_id}"
+            sleep = attempt
+            if sleep > 10:
+                # sleep 10s max per attempt
+                sleep = 10
+            _LOG.debug(f"{prefix}: ({status}) {status_message} (sleeping ~{sleep}s)")
+            time.sleep(sleep + random.random())
+            attempt += 1
+        raise TimeoutError(f"timed out after {opts.timeout}: {status_message}")
+
+
+class ClustersStartWaiter:
+    raw_response: StartClusterResponse
+    """raw_response is the raw response of the Start call."""
+    _service: ClustersAPI
+    _cluster_id: str
+
+    def __init__(self, raw_response: StartClusterResponse, service: ClustersAPI, cluster_id: str):
+        self._service = service
+        self.raw_response = raw_response
+        self._cluster_id = cluster_id
+
+    def WaitUntilDone(self, opts: Optional[WaitUntilDoneOptions] = None) -> ClusterDetails:
+        if opts is None:
+            opts = WaitUntilDoneOptions()
+        deadline = time.time() + opts.timeout.total_seconds()
+        target_states = (State.RUNNING,)
+        failure_states = (
+            State.ERROR,
+            State.TERMINATED,
+        )
+        status_message = "polling..."
+        attempt = 1
+        while time.time() < deadline:
+            poll = self._service.get(cluster_id=self._cluster_id)
+            status = poll.state
+            status_message = f"current status: {status}"
+            if status in target_states:
+                return poll
+            if status in failure_states:
+                msg = f"failed to reach RUNNING, got {status}: {status_message}"
+                raise OperationFailed(msg)
+            prefix = f"cluster_id={self._cluster_id}"
+            sleep = attempt
+            if sleep > 10:
+                # sleep 10s max per attempt
+                sleep = 10
+            _LOG.debug(f"{prefix}: ({status}) {status_message} (sleeping ~{sleep}s)")
+            time.sleep(sleep + random.random())
+            attempt += 1
+        raise TimeoutError(f"timed out after {opts.timeout}: {status_message}")
+
+
+class ClustersUpdateWaiter:
+    raw_response: UpdateClusterResponse
+    """raw_response is the raw response of the Update call."""
+    _service: ClustersAPI
+    _cluster_id: str
+
+    def __init__(self, raw_response: UpdateClusterResponse, service: ClustersAPI, cluster_id: str):
+        self._service = service
+        self.raw_response = raw_response
+        self._cluster_id = cluster_id
+
+    def WaitUntilDone(self, opts: Optional[WaitUntilDoneOptions] = None) -> ClusterDetails:
+        if opts is None:
+            opts = WaitUntilDoneOptions()
+        deadline = time.time() + opts.timeout.total_seconds()
+        target_states = (State.RUNNING,)
+        failure_states = (
+            State.ERROR,
+            State.TERMINATED,
+        )
+        status_message = "polling..."
+        attempt = 1
+        while time.time() < deadline:
+            poll = self._service.get(cluster_id=self._cluster_id)
+            status = poll.state
+            status_message = f"current status: {status}"
+            if status in target_states:
+                return poll
+            if status in failure_states:
+                msg = f"failed to reach RUNNING, got {status}: {status_message}"
+                raise OperationFailed(msg)
+            prefix = f"cluster_id={self._cluster_id}"
+            sleep = attempt
+            if sleep > 10:
+                # sleep 10s max per attempt
+                sleep = 10
+            _LOG.debug(f"{prefix}: ({status}) {status_message} (sleeping ~{sleep}s)")
+            time.sleep(sleep + random.random())
+            attempt += 1
+        raise TimeoutError(f"timed out after {opts.timeout}: {status_message}")
+
+
 class ClustersAPI:
     """The Clusters API allows you to create, start, edit, list, terminate, and delete clusters.
 
@@ -10054,7 +10348,7 @@ class ClustersAPI:
         ssh_public_keys: Optional[List[str]] = None,
         use_ml_runtime: Optional[bool] = None,
         workload_type: Optional[WorkloadType] = None,
-    ) -> CreateClusterResponse:
+    ) -> ClustersCreateWaiter:
         """Create new cluster.
 
         Creates a new Spark cluster. This method will acquire new instances from the cloud provider if
@@ -10306,10 +10600,12 @@ class ClustersAPI:
             "Content-Type": "application/json",
         }
 
-        res = self._api.do("POST", "/api/2.1/clusters/create", body=body, headers=headers)
-        return CreateClusterResponse.from_dict(res)
+        op_response = self._api.do("POST", "/api/2.1/clusters/create", body=body, headers=headers)
+        return ClustersCreateWaiter(
+            service=self, response=CreateClusterResponse.from_dict(op_response), cluster_id=op_response["cluster_id"]
+        )
 
-    def delete(self, cluster_id: str):
+    def delete(self, cluster_id: str) -> ClustersDeleteWaiter:
         """Terminate cluster.
 
         Terminates the Spark cluster with the specified ID. The cluster is removed asynchronously. Once the
@@ -10331,7 +10627,10 @@ class ClustersAPI:
             "Content-Type": "application/json",
         }
 
-        self._api.do("POST", "/api/2.1/clusters/delete", body=body, headers=headers)
+        op_response = self._api.do("POST", "/api/2.1/clusters/delete", body=body, headers=headers)
+        return ClustersDeleteWaiter(
+            service=self, response=DeleteClusterResponse.from_dict(op_response), cluster_id=cluster_id
+        )
 
     def edit(
         self,
@@ -10367,7 +10666,7 @@ class ClustersAPI:
         ssh_public_keys: Optional[List[str]] = None,
         use_ml_runtime: Optional[bool] = None,
         workload_type: Optional[WorkloadType] = None,
-    ):
+    ) -> ClustersEditWaiter:
         """Update cluster configuration.
 
         Updates the configuration of a cluster to match the provided attributes and size. A cluster can be
@@ -10616,7 +10915,10 @@ class ClustersAPI:
             "Content-Type": "application/json",
         }
 
-        self._api.do("POST", "/api/2.1/clusters/edit", body=body, headers=headers)
+        op_response = self._api.do("POST", "/api/2.1/clusters/edit", body=body, headers=headers)
+        return ClustersEditWaiter(
+            service=self, response=EditClusterResponse.from_dict(op_response), cluster_id=cluster_id
+        )
 
     def events(
         self,
@@ -10864,7 +11166,9 @@ class ClustersAPI:
 
         self._api.do("POST", "/api/2.1/clusters/pin", body=body, headers=headers)
 
-    def resize(self, cluster_id: str, *, autoscale: Optional[AutoScale] = None, num_workers: Optional[int] = None):
+    def resize(
+        self, cluster_id: str, *, autoscale: Optional[AutoScale] = None, num_workers: Optional[int] = None
+    ) -> ClustersResizeWaiter:
         """Resize cluster.
 
         Resizes a cluster to have a desired number of workers. This will fail unless the cluster is in a
@@ -10901,9 +11205,12 @@ class ClustersAPI:
             "Content-Type": "application/json",
         }
 
-        self._api.do("POST", "/api/2.1/clusters/resize", body=body, headers=headers)
+        op_response = self._api.do("POST", "/api/2.1/clusters/resize", body=body, headers=headers)
+        return ClustersResizeWaiter(
+            service=self, response=ResizeClusterResponse.from_dict(op_response), cluster_id=cluster_id
+        )
 
-    def restart(self, cluster_id: str, *, restart_user: Optional[str] = None):
+    def restart(self, cluster_id: str, *, restart_user: Optional[str] = None) -> ClustersRestartWaiter:
         """Restart cluster.
 
         Restarts a Spark cluster with the supplied ID. If the cluster is not currently in a `RUNNING` state,
@@ -10927,7 +11234,10 @@ class ClustersAPI:
             "Content-Type": "application/json",
         }
 
-        self._api.do("POST", "/api/2.1/clusters/restart", body=body, headers=headers)
+        op_response = self._api.do("POST", "/api/2.1/clusters/restart", body=body, headers=headers)
+        return ClustersRestartWaiter(
+            service=self, response=RestartClusterResponse.from_dict(op_response), cluster_id=cluster_id
+        )
 
     def set_permissions(
         self, cluster_id: str, *, access_control_list: Optional[List[ClusterAccessControlRequest]] = None
@@ -10969,7 +11279,7 @@ class ClustersAPI:
         res = self._api.do("GET", "/api/2.1/clusters/spark-versions", headers=headers)
         return GetSparkVersionsResponse.from_dict(res)
 
-    def start(self, cluster_id: str):
+    def start(self, cluster_id: str) -> ClustersStartWaiter:
         """Start terminated cluster.
 
         Starts a terminated Spark cluster with the supplied ID. This works similar to `createCluster` except:
@@ -10993,7 +11303,10 @@ class ClustersAPI:
             "Content-Type": "application/json",
         }
 
-        self._api.do("POST", "/api/2.1/clusters/start", body=body, headers=headers)
+        op_response = self._api.do("POST", "/api/2.1/clusters/start", body=body, headers=headers)
+        return ClustersStartWaiter(
+            service=self, response=StartClusterResponse.from_dict(op_response), cluster_id=cluster_id
+        )
 
     def unpin(self, cluster_id: str):
         """Unpin cluster.
@@ -11016,7 +11329,9 @@ class ClustersAPI:
 
         self._api.do("POST", "/api/2.1/clusters/unpin", body=body, headers=headers)
 
-    def update(self, cluster_id: str, update_mask: str, *, cluster: Optional[UpdateClusterResource] = None):
+    def update(
+        self, cluster_id: str, update_mask: str, *, cluster: Optional[UpdateClusterResource] = None
+    ) -> ClustersUpdateWaiter:
         """Update cluster configuration (partial).
 
         Updates the configuration of a cluster to match the partial set of attributes and size. Denote which
@@ -11062,7 +11377,10 @@ class ClustersAPI:
             "Content-Type": "application/json",
         }
 
-        self._api.do("POST", "/api/2.1/clusters/update", body=body, headers=headers)
+        op_response = self._api.do("POST", "/api/2.1/clusters/update", body=body, headers=headers)
+        return ClustersUpdateWaiter(
+            service=self, response=UpdateClusterResponse.from_dict(op_response), cluster_id=cluster_id
+        )
 
     def update_permissions(
         self, cluster_id: str, *, access_control_list: Optional[List[ClusterAccessControlRequest]] = None
@@ -11089,6 +11407,154 @@ class ClustersAPI:
         return ClusterPermissions.from_dict(res)
 
 
+class CommandExecutionCancelWaiter:
+    raw_response: CancelResponse
+    """raw_response is the raw response of the Cancel call."""
+    _service: CommandExecutionAPI
+    _cluster_id: str
+    _command_id: str
+    _context_id: str
+
+    def __init__(
+        self,
+        raw_response: CancelResponse,
+        service: CommandExecutionAPI,
+        cluster_id: str,
+        command_id: str,
+        context_id: str,
+    ):
+        self._service = service
+        self.raw_response = raw_response
+        self._cluster_id = cluster_id
+        self._command_id = command_id
+        self._context_id = context_id
+
+    def WaitUntilDone(self, opts: Optional[WaitUntilDoneOptions] = None) -> CommandStatusResponse:
+        if opts is None:
+            opts = WaitUntilDoneOptions()
+        deadline = time.time() + opts.timeout.total_seconds()
+        target_states = (CommandStatus.CANCELLED,)
+        failure_states = (CommandStatus.ERROR,)
+        status_message = "polling..."
+        attempt = 1
+        while time.time() < deadline:
+            poll = self._service.command_status(
+                cluster_id=self._cluster_id, command_id=self._command_id, context_id=self._context_id
+            )
+            status = poll.status
+            status_message = f"current status: {status}"
+            if poll.results:
+                status_message = poll.results.cause
+            if status in target_states:
+                return poll
+            if status in failure_states:
+                msg = f"failed to reach Cancelled, got {status}: {status_message}"
+                raise OperationFailed(msg)
+            prefix = f"cluster_id={self._cluster_id}, command_id={self._command_id}, context_id={self._context_id}"
+            sleep = attempt
+            if sleep > 10:
+                # sleep 10s max per attempt
+                sleep = 10
+            _LOG.debug(f"{prefix}: ({status}) {status_message} (sleeping ~{sleep}s)")
+            time.sleep(sleep + random.random())
+            attempt += 1
+        raise TimeoutError(f"timed out after {opts.timeout}: {status_message}")
+
+
+class CommandExecutionCreateWaiter:
+    raw_response: Created
+    """raw_response is the raw response of the Create call."""
+    _service: CommandExecutionAPI
+    _cluster_id: str
+    _context_id: str
+
+    def __init__(self, raw_response: Created, service: CommandExecutionAPI, cluster_id: str, context_id: str):
+        self._service = service
+        self.raw_response = raw_response
+        self._cluster_id = cluster_id
+        self._context_id = context_id
+
+    def WaitUntilDone(self, opts: Optional[WaitUntilDoneOptions] = None) -> ContextStatusResponse:
+        if opts is None:
+            opts = WaitUntilDoneOptions()
+        deadline = time.time() + opts.timeout.total_seconds()
+        target_states = (ContextStatus.RUNNING,)
+        failure_states = (ContextStatus.ERROR,)
+        status_message = "polling..."
+        attempt = 1
+        while time.time() < deadline:
+            poll = self._service.context_status(cluster_id=self._cluster_id, context_id=self._context_id)
+            status = poll.status
+            status_message = f"current status: {status}"
+            if status in target_states:
+                return poll
+            if status in failure_states:
+                msg = f"failed to reach Running, got {status}: {status_message}"
+                raise OperationFailed(msg)
+            prefix = f"cluster_id={self._cluster_id}, context_id={self._context_id}"
+            sleep = attempt
+            if sleep > 10:
+                # sleep 10s max per attempt
+                sleep = 10
+            _LOG.debug(f"{prefix}: ({status}) {status_message} (sleeping ~{sleep}s)")
+            time.sleep(sleep + random.random())
+            attempt += 1
+        raise TimeoutError(f"timed out after {opts.timeout}: {status_message}")
+
+
+class CommandExecutionExecuteWaiter:
+    raw_response: Created
+    """raw_response is the raw response of the Execute call."""
+    _service: CommandExecutionAPI
+    _cluster_id: str
+    _command_id: str
+    _context_id: str
+
+    def __init__(
+        self, raw_response: Created, service: CommandExecutionAPI, cluster_id: str, command_id: str, context_id: str
+    ):
+        self._service = service
+        self.raw_response = raw_response
+        self._cluster_id = cluster_id
+        self._command_id = command_id
+        self._context_id = context_id
+
+    def WaitUntilDone(self, opts: Optional[WaitUntilDoneOptions] = None) -> CommandStatusResponse:
+        if opts is None:
+            opts = WaitUntilDoneOptions()
+        deadline = time.time() + opts.timeout.total_seconds()
+        target_states = (
+            CommandStatus.FINISHED,
+            CommandStatus.ERROR,
+        )
+        failure_states = (
+            CommandStatus.CANCELLED,
+            CommandStatus.CANCELLING,
+        )
+        status_message = "polling..."
+        attempt = 1
+        while time.time() < deadline:
+            poll = self._service.command_status(
+                cluster_id=self._cluster_id, command_id=self._command_id, context_id=self._context_id
+            )
+            status = poll.status
+            status_message = f"current status: {status}"
+            if status in target_states:
+                return poll
+            if status in failure_states:
+                msg = f"failed to reach Finished or Error, got {status}: {status_message}"
+                raise OperationFailed(msg)
+            prefix = f"cluster_id={self._cluster_id}, command_id={self._command_id}, context_id={self._context_id}"
+            sleep = attempt
+            if sleep > 10:
+                # sleep 10s max per attempt
+                sleep = 10
+            _LOG.debug(f"{prefix}: ({status}) {status_message} (sleeping ~{sleep}s)")
+            time.sleep(sleep + random.random())
+            attempt += 1
+        raise TimeoutError(f"timed out after {opts.timeout}: {status_message}")
+
+
 class CommandExecutionAPI:
     """This API allows execution of Python, Scala, SQL, or R commands on running Databricks Clusters. This API
     only supports (classic) all-purpose clusters. Serverless compute is not supported."""
@@ -11098,7 +11564,7 @@ class CommandExecutionAPI:
 
     def cancel(
         self, *, cluster_id: Optional[str] = None, command_id: Optional[str] = None, context_id: Optional[str] = None
-    ):
+    ) -> CommandExecutionCancelWaiter:
         """Cancel a command.
 
         Cancels a currently running command within an execution context.
@@ -11125,7 +11591,14 @@ class CommandExecutionAPI:
             "Content-Type": "application/json",
         }
 
-        self._api.do("POST", "/api/1.2/commands/cancel", body=body, headers=headers)
+        op_response = self._api.do("POST", "/api/1.2/commands/cancel", body=body, headers=headers)
+        return CommandExecutionCancelWaiter(
+            service=self,
+            response=CancelResponse.from_dict(op_response),
+            cluster_id=cluster_id,
+            command_id=command_id,
+            context_id=context_id,
+        )
 
     def command_status(self, cluster_id: str, context_id: str, command_id: str) -> CommandStatusResponse:
         """Get command info.
@@ -11178,7 +11651,9 @@ class CommandExecutionAPI:
         res = self._api.do("GET", "/api/1.2/contexts/status", query=query, headers=headers)
         return ContextStatusResponse.from_dict(res)
 
-    def create(self, *, cluster_id: Optional[str] = None, language: Optional[Language] = None) -> Created:
+    def create(
+        self, *, cluster_id: Optional[str] = None, language: Optional[Language] = None
+    ) -> CommandExecutionCreateWaiter:
         """Create an execution context.
 
         Creates an execution context for running cluster commands.
@@ -11203,8 +11678,10 @@ class CommandExecutionAPI:
             "Content-Type": "application/json",
         }
 
-        res = self._api.do("POST", "/api/1.2/contexts/create", body=body, headers=headers)
-        return Created.from_dict(res)
+        op_response = self._api.do("POST", "/api/1.2/contexts/create", body=body, headers=headers)
+        return CommandExecutionCreateWaiter(
+            service=self, response=Created.from_dict(op_response), cluster_id=cluster_id, context_id=op_response["id"]
+        )
 
     def destroy(self, cluster_id: str, context_id: str):
         """Delete an execution context.
@@ -11235,7 +11712,7 @@ class CommandExecutionAPI:
         command: Optional[str] = None,
         context_id: Optional[str] = None,
         language: Optional[Language] = None,
-    ) -> Created:
+    ) -> CommandExecutionExecuteWaiter:
         """Run a command.
 
         Runs a cluster command in the given execution context, using the provided language.
@@ -11268,8 +11745,14 @@ class CommandExecutionAPI:
             "Content-Type": "application/json",
         }
 
-        res = self._api.do("POST", "/api/1.2/commands/execute", body=body, headers=headers)
-        return Created.from_dict(res)
+        op_response = self._api.do("POST", "/api/1.2/commands/execute", body=body, headers=headers)
+        return CommandExecutionExecuteWaiter(
+            service=self,
+            response=Created.from_dict(op_response),
+            cluster_id=cluster_id,
+            command_id=op_response["id"],
+            context_id=context_id,
+        )
 
 
 class GlobalInitScriptsAPI:

--- a/databricks/sdk/dashboards/v2/dashboards.py
+++ b/databricks/sdk/dashboards/v2/dashboards.py
@@ -2773,7 +2773,7 @@ class GenieAPI:
         )
         return GenieCreateMessageWaiter(
             service=self,
-            response=GenieMessage.from_dict(op_response),
+            raw_response=GenieMessage.from_dict(op_response),
             conversation_id=conversation_id,
             message_id=op_response["id"],
             space_id=space_id,
@@ -3076,7 +3076,7 @@ class GenieAPI:
         )
         return GenieStartConversationWaiter(
             service=self,
-            response=GenieStartConversationResponse.from_dict(op_response),
+            raw_response=GenieStartConversationResponse.from_dict(op_response),
             conversation_id=op_response["conversation_id"],
             message_id=op_response["message_id"],
             space_id=space_id,

--- a/databricks/sdk/dashboards/v2/dashboards.py
+++ b/databricks/sdk/dashboards/v2/dashboards.py
@@ -1186,7 +1186,7 @@ class GenieResultMetadata:
 @dataclass
 class GenieSpace:
     space_id: str
-    """Space ID"""
+    """Genie space ID"""
 
     title: str
     """Title of the Genie Space"""
@@ -2843,15 +2843,14 @@ class GenieAPI:
     ) -> GenieGenerateDownloadFullQueryResultResponse:
         """Generate full query result download.
 
-        Initiate full SQL query result download and obtain a `download_id` to track the download progress.
-        This call initiates a new SQL execution to generate the query result. The result is stored in an
-        external link can be retrieved using the [Get Download Full Query
-        Result](:method:genie/getdownloadfullqueryresult) API. Warning: Databricks strongly recommends that
-        you protect the URLs that are returned by the `EXTERNAL_LINKS` disposition. See [Execute
-        Statement](:method:statementexecution/executestatement) for more details.
+        Initiates a new SQL execution and returns a `download_id` that you can use to track the progress of
+        the download. The query result is stored in an external link and can be retrieved using the [Get
+        Download Full Query Result](:method:genie/getdownloadfullqueryresult) API. Warning: Databricks
+        strongly recommends that you protect the URLs that are returned by the `EXTERNAL_LINKS` disposition.
+        See [Execute Statement](:method:statementexecution/executestatement) for more details.
 
         :param space_id: str
-          Space ID
+          Genie space ID
         :param conversation_id: str
           Conversation ID
         :param message_id: str
@@ -2879,17 +2878,15 @@ class GenieAPI:
         """Get download full query result.
 
         After [Generating a Full Query Result Download](:method:genie/getdownloadfullqueryresult) and
-        successfully receiving a `download_id`, use this API to Poll download progress and retrieve the SQL
-        query result external link(s) upon completion. Warning: Databricks strongly recommends that you
-        protect the URLs that are returned by the `EXTERNAL_LINKS` disposition. When you use the
-        `EXTERNAL_LINKS` disposition, a short-lived, presigned URL is generated, which can be used to download
-        the results directly from Amazon S3. As a short-lived access credential is embedded in this presigned
-        URL, you should protect the URL. Because presigned URLs are already generated with embedded temporary
-        access credentials, you must not set an Authorization header in the download requests. See [Execute
+        successfully receiving a `download_id`, use this API to poll the download progress. When the download
+        is complete, the API returns one or more external links to the query result files. Warning: Databricks
+        strongly recommends that you protect the URLs that are returned by the `EXTERNAL_LINKS` disposition.
+        You must not set an Authorization header in download requests. When using the `EXTERNAL_LINKS`
+        disposition, Databricks returns presigned URLs that grant temporary access to data. See [Execute
         Statement](:method:statementexecution/executestatement) for more details.
 
         :param space_id: str
-          Space ID
+          Genie space ID
         :param conversation_id: str
           Conversation ID
         :param message_id: str

--- a/databricks/sdk/dashboards/v2/dashboards.py
+++ b/databricks/sdk/dashboards/v2/dashboards.py
@@ -868,45 +868,27 @@ class GenieCreateConversationMessageRequest:
 
 @dataclass
 class GenieGenerateDownloadFullQueryResultResponse:
-    error: Optional[str] = None
-    """Error message if Genie failed to download the result"""
-
-    status: Optional[MessageStatus] = None
-    """Download result status"""
-
-    transient_statement_id: Optional[str] = None
-    """Transient Statement ID. Use this ID to track the download request in subsequent polling calls"""
+    download_id: Optional[str] = None
+    """Download ID. Use this ID to track the download request in subsequent polling calls"""
 
     def as_dict(self) -> dict:
         """Serializes the GenieGenerateDownloadFullQueryResultResponse into a dictionary suitable for use as a JSON request body."""
         body = {}
-        if self.error is not None:
-            body["error"] = self.error
-        if self.status is not None:
-            body["status"] = self.status.value
-        if self.transient_statement_id is not None:
-            body["transient_statement_id"] = self.transient_statement_id
+        if self.download_id is not None:
+            body["download_id"] = self.download_id
         return body
 
     def as_shallow_dict(self) -> dict:
         """Serializes the GenieGenerateDownloadFullQueryResultResponse into a shallow dictionary of its immediate attributes."""
         body = {}
-        if self.error is not None:
-            body["error"] = self.error
-        if self.status is not None:
-            body["status"] = self.status
-        if self.transient_statement_id is not None:
-            body["transient_statement_id"] = self.transient_statement_id
+        if self.download_id is not None:
+            body["download_id"] = self.download_id
         return body
 
     @classmethod
     def from_dict(cls, d: Dict[str, Any]) -> GenieGenerateDownloadFullQueryResultResponse:
         """Deserializes the GenieGenerateDownloadFullQueryResultResponse from a dictionary."""
-        return cls(
-            error=d.get("error", None),
-            status=_enum(d, "status", MessageStatus),
-            transient_statement_id=d.get("transient_statement_id", None),
-        )
+        return cls(download_id=d.get("download_id", None))
 
 
 @dataclass
@@ -915,16 +897,11 @@ class GenieGetDownloadFullQueryResultResponse:
     """SQL Statement Execution response. See [Get status, manifest, and result first
     chunk](:method:statementexecution/getstatement) for more details."""
 
-    transient_statement_id: Optional[str] = None
-    """Transient Statement ID"""
-
     def as_dict(self) -> dict:
         """Serializes the GenieGetDownloadFullQueryResultResponse into a dictionary suitable for use as a JSON request body."""
         body = {}
         if self.statement_response:
             body["statement_response"] = self.statement_response.as_dict()
-        if self.transient_statement_id is not None:
-            body["transient_statement_id"] = self.transient_statement_id
         return body
 
     def as_shallow_dict(self) -> dict:
@@ -932,17 +909,12 @@ class GenieGetDownloadFullQueryResultResponse:
         body = {}
         if self.statement_response:
             body["statement_response"] = self.statement_response
-        if self.transient_statement_id is not None:
-            body["transient_statement_id"] = self.transient_statement_id
         return body
 
     @classmethod
     def from_dict(cls, d: Dict[str, Any]) -> GenieGetDownloadFullQueryResultResponse:
         """Deserializes the GenieGetDownloadFullQueryResultResponse from a dictionary."""
-        return cls(
-            statement_response=_from_dict(d, "statement_response", StatementResponse),
-            transient_statement_id=d.get("transient_statement_id", None),
-        )
+        return cls(statement_response=_from_dict(d, "statement_response", StatementResponse))
 
 
 @dataclass
@@ -2758,7 +2730,7 @@ class GenieAPI:
     ) -> GenieGenerateDownloadFullQueryResultResponse:
         """Generate full query result download.
 
-        Initiate full SQL query result download and obtain a transient ID for tracking the download progress.
+        Initiate full SQL query result download and obtain a `download_id` to track the download progress.
         This call initiates a new SQL execution to generate the query result. The result is stored in an
         external link can be retrieved using the [Get Download Full Query
         Result](:method:genie/getdownloadfullqueryresult) API. Warning: Databricks strongly recommends that
@@ -2783,24 +2755,25 @@ class GenieAPI:
 
         res = self._api.do(
             "POST",
-            f"/api/2.0/genie/spaces/{space_id}/conversations/{conversation_id}/messages/{message_id}/attachments/{attachment_id}/generate-download",
+            f"/api/2.0/genie/spaces/{space_id}/conversations/{conversation_id}/messages/{message_id}/attachments/{attachment_id}/downloads",
             headers=headers,
         )
         return GenieGenerateDownloadFullQueryResultResponse.from_dict(res)
 
     def get_download_full_query_result(
-        self, space_id: str, conversation_id: str, message_id: str, attachment_id: str, transient_statement_id: str
+        self, space_id: str, conversation_id: str, message_id: str, attachment_id: str, download_id: str
     ) -> GenieGetDownloadFullQueryResultResponse:
-        """Get download full query result status.
+        """Get download full query result.
 
-        Poll download progress and retrieve the SQL query result external link(s) upon completion. Warning:
-        Databricks strongly recommends that you protect the URLs that are returned by the `EXTERNAL_LINKS`
-        disposition. When you use the `EXTERNAL_LINKS` disposition, a short-lived, presigned URL is generated,
-        which can be used to download the results directly from Amazon S3. As a short-lived access credential
-        is embedded in this presigned URL, you should protect the URL. Because presigned URLs are already
-        generated with embedded temporary access credentials, you must not set an Authorization header in the
-        download requests. See [Execute Statement](:method:statementexecution/executestatement) for more
-        details.
+        After [Generating a Full Query Result Download](:method:genie/getdownloadfullqueryresult) and
+        successfully receiving a `download_id`, use this API to Poll download progress and retrieve the SQL
+        query result external link(s) upon completion. Warning: Databricks strongly recommends that you
+        protect the URLs that are returned by the `EXTERNAL_LINKS` disposition. When you use the
+        `EXTERNAL_LINKS` disposition, a short-lived, presigned URL is generated, which can be used to download
+        the results directly from Amazon S3. As a short-lived access credential is embedded in this presigned
+        URL, you should protect the URL. Because presigned URLs are already generated with embedded temporary
+        access credentials, you must not set an Authorization header in the download requests. See [Execute
+        Statement](:method:statementexecution/executestatement) for more details.
 
         :param space_id: str
           Space ID
@@ -2810,24 +2783,20 @@ class GenieAPI:
           Message ID
         :param attachment_id: str
           Attachment ID
-        :param transient_statement_id: str
-          Transient Statement ID. This ID is provided by the [Start Download
-          endpoint](:method:genie/startdownloadfullqueryresult)
+        :param download_id: str
+          Download ID. This ID is provided by the [Generate Download
+          endpoint](:method:genie/generateDownloadFullQueryResult)
 
         :returns: :class:`GenieGetDownloadFullQueryResultResponse`
         """
 
-        query = {}
-        if transient_statement_id is not None:
-            query["transient_statement_id"] = transient_statement_id
         headers = {
             "Accept": "application/json",
         }
 
         res = self._api.do(
             "GET",
-            f"/api/2.0/genie/spaces/{space_id}/conversations/{conversation_id}/messages/{message_id}/attachments/{attachment_id}/get-download",
-            query=query,
+            f"/api/2.0/genie/spaces/{space_id}/conversations/{conversation_id}/messages/{message_id}/attachments/{attachment_id}/downloads/{download_id}",
             headers=headers,
         )
         return GenieGetDownloadFullQueryResultResponse.from_dict(res)

--- a/databricks/sdk/jobs/v2/jobs.py
+++ b/databricks/sdk/jobs/v2/jobs.py
@@ -3,11 +3,15 @@
 from __future__ import annotations
 
 import logging
+import random
+import time
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Dict, Iterator, List, Optional
 
-from ...service._internal import _enum, _from_dict, _repeated_dict
+from ...databricks.errors import OperationFailed
+from ...service._internal import (WaitUntilDoneOptions, _enum, _from_dict,
+                                  _repeated_dict)
 
 _LOG = logging.getLogger("databricks.sdk")
 
@@ -10510,6 +10514,182 @@ class WorkspaceStorageInfo:
         return cls(destination=d.get("destination", None))
 
 
+class JobsCancelRunWaiter:
+    raw_response: CancelRunResponse
+    """raw_response is the raw response of the CancelRun call."""
+    _service: JobsAPI
+    _run_id: int
+
+    def __init__(self, raw_response: CancelRunResponse, service: JobsAPI, run_id: int):
+        self._service = service
+        self.raw_response = raw_response
+        self._run_id = run_id
+
+    def WaitUntilDone(self, opts: Optional[WaitUntilDoneOptions] = None) -> Run:
+        if opts is None:
+            opts = WaitUntilDoneOptions()
+        deadline = time.time() + opts.timeout.total_seconds()
+        target_states = (
+            RunLifeCycleState.TERMINATED,
+            RunLifeCycleState.SKIPPED,
+        )
+        failure_states = (RunLifeCycleState.INTERNAL_ERROR,)
+        status_message = "polling..."
+        attempt = 1
+        while time.time() < deadline:
+            poll = self._service.get_run(run_id=self._run_id)
+            status = poll.state.life_cycle_state
+            status_message = f"current status: {status}"
+            if poll.state:
+                status_message = poll.state.state_message
+            if status in target_states:
+                return poll
+            if status in failure_states:
+                msg = f"failed to reach TERMINATED or SKIPPED, got {status}: {status_message}"
+                raise OperationFailed(msg)
+            prefix = f"run_id={self._run_id}"
+            sleep = attempt
+            if sleep > 10:
+                # sleep 10s max per attempt
+                sleep = 10
+            _LOG.debug(f"{prefix}: ({status}) {status_message} (sleeping ~{sleep}s)")
+            time.sleep(sleep + random.random())
+            attempt += 1
+        raise TimeoutError(f"timed out after {opts.timeout}: {status_message}")
+
+
+class JobsRepairRunWaiter:
+    raw_response: RepairRunResponse
+    """raw_response is the raw response of the RepairRun call."""
+    _service: JobsAPI
+    _run_id: int
+
+    def __init__(self, raw_response: RepairRunResponse, service: JobsAPI, run_id: int):
+        self._service = service
+        self.raw_response = raw_response
+        self._run_id = run_id
+
+    def WaitUntilDone(self, opts: Optional[WaitUntilDoneOptions] = None) -> Run:
+        if opts is None:
+            opts = WaitUntilDoneOptions()
+        deadline = time.time() + opts.timeout.total_seconds()
+        target_states = (
+            RunLifeCycleState.TERMINATED,
+            RunLifeCycleState.SKIPPED,
+        )
+        failure_states = (RunLifeCycleState.INTERNAL_ERROR,)
+        status_message = "polling..."
+        attempt = 1
+        while time.time() < deadline:
+            poll = self._service.get_run(run_id=self._run_id)
+            status = poll.state.life_cycle_state
+            status_message = f"current status: {status}"
+            if poll.state:
+                status_message = poll.state.state_message
+            if status in target_states:
+                return poll
+            if status in failure_states:
+                msg = f"failed to reach TERMINATED or SKIPPED, got {status}: {status_message}"
+                raise OperationFailed(msg)
+            prefix = f"run_id={self._run_id}"
+            sleep = attempt
+            if sleep > 10:
+                # sleep 10s max per attempt
+                sleep = 10
+            _LOG.debug(f"{prefix}: ({status}) {status_message} (sleeping ~{sleep}s)")
+            time.sleep(sleep + random.random())
+            attempt += 1
+        raise TimeoutError(f"timed out after {opts.timeout}: {status_message}")
+
+
+class JobsRunNowWaiter:
+    raw_response: RunNowResponse
+    """raw_response is the raw response of the RunNow call."""
+    _service: JobsAPI
+    _run_id: int
+
+    def __init__(self, raw_response: RunNowResponse, service: JobsAPI, run_id: int):
+        self._service = service
+        self.raw_response = raw_response
+        self._run_id = run_id
+
+    def WaitUntilDone(self, opts: Optional[WaitUntilDoneOptions] = None) -> Run:
+        if opts is None:
+            opts = WaitUntilDoneOptions()
+        deadline = time.time() + opts.timeout.total_seconds()
+        target_states = (
+            RunLifeCycleState.TERMINATED,
+            RunLifeCycleState.SKIPPED,
+        )
+        failure_states = (RunLifeCycleState.INTERNAL_ERROR,)
+        status_message = "polling..."
+        attempt = 1
+        while time.time() < deadline:
+            poll = self._service.get_run(run_id=self._run_id)
+            status = poll.state.life_cycle_state
+            status_message = f"current status: {status}"
+            if poll.state:
+                status_message = poll.state.state_message
+            if status in target_states:
+                return poll
+            if status in failure_states:
+                msg = f"failed to reach TERMINATED or SKIPPED, got {status}: {status_message}"
+                raise OperationFailed(msg)
+            prefix = f"run_id={self._run_id}"
+            sleep = attempt
+            if sleep > 10:
+                # sleep 10s max per attempt
+                sleep = 10
+            _LOG.debug(f"{prefix}: ({status}) {status_message} (sleeping ~{sleep}s)")
+            time.sleep(sleep + random.random())
+            attempt += 1
+        raise TimeoutError(f"timed out after {opts.timeout}: {status_message}")
+
+
+class JobsSubmitWaiter:
+    raw_response: SubmitRunResponse
+    """raw_response is the raw response of the Submit call."""
+    _service: JobsAPI
+    _run_id: int
+
+    def __init__(self, raw_response: SubmitRunResponse, service: JobsAPI, run_id: int):
+        self._service = service
+        self.raw_response = raw_response
+        self._run_id = run_id
+
+    def WaitUntilDone(self, opts: Optional[WaitUntilDoneOptions] = None) -> Run:
+        if opts is None:
+            opts = WaitUntilDoneOptions()
+        deadline = time.time() + opts.timeout.total_seconds()
+        target_states = (
+            RunLifeCycleState.TERMINATED,
+            RunLifeCycleState.SKIPPED,
+        )
+        failure_states = (RunLifeCycleState.INTERNAL_ERROR,)
+        status_message = "polling..."
+        attempt = 1
+        while time.time() < deadline:
+            poll = self._service.get_run(run_id=self._run_id)
+            status = poll.state.life_cycle_state
+            status_message = f"current status: {status}"
+            if poll.state:
+                status_message = poll.state.state_message
+            if status in target_states:
+                return poll
+            if status in failure_states:
+                msg = f"failed to reach TERMINATED or SKIPPED, got {status}: {status_message}"
+                raise OperationFailed(msg)
+            prefix = f"run_id={self._run_id}"
+            sleep = attempt
+            if sleep > 10:
+                # sleep 10s max per attempt
+                sleep = 10
+            _LOG.debug(f"{prefix}: ({status}) {status_message} (sleeping ~{sleep}s)")
+            time.sleep(sleep + random.random())
+            attempt += 1
+        raise TimeoutError(f"timed out after {opts.timeout}: {status_message}")
+
+
 class JobsAPI:
     """The Jobs API allows you to create, edit, and delete jobs.
 
@@ -10555,7 +10735,7 @@ class JobsAPI:
 
         self._api.do("POST", "/api/2.2/jobs/runs/cancel-all", body=body, headers=headers)
 
-    def cancel_run(self, run_id: int):
+    def cancel_run(self, run_id: int) -> JobsCancelRunWaiter:
         """Cancel a run.
 
         Cancels a job run or a task run. The run is canceled asynchronously, so it may still be running when
@@ -10575,7 +10755,8 @@ class JobsAPI:
             "Content-Type": "application/json",
         }
 
-        self._api.do("POST", "/api/2.2/jobs/runs/cancel", body=body, headers=headers)
+        op_response = self._api.do("POST", "/api/2.2/jobs/runs/cancel", body=body, headers=headers)
+        return JobsCancelRunWaiter(service=self, response=CancelRunResponse.from_dict(op_response), run_id=run_id)
 
     def create(
         self,
@@ -11131,7 +11312,7 @@ class JobsAPI:
         rerun_tasks: Optional[List[str]] = None,
         spark_submit_params: Optional[List[str]] = None,
         sql_params: Optional[Dict[str, str]] = None,
-    ) -> RepairRunResponse:
+    ) -> JobsRepairRunWaiter:
         """Repair a job run.
 
         Re-run one or more tasks. Tasks are re-run as part of the original job run. They use the current job
@@ -11256,8 +11437,8 @@ class JobsAPI:
             "Content-Type": "application/json",
         }
 
-        res = self._api.do("POST", "/api/2.2/jobs/runs/repair", body=body, headers=headers)
-        return RepairRunResponse.from_dict(res)
+        op_response = self._api.do("POST", "/api/2.2/jobs/runs/repair", body=body, headers=headers)
+        return JobsRepairRunWaiter(service=self, response=RepairRunResponse.from_dict(op_response), run_id=run_id)
 
     def reset(self, job_id: int, new_settings: JobSettings):
         """Update all job settings (reset).
@@ -11303,7 +11484,7 @@ class JobsAPI:
         queue: Optional[QueueSettings] = None,
         spark_submit_params: Optional[List[str]] = None,
         sql_params: Optional[Dict[str, str]] = None,
-    ) -> RunNowResponse:
+    ) -> JobsRunNowWaiter:
         """Trigger a new job run.
 
         Run a job and return the `run_id` of the triggered run.
@@ -11443,8 +11624,10 @@ class JobsAPI:
             "Content-Type": "application/json",
         }
 
-        res = self._api.do("POST", "/api/2.2/jobs/run-now", body=body, headers=headers)
-        return RunNowResponse.from_dict(res)
+        op_response = self._api.do("POST", "/api/2.2/jobs/run-now", body=body, headers=headers)
+        return JobsRunNowWaiter(
+            service=self, response=RunNowResponse.from_dict(op_response), run_id=op_response["run_id"]
+        )
 
     def set_permissions(
         self, job_id: str, *, access_control_list: Optional[List[JobAccessControlRequest]] = None
@@ -11488,7 +11671,7 @@ class JobsAPI:
         tasks: Optional[List[SubmitTask]] = None,
         timeout_seconds: Optional[int] = None,
         webhook_notifications: Optional[WebhookNotifications] = None,
-    ) -> SubmitRunResponse:
+    ) -> JobsSubmitWaiter:
         """Create and trigger a one-time run.
 
         Submit a one-time run. This endpoint allows you to submit a workload directly without creating a job.
@@ -11582,8 +11765,10 @@ class JobsAPI:
             "Content-Type": "application/json",
         }
 
-        res = self._api.do("POST", "/api/2.2/jobs/runs/submit", body=body, headers=headers)
-        return SubmitRunResponse.from_dict(res)
+        op_response = self._api.do("POST", "/api/2.2/jobs/runs/submit", body=body, headers=headers)
+        return JobsSubmitWaiter(
+            service=self, response=SubmitRunResponse.from_dict(op_response), run_id=op_response["run_id"]
+        )
 
     def update(
         self, job_id: int, *, fields_to_remove: Optional[List[str]] = None, new_settings: Optional[JobSettings] = None

--- a/databricks/sdk/jobs/v2/jobs.py
+++ b/databricks/sdk/jobs/v2/jobs.py
@@ -864,10 +864,11 @@ class CleanRoomTaskRunState:
 
     life_cycle_state: Optional[CleanRoomTaskRunLifeCycleState] = None
     """A value indicating the run's current lifecycle state. This field is always available in the
-    response."""
+    response. Note: Additional states might be introduced in future releases."""
 
     result_state: Optional[CleanRoomTaskRunResultState] = None
-    """A value indicating the run's result. This field is only available for terminal lifecycle states."""
+    """A value indicating the run's result. This field is only available for terminal lifecycle states.
+    Note: Additional states might be introduced in future releases."""
 
     def as_dict(self) -> dict:
         """Serializes the CleanRoomTaskRunState into a dictionary suitable for use as a JSON request body."""
@@ -1692,11 +1693,14 @@ class DashboardTask:
     """Configures the Lakeview Dashboard job task type."""
 
     dashboard_id: Optional[str] = None
+    """The identifier of the dashboard to refresh."""
 
     subscription: Optional[Subscription] = None
+    """Optional: subscription configuration for sending the dashboard snapshot."""
 
     warehouse_id: Optional[str] = None
-    """The warehouse id to execute the dashboard with for the schedule"""
+    """Optional: The warehouse id to execute the dashboard with for the schedule. If not specified, the
+    default warehouse of the dashboard will be used."""
 
     def as_dict(self) -> dict:
         """Serializes the DashboardTask into a dictionary suitable for use as a JSON request body."""
@@ -5572,6 +5576,15 @@ class RCranLibrary:
 
 @dataclass
 class RepairHistoryItem:
+    effective_performance_target: Optional[PerformanceTarget] = None
+    """The actual performance target used by the serverless run during execution. This can differ from
+    the client-set performance target on the request depending on whether the performance mode is
+    supported by the job type.
+    
+    * `STANDARD`: Enables cost-efficient execution of serverless workloads. *
+    `PERFORMANCE_OPTIMIZED`: Prioritizes fast startup and execution times through rapid scaling and
+    optimized cluster performance."""
+
     end_time: Optional[int] = None
     """The end time of the (repaired) run."""
 
@@ -5596,6 +5609,8 @@ class RepairHistoryItem:
     def as_dict(self) -> dict:
         """Serializes the RepairHistoryItem into a dictionary suitable for use as a JSON request body."""
         body = {}
+        if self.effective_performance_target is not None:
+            body["effective_performance_target"] = self.effective_performance_target.value
         if self.end_time is not None:
             body["end_time"] = self.end_time
         if self.id is not None:
@@ -5615,6 +5630,8 @@ class RepairHistoryItem:
     def as_shallow_dict(self) -> dict:
         """Serializes the RepairHistoryItem into a shallow dictionary of its immediate attributes."""
         body = {}
+        if self.effective_performance_target is not None:
+            body["effective_performance_target"] = self.effective_performance_target
         if self.end_time is not None:
             body["end_time"] = self.end_time
         if self.id is not None:
@@ -5635,6 +5652,7 @@ class RepairHistoryItem:
     def from_dict(cls, d: Dict[str, Any]) -> RepairHistoryItem:
         """Deserializes the RepairHistoryItem from a dictionary."""
         return cls(
+            effective_performance_target=_enum(d, "effective_performance_target", PerformanceTarget),
             end_time=d.get("end_time", None),
             id=d.get("id", None),
             start_time=d.get("start_time", None),
@@ -5695,6 +5713,15 @@ class RepairRun:
     
     [Task parameter variables]: https://docs.databricks.com/jobs.html#parameter-variables
     [dbutils.widgets.get]: https://docs.databricks.com/dev-tools/databricks-utils.html"""
+
+    performance_target: Optional[PerformanceTarget] = None
+    """The performance mode on a serverless job. The performance target determines the level of compute
+    performance or cost-efficiency for the run. This field overrides the performance target defined
+    on the job level.
+    
+    * `STANDARD`: Enables cost-efficient execution of serverless workloads. *
+    `PERFORMANCE_OPTIMIZED`: Prioritizes fast startup and execution times through rapid scaling and
+    optimized cluster performance."""
 
     pipeline_params: Optional[PipelineParams] = None
     """Controls whether the pipeline should perform a full refresh"""
@@ -5762,6 +5789,8 @@ class RepairRun:
             body["latest_repair_id"] = self.latest_repair_id
         if self.notebook_params:
             body["notebook_params"] = self.notebook_params
+        if self.performance_target is not None:
+            body["performance_target"] = self.performance_target.value
         if self.pipeline_params:
             body["pipeline_params"] = self.pipeline_params.as_dict()
         if self.python_named_params:
@@ -5795,6 +5824,8 @@ class RepairRun:
             body["latest_repair_id"] = self.latest_repair_id
         if self.notebook_params:
             body["notebook_params"] = self.notebook_params
+        if self.performance_target is not None:
+            body["performance_target"] = self.performance_target
         if self.pipeline_params:
             body["pipeline_params"] = self.pipeline_params
         if self.python_named_params:
@@ -5824,6 +5855,7 @@ class RepairRun:
             job_parameters=d.get("job_parameters", None),
             latest_repair_id=d.get("latest_repair_id", None),
             notebook_params=d.get("notebook_params", None),
+            performance_target=_enum(d, "performance_target", PerformanceTarget),
             pipeline_params=_from_dict(d, "pipeline_params", PipelineParams),
             python_named_params=d.get("python_named_params", None),
             python_params=d.get("python_params", None),
@@ -7418,13 +7450,14 @@ class RunState:
 
     life_cycle_state: Optional[RunLifeCycleState] = None
     """A value indicating the run's current lifecycle state. This field is always available in the
-    response."""
+    response. Note: Additional states might be introduced in future releases."""
 
     queue_reason: Optional[str] = None
     """The reason indicating why the run was queued."""
 
     result_state: Optional[RunResultState] = None
-    """A value indicating the run's result. This field is only available for terminal lifecycle states."""
+    """A value indicating the run's result. This field is only available for terminal lifecycle states.
+    Note: Additional states might be introduced in future releases."""
 
     state_message: Optional[str] = None
     """A descriptive message for the current state. This field is unstructured, and its exact format is
@@ -7559,7 +7592,7 @@ class RunTask:
     does not support retries or notifications."""
 
     dashboard_task: Optional[DashboardTask] = None
-    """The task runs a DashboardTask when the `dashboard_task` field is present."""
+    """The task refreshes a dashboard and sends a snapshot to subscribers."""
 
     dbt_task: Optional[DbtTask] = None
     """The task runs one or more dbt commands when the `dbt_task` field is present. The dbt task
@@ -9043,7 +9076,7 @@ class SubmitTask:
     does not support retries or notifications."""
 
     dashboard_task: Optional[DashboardTask] = None
-    """The task runs a DashboardTask when the `dashboard_task` field is present."""
+    """The task refreshes a dashboard and sends a snapshot to subscribers."""
 
     dbt_task: Optional[DbtTask] = None
     """The task runs one or more dbt commands when the `dbt_task` field is present. The dbt task
@@ -9312,6 +9345,7 @@ class Subscription:
     """When true, the subscription will not send emails."""
 
     subscribers: Optional[List[SubscriptionSubscriber]] = None
+    """The list of subscribers to send the snapshot of the dashboard to."""
 
     def as_dict(self) -> dict:
         """Serializes the Subscription into a dictionary suitable for use as a JSON request body."""
@@ -9348,8 +9382,12 @@ class Subscription:
 @dataclass
 class SubscriptionSubscriber:
     destination_id: Optional[str] = None
+    """A snapshot of the dashboard will be sent to the destination when the `destination_id` field is
+    present."""
 
     user_name: Optional[str] = None
+    """A snapshot of the dashboard will be sent to the user's email when the `user_name` field is
+    present."""
 
     def as_dict(self) -> dict:
         """Serializes the SubscriptionSubscriber into a dictionary suitable for use as a JSON request body."""
@@ -9448,7 +9486,7 @@ class Task:
     does not support retries or notifications."""
 
     dashboard_task: Optional[DashboardTask] = None
-    """The task runs a DashboardTask when the `dashboard_task` field is present."""
+    """The task refreshes a dashboard and sends a snapshot to subscribers."""
 
     dbt_task: Optional[DbtTask] = None
     """The task runs one or more dbt commands when the `dbt_task` field is present. The dbt task
@@ -9953,7 +9991,7 @@ class TerminationCodeCode(Enum):
     invalid configuration. Refer to the state message for further details. * `CLOUD_FAILURE`: The
     run failed due to a cloud provider issue. Refer to the state message for further details. *
     `MAX_JOB_QUEUE_SIZE_EXCEEDED`: The run was skipped due to reaching the job level queue size
-    limit.
+    limit. * `DISABLED`: The run was never executed because it was disabled explicitly by the user.
 
     [Link]: https://kb.databricks.com/en_US/notebooks/too-many-execution-contexts-are-open-right-now"""
 
@@ -9962,6 +10000,7 @@ class TerminationCodeCode(Enum):
     CLOUD_FAILURE = "CLOUD_FAILURE"
     CLUSTER_ERROR = "CLUSTER_ERROR"
     CLUSTER_REQUEST_LIMIT_EXCEEDED = "CLUSTER_REQUEST_LIMIT_EXCEEDED"
+    DISABLED = "DISABLED"
     DRIVER_ERROR = "DRIVER_ERROR"
     FEATURE_DISABLED = "FEATURE_DISABLED"
     INTERNAL_ERROR = "INTERNAL_ERROR"
@@ -10017,7 +10056,7 @@ class TerminationDetails:
     invalid configuration. Refer to the state message for further details. * `CLOUD_FAILURE`: The
     run failed due to a cloud provider issue. Refer to the state message for further details. *
     `MAX_JOB_QUEUE_SIZE_EXCEEDED`: The run was skipped due to reaching the job level queue size
-    limit.
+    limit. * `DISABLED`: The run was never executed because it was disabled explicitly by the user.
     
     [Link]: https://kb.databricks.com/en_US/notebooks/too-many-execution-contexts-are-open-right-now"""
 
@@ -11304,6 +11343,7 @@ class JobsAPI:
         job_parameters: Optional[Dict[str, str]] = None,
         latest_repair_id: Optional[int] = None,
         notebook_params: Optional[Dict[str, str]] = None,
+        performance_target: Optional[PerformanceTarget] = None,
         pipeline_params: Optional[PipelineParams] = None,
         python_named_params: Optional[Dict[str, str]] = None,
         python_params: Optional[List[str]] = None,
@@ -11354,6 +11394,14 @@ class JobsAPI:
 
           [Task parameter variables]: https://docs.databricks.com/jobs.html#parameter-variables
           [dbutils.widgets.get]: https://docs.databricks.com/dev-tools/databricks-utils.html
+        :param performance_target: :class:`PerformanceTarget` (optional)
+          The performance mode on a serverless job. The performance target determines the level of compute
+          performance or cost-efficiency for the run. This field overrides the performance target defined on
+          the job level.
+
+          * `STANDARD`: Enables cost-efficient execution of serverless workloads. * `PERFORMANCE_OPTIMIZED`:
+          Prioritizes fast startup and execution times through rapid scaling and optimized cluster
+          performance.
         :param pipeline_params: :class:`PipelineParams` (optional)
           Controls whether the pipeline should perform a full refresh
         :param python_named_params: Dict[str,str] (optional)
@@ -11414,6 +11462,8 @@ class JobsAPI:
             body["latest_repair_id"] = latest_repair_id
         if notebook_params is not None:
             body["notebook_params"] = notebook_params
+        if performance_target is not None:
+            body["performance_target"] = performance_target.value
         if pipeline_params is not None:
             body["pipeline_params"] = pipeline_params.as_dict()
         if python_named_params is not None:

--- a/databricks/sdk/jobs/v2/jobs.py
+++ b/databricks/sdk/jobs/v2/jobs.py
@@ -417,7 +417,11 @@ class BaseRun:
     effective_performance_target: Optional[PerformanceTarget] = None
     """The actual performance target used by the serverless run during execution. This can differ from
     the client-set performance target on the request depending on whether the performance mode is
-    supported by the job type."""
+    supported by the job type.
+    
+    * `STANDARD`: Enables cost-efficient execution of serverless workloads. *
+    `PERFORMANCE_OPTIMIZED`: Prioritizes fast startup and execution times through rapid scaling and
+    optimized cluster performance."""
 
     end_time: Optional[int] = None
     """The time at which this run ended in epoch milliseconds (milliseconds since 1/1/1970 UTC). This
@@ -1362,8 +1366,7 @@ class CreateJob:
     job_clusters: Optional[List[JobCluster]] = None
     """A list of job cluster specifications that can be shared and reused by tasks of this job.
     Libraries cannot be declared in a shared job cluster. You must declare dependent libraries in
-    task settings. If more than 100 job clusters are available, you can paginate through them using
-    :method:jobs/get."""
+    task settings."""
 
     max_concurrent_runs: Optional[int] = None
     """An optional maximum allowed number of concurrent runs of the job. Set this value if you want to
@@ -1387,7 +1390,11 @@ class CreateJob:
 
     performance_target: Optional[PerformanceTarget] = None
     """The performance mode on a serverless job. The performance target determines the level of compute
-    performance or cost-efficiency for the run."""
+    performance or cost-efficiency for the run.
+    
+    * `STANDARD`: Enables cost-efficient execution of serverless workloads. *
+    `PERFORMANCE_OPTIMIZED`: Prioritizes fast startup and execution times through rapid scaling and
+    optimized cluster performance."""
 
     queue: Optional[QueueSettings] = None
     """The queue settings of the job."""
@@ -1408,9 +1415,11 @@ class CreateJob:
     be added to the job."""
 
     tasks: Optional[List[Task]] = None
-    """A list of task specifications to be executed by this job. If more than 100 tasks are available,
-    you can paginate through them using :method:jobs/get. Use the `next_page_token` field at the
-    object root to determine if more results are available."""
+    """A list of task specifications to be executed by this job. It supports up to 1000 elements in
+    write endpoints (:method:jobs/create, :method:jobs/reset, :method:jobs/update,
+    :method:jobs/submit). Read endpoints return only 100 tasks. If more than 100 tasks are
+    available, you can paginate through them using :method:jobs/get. Use the `next_page_token` field
+    at the object root to determine if more results are available."""
 
     timeout_seconds: Optional[int] = None
     """An optional timeout applied to each run of this job. A value of `0` means no timeout."""
@@ -3837,8 +3846,7 @@ class JobSettings:
     job_clusters: Optional[List[JobCluster]] = None
     """A list of job cluster specifications that can be shared and reused by tasks of this job.
     Libraries cannot be declared in a shared job cluster. You must declare dependent libraries in
-    task settings. If more than 100 job clusters are available, you can paginate through them using
-    :method:jobs/get."""
+    task settings."""
 
     max_concurrent_runs: Optional[int] = None
     """An optional maximum allowed number of concurrent runs of the job. Set this value if you want to
@@ -3862,7 +3870,11 @@ class JobSettings:
 
     performance_target: Optional[PerformanceTarget] = None
     """The performance mode on a serverless job. The performance target determines the level of compute
-    performance or cost-efficiency for the run."""
+    performance or cost-efficiency for the run.
+    
+    * `STANDARD`: Enables cost-efficient execution of serverless workloads. *
+    `PERFORMANCE_OPTIMIZED`: Prioritizes fast startup and execution times through rapid scaling and
+    optimized cluster performance."""
 
     queue: Optional[QueueSettings] = None
     """The queue settings of the job."""
@@ -3883,9 +3895,11 @@ class JobSettings:
     be added to the job."""
 
     tasks: Optional[List[Task]] = None
-    """A list of task specifications to be executed by this job. If more than 100 tasks are available,
-    you can paginate through them using :method:jobs/get. Use the `next_page_token` field at the
-    object root to determine if more results are available."""
+    """A list of task specifications to be executed by this job. It supports up to 1000 elements in
+    write endpoints (:method:jobs/create, :method:jobs/reset, :method:jobs/update,
+    :method:jobs/submit). Read endpoints return only 100 tasks. If more than 100 tasks are
+    available, you can paginate through them using :method:jobs/get. Use the `next_page_token` field
+    at the object root to determine if more results are available."""
 
     timeout_seconds: Optional[int] = None
     """An optional timeout applied to each run of this job. A value of `0` means no timeout."""
@@ -5090,7 +5104,6 @@ class PerformanceTarget(Enum):
     on serverless compute should be. The performance mode on the job or pipeline should map to a
     performance setting that is passed to Cluster Manager (see cluster-common PerformanceTarget)."""
 
-    COST_OPTIMIZED = "COST_OPTIMIZED"
     PERFORMANCE_OPTIMIZED = "PERFORMANCE_OPTIMIZED"
     STANDARD = "STANDARD"
 
@@ -6209,7 +6222,11 @@ class Run:
     effective_performance_target: Optional[PerformanceTarget] = None
     """The actual performance target used by the serverless run during execution. This can differ from
     the client-set performance target on the request depending on whether the performance mode is
-    supported by the job type."""
+    supported by the job type.
+    
+    * `STANDARD`: Enables cost-efficient execution of serverless workloads. *
+    `PERFORMANCE_OPTIMIZED`: Prioritizes fast startup and execution times through rapid scaling and
+    optimized cluster performance."""
 
     end_time: Optional[int] = None
     """The time at which this run ended in epoch milliseconds (milliseconds since 1/1/1970 UTC). This
@@ -6933,7 +6950,11 @@ class RunNow:
     performance_target: Optional[PerformanceTarget] = None
     """The performance mode on a serverless job. The performance target determines the level of compute
     performance or cost-efficiency for the run. This field overrides the performance target defined
-    on the job-level."""
+    on the job level.
+    
+    * `STANDARD`: Enables cost-efficient execution of serverless workloads. *
+    `PERFORMANCE_OPTIMIZED`: Prioritizes fast startup and execution times through rapid scaling and
+    optimized cluster performance."""
 
     pipeline_params: Optional[PipelineParams] = None
     """Controls whether the pipeline should perform a full refresh"""
@@ -7554,7 +7575,11 @@ class RunTask:
     effective_performance_target: Optional[PerformanceTarget] = None
     """The actual performance target used by the serverless run during execution. This can differ from
     the client-set performance target on the request depending on whether the performance mode is
-    supported by the job type."""
+    supported by the job type.
+    
+    * `STANDARD`: Enables cost-efficient execution of serverless workloads. *
+    `PERFORMANCE_OPTIMIZED`: Prioritizes fast startup and execution times through rapid scaling and
+    optimized cluster performance."""
 
     email_notifications: Optional[JobEmailNotifications] = None
     """An optional set of email addresses notified when the task run begins or completes. The default
@@ -9054,7 +9079,7 @@ class SubmitTask:
     """An optional list of libraries to be installed on the cluster. The default value is an empty
     list."""
 
-    new_cluster: Optional[JobsClusterSpec] = None
+    new_cluster: Optional[ClusterSpec] = None
     """If new_cluster, a description of a new cluster that is created for each run."""
 
     notebook_task: Optional[NotebookTask] = None
@@ -9256,7 +9281,7 @@ class SubmitTask:
             gen_ai_compute_task=_from_dict(d, "gen_ai_compute_task", GenAiComputeTask),
             health=_from_dict(d, "health", JobsHealthRules),
             libraries=_repeated_dict(d, "libraries", Library),
-            new_cluster=_from_dict(d, "new_cluster", JobsClusterSpec),
+            new_cluster=_from_dict(d, "new_cluster", ClusterSpec),
             notebook_task=_from_dict(d, "notebook_task", NotebookTask),
             notification_settings=_from_dict(d, "notification_settings", TaskNotificationSettings),
             pipeline_task=_from_dict(d, "pipeline_task", PipelineTask),
@@ -10628,7 +10653,6 @@ class JobsAPI:
         :param job_clusters: List[:class:`JobCluster`] (optional)
           A list of job cluster specifications that can be shared and reused by tasks of this job. Libraries
           cannot be declared in a shared job cluster. You must declare dependent libraries in task settings.
-          If more than 100 job clusters are available, you can paginate through them using :method:jobs/get.
         :param max_concurrent_runs: int (optional)
           An optional maximum allowed number of concurrent runs of the job. Set this value if you want to be
           able to execute multiple runs of the same job concurrently. This is useful for example if you
@@ -10648,6 +10672,10 @@ class JobsAPI:
         :param performance_target: :class:`PerformanceTarget` (optional)
           The performance mode on a serverless job. The performance target determines the level of compute
           performance or cost-efficiency for the run.
+
+          * `STANDARD`: Enables cost-efficient execution of serverless workloads. * `PERFORMANCE_OPTIMIZED`:
+          Prioritizes fast startup and execution times through rapid scaling and optimized cluster
+          performance.
         :param queue: :class:`QueueSettings` (optional)
           The queue settings of the job.
         :param run_as: :class:`JobRunAs` (optional)
@@ -10663,9 +10691,11 @@ class JobsAPI:
           clusters, and are subject to the same limitations as cluster tags. A maximum of 25 tags can be added
           to the job.
         :param tasks: List[:class:`Task`] (optional)
-          A list of task specifications to be executed by this job. If more than 100 tasks are available, you
-          can paginate through them using :method:jobs/get. Use the `next_page_token` field at the object root
-          to determine if more results are available.
+          A list of task specifications to be executed by this job. It supports up to 1000 elements in write
+          endpoints (:method:jobs/create, :method:jobs/reset, :method:jobs/update, :method:jobs/submit). Read
+          endpoints return only 100 tasks. If more than 100 tasks are available, you can paginate through them
+          using :method:jobs/get. Use the `next_page_token` field at the object root to determine if more
+          results are available.
         :param timeout_seconds: int (optional)
           An optional timeout applied to each run of this job. A value of `0` means no timeout.
         :param trigger: :class:`TriggerSettings` (optional)
@@ -10958,8 +10988,8 @@ class JobsAPI:
         Retrieves a list of jobs.
 
         :param expand_tasks: bool (optional)
-          Whether to include task and cluster details in the response. Note that in API 2.2, only the first
-          100 elements will be shown. Use :method:jobs/get to paginate through all tasks and clusters.
+          Whether to include task and cluster details in the response. Note that only the first 100 elements
+          will be shown. Use :method:jobs/get to paginate through all tasks and clusters.
         :param limit: int (optional)
           The number of jobs to return. This value must be greater than 0 and less or equal to 100. The
           default value is 20.
@@ -11025,8 +11055,8 @@ class JobsAPI:
           If completed_only is `true`, only completed runs are included in the results; otherwise, lists both
           active and completed runs. This field cannot be `true` when active_only is `true`.
         :param expand_tasks: bool (optional)
-          Whether to include task and cluster details in the response. Note that in API 2.2, only the first
-          100 elements will be shown. Use :method:jobs/getrun to paginate through all tasks and clusters.
+          Whether to include task and cluster details in the response. Note that only the first 100 elements
+          will be shown. Use :method:jobs/getrun to paginate through all tasks and clusters.
         :param job_id: int (optional)
           The job for which to list runs. If omitted, the Jobs service lists runs from all jobs.
         :param limit: int (optional)
@@ -11330,7 +11360,11 @@ class JobsAPI:
         :param performance_target: :class:`PerformanceTarget` (optional)
           The performance mode on a serverless job. The performance target determines the level of compute
           performance or cost-efficiency for the run. This field overrides the performance target defined on
-          the job-level.
+          the job level.
+
+          * `STANDARD`: Enables cost-efficient execution of serverless workloads. * `PERFORMANCE_OPTIMIZED`:
+          Prioritizes fast startup and execution times through rapid scaling and optimized cluster
+          performance.
         :param pipeline_params: :class:`PipelineParams` (optional)
           Controls whether the pipeline should perform a full refresh
         :param python_named_params: Dict[str,str] (optional)

--- a/databricks/sdk/jobs/v2/jobs.py
+++ b/databricks/sdk/jobs/v2/jobs.py
@@ -10756,7 +10756,7 @@ class JobsAPI:
         }
 
         op_response = self._api.do("POST", "/api/2.2/jobs/runs/cancel", body=body, headers=headers)
-        return JobsCancelRunWaiter(service=self, response=CancelRunResponse.from_dict(op_response), run_id=run_id)
+        return JobsCancelRunWaiter(service=self, raw_response=CancelRunResponse.from_dict(op_response), run_id=run_id)
 
     def create(
         self,
@@ -11438,7 +11438,7 @@ class JobsAPI:
         }
 
         op_response = self._api.do("POST", "/api/2.2/jobs/runs/repair", body=body, headers=headers)
-        return JobsRepairRunWaiter(service=self, response=RepairRunResponse.from_dict(op_response), run_id=run_id)
+        return JobsRepairRunWaiter(service=self, raw_response=RepairRunResponse.from_dict(op_response), run_id=run_id)
 
     def reset(self, job_id: int, new_settings: JobSettings):
         """Update all job settings (reset).
@@ -11626,7 +11626,7 @@ class JobsAPI:
 
         op_response = self._api.do("POST", "/api/2.2/jobs/run-now", body=body, headers=headers)
         return JobsRunNowWaiter(
-            service=self, response=RunNowResponse.from_dict(op_response), run_id=op_response["run_id"]
+            service=self, raw_response=RunNowResponse.from_dict(op_response), run_id=op_response["run_id"]
         )
 
     def set_permissions(
@@ -11767,7 +11767,7 @@ class JobsAPI:
 
         op_response = self._api.do("POST", "/api/2.2/jobs/runs/submit", body=body, headers=headers)
         return JobsSubmitWaiter(
-            service=self, response=SubmitRunResponse.from_dict(op_response), run_id=op_response["run_id"]
+            service=self, raw_response=SubmitRunResponse.from_dict(op_response), run_id=op_response["run_id"]
         )
 
     def update(

--- a/databricks/sdk/ml/v2/ml.py
+++ b/databricks/sdk/ml/v2/ml.py
@@ -7433,7 +7433,7 @@ class ForecastingAPI:
         op_response = self._api.do("POST", "/api/2.0/automl/create-forecasting-experiment", body=body, headers=headers)
         return ForecastingCreateExperimentWaiter(
             service=self,
-            response=CreateForecastingExperimentResponse.from_dict(op_response),
+            raw_response=CreateForecastingExperimentResponse.from_dict(op_response),
             experiment_id=op_response["experiment_id"],
         )
 

--- a/databricks/sdk/ml/v2/ml.py
+++ b/databricks/sdk/ml/v2/ml.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 import logging
+import random
+import time
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Dict, Iterator, List, Optional
 
-from ...service._internal import (_enum, _from_dict, _repeated_dict,
-                                  _repeated_enum)
+from ...databricks.errors import OperationFailed
+from ...service._internal import (WaitUntilDoneOptions, _enum, _from_dict,
+                                  _repeated_dict, _repeated_enum)
 
 _LOG = logging.getLogger("databricks.sdk")
 
@@ -7267,6 +7270,48 @@ class ExperimentsAPI:
         return UpdateRunResponse.from_dict(res)
 
 
+class ForecastingCreateExperimentWaiter:
+    raw_response: CreateForecastingExperimentResponse
+    """raw_response is the raw response of the CreateExperiment call."""
+    _service: ForecastingAPI
+    _experiment_id: str
+
+    def __init__(self, raw_response: CreateForecastingExperimentResponse, service: ForecastingAPI, experiment_id: str):
+        self._service = service
+        self.raw_response = raw_response
+        self._experiment_id = experiment_id
+
+    def WaitUntilDone(self, opts: Optional[WaitUntilDoneOptions] = None) -> ForecastingExperiment:
+        if opts is None:
+            opts = WaitUntilDoneOptions()
+        deadline = time.time() + opts.timeout.total_seconds()
+        target_states = (ForecastingExperimentState.SUCCEEDED,)
+        failure_states = (
+            ForecastingExperimentState.FAILED,
+            ForecastingExperimentState.CANCELLED,
+        )
+        status_message = "polling..."
+        attempt = 1
+        while time.time() < deadline:
+            poll = self._service.get_experiment(experiment_id=self._experiment_id)
+            status = poll.state
+            status_message = f"current status: {status}"
+            if status in target_states:
+                return poll
+            if status in failure_states:
+                msg = f"failed to reach SUCCEEDED, got {status}: {status_message}"
+                raise OperationFailed(msg)
+            prefix = f"experiment_id={self._experiment_id}"
+            sleep = attempt
+            if sleep > 10:
+                # sleep 10s max per attempt
+                sleep = 10
+            _LOG.debug(f"{prefix}: ({status}) {status_message} (sleeping ~{sleep}s)")
+            time.sleep(sleep + random.random())
+            attempt += 1
+        raise TimeoutError(f"timed out after {opts.timeout}: {status_message}")
+
+
 class ForecastingAPI:
     """The Forecasting API allows you to create and get serverless forecasting experiments"""
 
@@ -7292,7 +7337,7 @@ class ForecastingAPI:
         split_column: Optional[str] = None,
         timeseries_identifier_columns: Optional[List[str]] = None,
         training_frameworks: Optional[List[str]] = None,
-    ) -> CreateForecastingExperimentResponse:
+    ) -> ForecastingCreateExperimentWaiter:
         """Create a forecasting experiment.
 
         Creates a serverless forecasting experiment. Returns the experiment ID.
@@ -7385,8 +7430,12 @@ class ForecastingAPI:
             "Content-Type": "application/json",
         }
 
-        res = self._api.do("POST", "/api/2.0/automl/create-forecasting-experiment", body=body, headers=headers)
-        return CreateForecastingExperimentResponse.from_dict(res)
+        op_response = self._api.do("POST", "/api/2.0/automl/create-forecasting-experiment", body=body, headers=headers)
+        return ForecastingCreateExperimentWaiter(
+            service=self,
+            response=CreateForecastingExperimentResponse.from_dict(op_response),
+            experiment_id=op_response["experiment_id"],
+        )
 
     def get_experiment(self, experiment_id: str) -> ForecastingExperiment:
         """Get a forecasting experiment.

--- a/databricks/sdk/pipelines/v2/pipelines.py
+++ b/databricks/sdk/pipelines/v2/pipelines.py
@@ -4716,7 +4716,7 @@ class PipelinesAPI:
 
         op_response = self._api.do("POST", f"/api/2.0/pipelines/{pipeline_id}/stop", headers=headers)
         return PipelinesStopWaiter(
-            service=self, response=StopPipelineResponse.from_dict(op_response), pipeline_id=pipeline_id
+            service=self, raw_response=StopPipelineResponse.from_dict(op_response), pipeline_id=pipeline_id
         )
 
     def update(

--- a/databricks/sdk/pipelines/v2/pipelines.py
+++ b/databricks/sdk/pipelines/v2/pipelines.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 import logging
+import random
+import time
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Dict, Iterator, List, Optional
 
-from ...service._internal import (_enum, _from_dict, _repeated_dict,
-                                  _repeated_enum)
+from ...databricks.errors import OperationFailed
+from ...service._internal import (WaitUntilDoneOptions, _enum, _from_dict,
+                                  _repeated_dict, _repeated_enum)
 
 _LOG = logging.getLogger("databricks.sdk")
 
@@ -4160,6 +4163,45 @@ class WorkspaceStorageInfo:
         return cls(destination=d.get("destination", None))
 
 
+class PipelinesStopWaiter:
+    raw_response: StopPipelineResponse
+    """raw_response is the raw response of the Stop call."""
+    _service: PipelinesAPI
+    _pipeline_id: str
+
+    def __init__(self, raw_response: StopPipelineResponse, service: PipelinesAPI, pipeline_id: str):
+        self._service = service
+        self.raw_response = raw_response
+        self._pipeline_id = pipeline_id
+
+    def WaitUntilDone(self, opts: Optional[WaitUntilDoneOptions] = None) -> GetPipelineResponse:
+        if opts is None:
+            opts = WaitUntilDoneOptions()
+        deadline = time.time() + opts.timeout.total_seconds()
+        target_states = (PipelineState.IDLE,)
+        failure_states = (PipelineState.FAILED,)
+        status_message = "polling..."
+        attempt = 1
+        while time.time() < deadline:
+            poll = self._service.get(pipeline_id=self._pipeline_id)
+            status = poll.state
+            status_message = f"current status: {status}"
+            if status in target_states:
+                return poll
+            if status in failure_states:
+                msg = f"failed to reach IDLE, got {status}: {status_message}"
+                raise OperationFailed(msg)
+            prefix = f"pipeline_id={self._pipeline_id}"
+            sleep = attempt
+            if sleep > 10:
+                # sleep 10s max per attempt
+                sleep = 10
+            _LOG.debug(f"{prefix}: ({status}) {status_message} (sleeping ~{sleep}s)")
+            time.sleep(sleep + random.random())
+            attempt += 1
+        raise TimeoutError(f"timed out after {opts.timeout}: {status_message}")
+
+
 class PipelinesAPI:
     """The Delta Live Tables API allows you to create, edit, delete, start, and view details about pipelines.
 
@@ -4655,7 +4697,7 @@ class PipelinesAPI:
         res = self._api.do("POST", f"/api/2.0/pipelines/{pipeline_id}/updates", body=body, headers=headers)
         return StartUpdateResponse.from_dict(res)
 
-    def stop(self, pipeline_id: str):
+    def stop(self, pipeline_id: str) -> PipelinesStopWaiter:
         """Stop a pipeline.
 
         Stops the pipeline by canceling the active update. If there is no active update for the pipeline, this
@@ -4672,7 +4714,10 @@ class PipelinesAPI:
             "Accept": "application/json",
         }
 
-        self._api.do("POST", f"/api/2.0/pipelines/{pipeline_id}/stop", headers=headers)
+        op_response = self._api.do("POST", f"/api/2.0/pipelines/{pipeline_id}/stop", headers=headers)
+        return PipelinesStopWaiter(
+            service=self, response=StopPipelineResponse.from_dict(op_response), pipeline_id=pipeline_id
+        )
 
     def update(
         self,

--- a/databricks/sdk/provisioning/v2/provisioning.py
+++ b/databricks/sdk/provisioning/v2/provisioning.py
@@ -3418,7 +3418,7 @@ class WorkspacesAPI:
             "POST", f"/api/2.0/accounts/{self._api.account_id}/workspaces", body=body, headers=headers
         )
         return WorkspacesCreateWaiter(
-            service=self, response=Workspace.from_dict(op_response), workspace_id=op_response["workspace_id"]
+            service=self, raw_response=Workspace.from_dict(op_response), workspace_id=op_response["workspace_id"]
         )
 
     def delete(self, workspace_id: int):
@@ -3664,5 +3664,5 @@ class WorkspacesAPI:
             "PATCH", f"/api/2.0/accounts/{self._api.account_id}/workspaces/{workspace_id}", body=body, headers=headers
         )
         return WorkspacesUpdateWaiter(
-            service=self, response=UpdateResponse.from_dict(op_response), workspace_id=workspace_id
+            service=self, raw_response=UpdateResponse.from_dict(op_response), workspace_id=workspace_id
         )

--- a/databricks/sdk/service/_internal.py
+++ b/databricks/sdk/service/_internal.py
@@ -49,6 +49,10 @@ def _escape_multi_segment_path_parameter(param: str) -> str:
 ReturnType = TypeVar("ReturnType")
 
 
+class WaitUntilDoneOptions:
+    timeout: datetime.timedelta = datetime.timedelta(minutes=20)
+
+
 class Wait(Generic[ReturnType]):
 
     def __init__(self, waiter: Callable, response: Any = None, **kwargs) -> None:

--- a/databricks/sdk/serving/v2/serving.py
+++ b/databricks/sdk/serving/v2/serving.py
@@ -4331,7 +4331,7 @@ class ServingEndpointsAPI:
 
         op_response = self._api.do("POST", "/api/2.0/serving-endpoints", body=body, headers=headers)
         return ServingEndpointsCreateWaiter(
-            service=self, response=ServingEndpointDetailed.from_dict(op_response), name=op_response["name"]
+            service=self, raw_response=ServingEndpointDetailed.from_dict(op_response), name=op_response["name"]
         )
 
     def delete(self, name: str):
@@ -4819,7 +4819,7 @@ class ServingEndpointsAPI:
 
         op_response = self._api.do("PUT", f"/api/2.0/serving-endpoints/{name}/config", body=body, headers=headers)
         return ServingEndpointsUpdateConfigWaiter(
-            service=self, response=ServingEndpointDetailed.from_dict(op_response), name=op_response["name"]
+            service=self, raw_response=ServingEndpointDetailed.from_dict(op_response), name=op_response["name"]
         )
 
     def update_permissions(

--- a/databricks/sdk/settings/v2/client.py
+++ b/databricks/sdk/settings/v2/client.py
@@ -13,7 +13,9 @@ from .settings import (AccountIpAccessListsAPI, AccountSettingsAPI,
                        CredentialsManagerAPI, CspEnablementAccountAPI,
                        DefaultNamespaceAPI, DisableLegacyAccessAPI,
                        DisableLegacyDbfsAPI, DisableLegacyFeaturesAPI,
-                       EnableIpAccessListsAPI, EnableResultsDownloadingAPI,
+                       EnableExportNotebookAPI, EnableIpAccessListsAPI,
+                       EnableNotebookTableClipboardAPI,
+                       EnableResultsDownloadingAPI,
                        EnhancedSecurityMonitoringAPI, EsmEnablementAccountAPI,
                        IpAccessListsAPI, NetworkConnectivityAPI,
                        NotificationDestinationsAPI, PersonalComputeAPI,
@@ -867,6 +869,73 @@ class DisableLegacyFeaturesClient(DisableLegacyFeaturesAPI):
         super().__init__(client.ApiClient(config))
 
 
+class EnableExportNotebookClient(EnableExportNotebookAPI):
+    """
+    Controls whether users can export notebooks and files from the Workspace. By default, this
+    setting is enabled.
+    """
+
+    def __init__(
+        self,
+        *,
+        host: Optional[str] = None,
+        account_id: Optional[str] = None,
+        username: Optional[str] = None,
+        password: Optional[str] = None,
+        client_id: Optional[str] = None,
+        client_secret: Optional[str] = None,
+        token: Optional[str] = None,
+        profile: Optional[str] = None,
+        config_file: Optional[str] = None,
+        azure_workspace_resource_id: Optional[str] = None,
+        azure_client_secret: Optional[str] = None,
+        azure_client_id: Optional[str] = None,
+        azure_tenant_id: Optional[str] = None,
+        azure_environment: Optional[str] = None,
+        auth_type: Optional[str] = None,
+        cluster_id: Optional[str] = None,
+        google_credentials: Optional[str] = None,
+        google_service_account: Optional[str] = None,
+        debug_truncate_bytes: Optional[int] = None,
+        debug_headers: Optional[bool] = None,
+        product="unknown",
+        product_version="0.0.0",
+        credentials_strategy: Optional[CredentialsStrategy] = None,
+        credentials_provider: Optional[CredentialsStrategy] = None,
+        config: Optional[client.Config] = None,
+    ):
+
+        if not config:
+            config = client.Config(
+                host=host,
+                account_id=account_id,
+                username=username,
+                password=password,
+                client_id=client_id,
+                client_secret=client_secret,
+                token=token,
+                profile=profile,
+                config_file=config_file,
+                azure_workspace_resource_id=azure_workspace_resource_id,
+                azure_client_secret=azure_client_secret,
+                azure_client_id=azure_client_id,
+                azure_tenant_id=azure_tenant_id,
+                azure_environment=azure_environment,
+                auth_type=auth_type,
+                cluster_id=cluster_id,
+                google_credentials=google_credentials,
+                google_service_account=google_service_account,
+                credentials_strategy=credentials_strategy,
+                credentials_provider=credentials_provider,
+                debug_truncate_bytes=debug_truncate_bytes,
+                debug_headers=debug_headers,
+                product=product,
+                product_version=product_version,
+            )
+        self._config = config.copy()
+        super().__init__(client.ApiClient(config))
+
+
 class EnableIpAccessListsClient(EnableIpAccessListsAPI):
     """
     Controls the enforcement of IP access lists for accessing the account console. Allowing you to
@@ -934,10 +1003,76 @@ class EnableIpAccessListsClient(EnableIpAccessListsAPI):
         super().__init__(client.ApiClient(config))
 
 
+class EnableNotebookTableClipboardClient(EnableNotebookTableClipboardAPI):
+    """
+    Controls whether users can copy tabular data to the clipboard via the UI. By default, this
+    setting is enabled.
+    """
+
+    def __init__(
+        self,
+        *,
+        host: Optional[str] = None,
+        account_id: Optional[str] = None,
+        username: Optional[str] = None,
+        password: Optional[str] = None,
+        client_id: Optional[str] = None,
+        client_secret: Optional[str] = None,
+        token: Optional[str] = None,
+        profile: Optional[str] = None,
+        config_file: Optional[str] = None,
+        azure_workspace_resource_id: Optional[str] = None,
+        azure_client_secret: Optional[str] = None,
+        azure_client_id: Optional[str] = None,
+        azure_tenant_id: Optional[str] = None,
+        azure_environment: Optional[str] = None,
+        auth_type: Optional[str] = None,
+        cluster_id: Optional[str] = None,
+        google_credentials: Optional[str] = None,
+        google_service_account: Optional[str] = None,
+        debug_truncate_bytes: Optional[int] = None,
+        debug_headers: Optional[bool] = None,
+        product="unknown",
+        product_version="0.0.0",
+        credentials_strategy: Optional[CredentialsStrategy] = None,
+        credentials_provider: Optional[CredentialsStrategy] = None,
+        config: Optional[client.Config] = None,
+    ):
+
+        if not config:
+            config = client.Config(
+                host=host,
+                account_id=account_id,
+                username=username,
+                password=password,
+                client_id=client_id,
+                client_secret=client_secret,
+                token=token,
+                profile=profile,
+                config_file=config_file,
+                azure_workspace_resource_id=azure_workspace_resource_id,
+                azure_client_secret=azure_client_secret,
+                azure_client_id=azure_client_id,
+                azure_tenant_id=azure_tenant_id,
+                azure_environment=azure_environment,
+                auth_type=auth_type,
+                cluster_id=cluster_id,
+                google_credentials=google_credentials,
+                google_service_account=google_service_account,
+                credentials_strategy=credentials_strategy,
+                credentials_provider=credentials_provider,
+                debug_truncate_bytes=debug_truncate_bytes,
+                debug_headers=debug_headers,
+                product=product,
+                product_version=product_version,
+            )
+        self._config = config.copy()
+        super().__init__(client.ApiClient(config))
+
+
 class EnableResultsDownloadingClient(EnableResultsDownloadingAPI):
     """
-    The Enable Results Downloading API controls the workspace level conf for the enablement of
-    downloading results.
+    Controls whether users can download notebook results. By default, this setting is enabled.
     """
 
     def __init__(

--- a/databricks/sdk/settings/v2/client.py
+++ b/databricks/sdk/settings/v2/client.py
@@ -871,7 +871,7 @@ class DisableLegacyFeaturesClient(DisableLegacyFeaturesAPI):
 
 class EnableExportNotebookClient(EnableExportNotebookAPI):
     """
-    Controls whether users can export notebooks and files from the Workspace. By default, this
+    Controls whether users can export notebooks and files from the Workspace UI. By default, this
     setting is enabled.
     """
 

--- a/databricks/sdk/settings/v2/settings.py
+++ b/databricks/sdk/settings/v2/settings.py
@@ -635,6 +635,7 @@ class ComplianceStandard(Enum):
     IRAP_PROTECTED = "IRAP_PROTECTED"
     ISMAP = "ISMAP"
     ITAR_EAR = "ITAR_EAR"
+    K_FSI = "K_FSI"
     NONE = "NONE"
     PCI_DSS = "PCI_DSS"
 
@@ -6160,16 +6161,16 @@ class DisableLegacyFeaturesAPI:
 
 
 class EnableExportNotebookAPI:
-    """Controls whether users can export notebooks and files from the Workspace. By default, this setting is
+    """Controls whether users can export notebooks and files from the Workspace UI. By default, this setting is
     enabled."""
 
     def __init__(self, api_client):
         self._api = api_client
 
     def get_enable_export_notebook(self) -> EnableExportNotebook:
-        """Get the Enable Export Notebook setting.
+        """Get the Notebook and File exporting setting.
 
-        Gets the Enable Export Notebook setting.
+        Gets the Notebook and File exporting setting.
 
         :returns: :class:`EnableExportNotebook`
         """
@@ -6184,10 +6185,10 @@ class EnableExportNotebookAPI:
     def patch_enable_export_notebook(
         self, allow_missing: bool, setting: EnableExportNotebook, field_mask: str
     ) -> EnableExportNotebook:
-        """Update the Enable Export Notebook setting.
+        """Update the Notebook and File exporting setting.
 
-        Updates the Enable Export Notebook setting. The model follows eventual consistency, which means the
-        get after the update operation might receive stale values for some time.
+        Updates the Notebook and File exporting setting. The model follows eventual consistency, which means
+        the get after the update operation might receive stale values for some time.
 
         :param allow_missing: bool
           This should always be set to true for Settings API. Added for AIP compliance.
@@ -6340,9 +6341,9 @@ class EnableNotebookTableClipboardAPI:
         self._api = api_client
 
     def get_enable_notebook_table_clipboard(self) -> EnableNotebookTableClipboard:
-        """Get the Enable Notebook Table Clipboard setting.
+        """Get the Results Table Clipboard features setting.
 
-        Gets the Enable Notebook Table Clipboard setting.
+        Gets the Results Table Clipboard features setting.
 
         :returns: :class:`EnableNotebookTableClipboard`
         """
@@ -6359,9 +6360,9 @@ class EnableNotebookTableClipboardAPI:
     def patch_enable_notebook_table_clipboard(
         self, allow_missing: bool, setting: EnableNotebookTableClipboard, field_mask: str
     ) -> EnableNotebookTableClipboard:
-        """Update the Enable Notebook Table Clipboard setting.
+        """Update the Results Table Clipboard features setting.
 
-        Updates the Enable Notebook Table Clipboard setting. The model follows eventual consistency, which
+        Updates the Results Table Clipboard features setting. The model follows eventual consistency, which
         means the get after the update operation might receive stale values for some time.
 
         :param allow_missing: bool
@@ -6405,9 +6406,9 @@ class EnableResultsDownloadingAPI:
         self._api = api_client
 
     def get_enable_results_downloading(self) -> EnableResultsDownloading:
-        """Get the Enable Results Downloading setting.
+        """Get the Notebook results download setting.
 
-        Gets the Enable Results Downloading setting.
+        Gets the Notebook results download setting.
 
         :returns: :class:`EnableResultsDownloading`
         """
@@ -6422,10 +6423,10 @@ class EnableResultsDownloadingAPI:
     def patch_enable_results_downloading(
         self, allow_missing: bool, setting: EnableResultsDownloading, field_mask: str
     ) -> EnableResultsDownloading:
-        """Update the Enable Results Downloading setting.
+        """Update the Notebook results download setting.
 
-        Updates the Enable Results Downloading setting. The model follows eventual consistency, which means
-        the get after the update operation might receive stale values for some time.
+        Updates the Notebook results download setting. The model follows eventual consistency, which means the
+        get after the update operation might receive stale values for some time.
 
         :param allow_missing: bool
           This should always be set to true for Settings API. Added for AIP compliance.

--- a/databricks/sdk/settings/v2/settings.py
+++ b/databricks/sdk/settings/v2/settings.py
@@ -1706,6 +1706,74 @@ class Empty:
 
 
 @dataclass
+class EnableExportNotebook:
+    boolean_val: Optional[BooleanMessage] = None
+
+    setting_name: Optional[str] = None
+    """Name of the corresponding setting. This field is populated in the response, but it will not be
+    respected even if it's set in the request body. The setting name in the path parameter will be
+    respected instead. Setting name is required to be 'default' if the setting only has one instance
+    per workspace."""
+
+    def as_dict(self) -> dict:
+        """Serializes the EnableExportNotebook into a dictionary suitable for use as a JSON request body."""
+        body = {}
+        if self.boolean_val:
+            body["boolean_val"] = self.boolean_val.as_dict()
+        if self.setting_name is not None:
+            body["setting_name"] = self.setting_name
+        return body
+
+    def as_shallow_dict(self) -> dict:
+        """Serializes the EnableExportNotebook into a shallow dictionary of its immediate attributes."""
+        body = {}
+        if self.boolean_val:
+            body["boolean_val"] = self.boolean_val
+        if self.setting_name is not None:
+            body["setting_name"] = self.setting_name
+        return body
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, Any]) -> EnableExportNotebook:
+        """Deserializes the EnableExportNotebook from a dictionary."""
+        return cls(boolean_val=_from_dict(d, "boolean_val", BooleanMessage), setting_name=d.get("setting_name", None))
+
+
+@dataclass
+class EnableNotebookTableClipboard:
+    boolean_val: Optional[BooleanMessage] = None
+
+    setting_name: Optional[str] = None
+    """Name of the corresponding setting. This field is populated in the response, but it will not be
+    respected even if it's set in the request body. The setting name in the path parameter will be
+    respected instead. Setting name is required to be 'default' if the setting only has one instance
+    per workspace."""
+
+    def as_dict(self) -> dict:
+        """Serializes the EnableNotebookTableClipboard into a dictionary suitable for use as a JSON request body."""
+        body = {}
+        if self.boolean_val:
+            body["boolean_val"] = self.boolean_val.as_dict()
+        if self.setting_name is not None:
+            body["setting_name"] = self.setting_name
+        return body
+
+    def as_shallow_dict(self) -> dict:
+        """Serializes the EnableNotebookTableClipboard into a shallow dictionary of its immediate attributes."""
+        body = {}
+        if self.boolean_val:
+            body["boolean_val"] = self.boolean_val
+        if self.setting_name is not None:
+            body["setting_name"] = self.setting_name
+        return body
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, Any]) -> EnableNotebookTableClipboard:
+        """Deserializes the EnableNotebookTableClipboard from a dictionary."""
+        return cls(boolean_val=_from_dict(d, "boolean_val", BooleanMessage), setting_name=d.get("setting_name", None))
+
+
+@dataclass
 class EnableResultsDownloading:
     boolean_val: Optional[BooleanMessage] = None
 
@@ -4416,6 +4484,110 @@ class UpdateDisableLegacyFeaturesRequest:
 
 
 @dataclass
+class UpdateEnableExportNotebookRequest:
+    """Details required to update a setting."""
+
+    allow_missing: bool
+    """This should always be set to true for Settings API. Added for AIP compliance."""
+
+    setting: EnableExportNotebook
+
+    field_mask: str
+    """The field mask must be a single string, with multiple fields separated by commas (no spaces).
+    The field path is relative to the resource object, using a dot (`.`) to navigate sub-fields
+    (e.g., `author.given_name`). Specification of elements in sequence or map fields is not allowed,
+    as only the entire collection field can be specified. Field names must exactly match the
+    resource field names.
+    
+    A field mask of `*` indicates full replacement. It’s recommended to always explicitly list the
+    fields being updated and avoid using `*` wildcards, as it can lead to unintended results if the
+    API changes in the future."""
+
+    def as_dict(self) -> dict:
+        """Serializes the UpdateEnableExportNotebookRequest into a dictionary suitable for use as a JSON request body."""
+        body = {}
+        if self.allow_missing is not None:
+            body["allow_missing"] = self.allow_missing
+        if self.field_mask is not None:
+            body["field_mask"] = self.field_mask
+        if self.setting:
+            body["setting"] = self.setting.as_dict()
+        return body
+
+    def as_shallow_dict(self) -> dict:
+        """Serializes the UpdateEnableExportNotebookRequest into a shallow dictionary of its immediate attributes."""
+        body = {}
+        if self.allow_missing is not None:
+            body["allow_missing"] = self.allow_missing
+        if self.field_mask is not None:
+            body["field_mask"] = self.field_mask
+        if self.setting:
+            body["setting"] = self.setting
+        return body
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateEnableExportNotebookRequest:
+        """Deserializes the UpdateEnableExportNotebookRequest from a dictionary."""
+        return cls(
+            allow_missing=d.get("allow_missing", None),
+            field_mask=d.get("field_mask", None),
+            setting=_from_dict(d, "setting", EnableExportNotebook),
+        )
+
+
+@dataclass
+class UpdateEnableNotebookTableClipboardRequest:
+    """Details required to update a setting."""
+
+    allow_missing: bool
+    """This should always be set to true for Settings API. Added for AIP compliance."""
+
+    setting: EnableNotebookTableClipboard
+
+    field_mask: str
+    """The field mask must be a single string, with multiple fields separated by commas (no spaces).
+    The field path is relative to the resource object, using a dot (`.`) to navigate sub-fields
+    (e.g., `author.given_name`). Specification of elements in sequence or map fields is not allowed,
+    as only the entire collection field can be specified. Field names must exactly match the
+    resource field names.
+    
+    A field mask of `*` indicates full replacement. It’s recommended to always explicitly list the
+    fields being updated and avoid using `*` wildcards, as it can lead to unintended results if the
+    API changes in the future."""
+
+    def as_dict(self) -> dict:
+        """Serializes the UpdateEnableNotebookTableClipboardRequest into a dictionary suitable for use as a JSON request body."""
+        body = {}
+        if self.allow_missing is not None:
+            body["allow_missing"] = self.allow_missing
+        if self.field_mask is not None:
+            body["field_mask"] = self.field_mask
+        if self.setting:
+            body["setting"] = self.setting.as_dict()
+        return body
+
+    def as_shallow_dict(self) -> dict:
+        """Serializes the UpdateEnableNotebookTableClipboardRequest into a shallow dictionary of its immediate attributes."""
+        body = {}
+        if self.allow_missing is not None:
+            body["allow_missing"] = self.allow_missing
+        if self.field_mask is not None:
+            body["field_mask"] = self.field_mask
+        if self.setting:
+            body["setting"] = self.setting
+        return body
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, Any]) -> UpdateEnableNotebookTableClipboardRequest:
+        """Deserializes the UpdateEnableNotebookTableClipboardRequest from a dictionary."""
+        return cls(
+            allow_missing=d.get("allow_missing", None),
+            field_mask=d.get("field_mask", None),
+            setting=_from_dict(d, "setting", EnableNotebookTableClipboard),
+        )
+
+
+@dataclass
 class UpdateEnableResultsDownloadingRequest:
     """Details required to update a setting."""
 
@@ -5987,6 +6159,70 @@ class DisableLegacyFeaturesAPI:
         return DisableLegacyFeatures.from_dict(res)
 
 
+class EnableExportNotebookAPI:
+    """Controls whether users can export notebooks and files from the Workspace. By default, this setting is
+    enabled."""
+
+    def __init__(self, api_client):
+        self._api = api_client
+
+    def get_enable_export_notebook(self) -> EnableExportNotebook:
+        """Get the Enable Export Notebook setting.
+
+        Gets the Enable Export Notebook setting.
+
+        :returns: :class:`EnableExportNotebook`
+        """
+
+        headers = {
+            "Accept": "application/json",
+        }
+
+        res = self._api.do("GET", "/api/2.0/settings/types/enable-export-notebook/names/default", headers=headers)
+        return EnableExportNotebook.from_dict(res)
+
+    def patch_enable_export_notebook(
+        self, allow_missing: bool, setting: EnableExportNotebook, field_mask: str
+    ) -> EnableExportNotebook:
+        """Update the Enable Export Notebook setting.
+
+        Updates the Enable Export Notebook setting. The model follows eventual consistency, which means the
+        get after the update operation might receive stale values for some time.
+
+        :param allow_missing: bool
+          This should always be set to true for Settings API. Added for AIP compliance.
+        :param setting: :class:`EnableExportNotebook`
+        :param field_mask: str
+          The field mask must be a single string, with multiple fields separated by commas (no spaces). The
+          field path is relative to the resource object, using a dot (`.`) to navigate sub-fields (e.g.,
+          `author.given_name`). Specification of elements in sequence or map fields is not allowed, as only
+          the entire collection field can be specified. Field names must exactly match the resource field
+          names.
+
+          A field mask of `*` indicates full replacement. It’s recommended to always explicitly list the
+          fields being updated and avoid using `*` wildcards, as it can lead to unintended results if the API
+          changes in the future.
+
+        :returns: :class:`EnableExportNotebook`
+        """
+        body = {}
+        if allow_missing is not None:
+            body["allow_missing"] = allow_missing
+        if field_mask is not None:
+            body["field_mask"] = field_mask
+        if setting is not None:
+            body["setting"] = setting.as_dict()
+        headers = {
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+        }
+
+        res = self._api.do(
+            "PATCH", "/api/2.0/settings/types/enable-export-notebook/names/default", body=body, headers=headers
+        )
+        return EnableExportNotebook.from_dict(res)
+
+
 class EnableIpAccessListsAPI:
     """Controls the enforcement of IP access lists for accessing the account console. Allowing you to enable or
     disable restricted access based on IP addresses."""
@@ -6096,9 +6332,74 @@ class EnableIpAccessListsAPI:
         return AccountIpAccessEnable.from_dict(res)
 
 
+class EnableNotebookTableClipboardAPI:
+    """Controls whether users can copy tabular data to the clipboard via the UI. By default, this setting is
+    enabled."""
+
+    def __init__(self, api_client):
+        self._api = api_client
+
+    def get_enable_notebook_table_clipboard(self) -> EnableNotebookTableClipboard:
+        """Get the Enable Notebook Table Clipboard setting.
+
+        Gets the Enable Notebook Table Clipboard setting.
+
+        :returns: :class:`EnableNotebookTableClipboard`
+        """
+
+        headers = {
+            "Accept": "application/json",
+        }
+
+        res = self._api.do(
+            "GET", "/api/2.0/settings/types/enable-notebook-table-clipboard/names/default", headers=headers
+        )
+        return EnableNotebookTableClipboard.from_dict(res)
+
+    def patch_enable_notebook_table_clipboard(
+        self, allow_missing: bool, setting: EnableNotebookTableClipboard, field_mask: str
+    ) -> EnableNotebookTableClipboard:
+        """Update the Enable Notebook Table Clipboard setting.
+
+        Updates the Enable Notebook Table Clipboard setting. The model follows eventual consistency, which
+        means the get after the update operation might receive stale values for some time.
+
+        :param allow_missing: bool
+          This should always be set to true for Settings API. Added for AIP compliance.
+        :param setting: :class:`EnableNotebookTableClipboard`
+        :param field_mask: str
+          The field mask must be a single string, with multiple fields separated by commas (no spaces). The
+          field path is relative to the resource object, using a dot (`.`) to navigate sub-fields (e.g.,
+          `author.given_name`). Specification of elements in sequence or map fields is not allowed, as only
+          the entire collection field can be specified. Field names must exactly match the resource field
+          names.
+
+          A field mask of `*` indicates full replacement. It’s recommended to always explicitly list the
+          fields being updated and avoid using `*` wildcards, as it can lead to unintended results if the API
+          changes in the future.
+
+        :returns: :class:`EnableNotebookTableClipboard`
+        """
+        body = {}
+        if allow_missing is not None:
+            body["allow_missing"] = allow_missing
+        if field_mask is not None:
+            body["field_mask"] = field_mask
+        if setting is not None:
+            body["setting"] = setting.as_dict()
+        headers = {
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+        }
+
+        res = self._api.do(
+            "PATCH", "/api/2.0/settings/types/enable-notebook-table-clipboard/names/default", body=body, headers=headers
+        )
+        return EnableNotebookTableClipboard.from_dict(res)
+
+
 class EnableResultsDownloadingAPI:
-    """The Enable Results Downloading API controls the workspace level conf for the enablement of downloading
-    results."""
+    """Controls whether users can download notebook results. By default, this setting is enabled."""
 
     def __init__(self, api_client):
         self._api = api_client

--- a/databricks/sdk/sql/v2/sql.py
+++ b/databricks/sdk/sql/v2/sql.py
@@ -10029,7 +10029,7 @@ class WarehousesAPI:
 
         op_response = self._api.do("POST", "/api/2.0/sql/warehouses", body=body, headers=headers)
         return WarehousesCreateWaiter(
-            service=self, response=CreateWarehouseResponse.from_dict(op_response), id=op_response["id"]
+            service=self, raw_response=CreateWarehouseResponse.from_dict(op_response), id=op_response["id"]
         )
 
     def delete(self, id: str):
@@ -10165,7 +10165,7 @@ class WarehousesAPI:
         }
 
         op_response = self._api.do("POST", f"/api/2.0/sql/warehouses/{id}/edit", body=body, headers=headers)
-        return WarehousesEditWaiter(service=self, response=EditWarehouseResponse.from_dict(op_response), id=id)
+        return WarehousesEditWaiter(service=self, raw_response=EditWarehouseResponse.from_dict(op_response), id=id)
 
     def get(self, id: str) -> GetWarehouseResponse:
         """Get warehouse info.
@@ -10371,7 +10371,7 @@ class WarehousesAPI:
         }
 
         op_response = self._api.do("POST", f"/api/2.0/sql/warehouses/{id}/start", headers=headers)
-        return WarehousesStartWaiter(service=self, response=StartWarehouseResponse.from_dict(op_response), id=id)
+        return WarehousesStartWaiter(service=self, raw_response=StartWarehouseResponse.from_dict(op_response), id=id)
 
     def stop(self, id: str) -> WarehousesStopWaiter:
         """Stop a warehouse.
@@ -10391,7 +10391,7 @@ class WarehousesAPI:
         }
 
         op_response = self._api.do("POST", f"/api/2.0/sql/warehouses/{id}/stop", headers=headers)
-        return WarehousesStopWaiter(service=self, response=StopWarehouseResponse.from_dict(op_response), id=id)
+        return WarehousesStopWaiter(service=self, raw_response=StopWarehouseResponse.from_dict(op_response), id=id)
 
     def update_permissions(
         self, warehouse_id: str, *, access_control_list: Optional[List[WarehouseAccessControlRequest]] = None

--- a/databricks/sdk/sql/v2/sql.py
+++ b/databricks/sdk/sql/v2/sql.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 import logging
+import random
+import time
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Dict, Iterator, List, Optional
 
-from ...service._internal import (_enum, _from_dict, _repeated_dict,
-                                  _repeated_enum)
+from ...databricks.errors import OperationFailed
+from ...service._internal import (WaitUntilDoneOptions, _enum, _from_dict,
+                                  _repeated_dict, _repeated_enum)
 
 _LOG = logging.getLogger("databricks.sdk")
 
@@ -9735,6 +9738,175 @@ class StatementExecutionAPI:
         return ResultData.from_dict(res)
 
 
+class WarehousesCreateWaiter:
+    raw_response: CreateWarehouseResponse
+    """raw_response is the raw response of the Create call."""
+    _service: WarehousesAPI
+    _id: str
+
+    def __init__(self, raw_response: CreateWarehouseResponse, service: WarehousesAPI, id: str):
+        self._service = service
+        self.raw_response = raw_response
+        self._id = id
+
+    def WaitUntilDone(self, opts: Optional[WaitUntilDoneOptions] = None) -> GetWarehouseResponse:
+        if opts is None:
+            opts = WaitUntilDoneOptions()
+        deadline = time.time() + opts.timeout.total_seconds()
+        target_states = (State.RUNNING,)
+        failure_states = (
+            State.STOPPED,
+            State.DELETED,
+        )
+        status_message = "polling..."
+        attempt = 1
+        while time.time() < deadline:
+            poll = self._service.get(id=self._id)
+            status = poll.state
+            status_message = f"current status: {status}"
+            if poll.health:
+                status_message = poll.health.summary
+            if status in target_states:
+                return poll
+            if status in failure_states:
+                msg = f"failed to reach RUNNING, got {status}: {status_message}"
+                raise OperationFailed(msg)
+            prefix = f"id={self._id}"
+            sleep = attempt
+            if sleep > 10:
+                # sleep 10s max per attempt
+                sleep = 10
+            _LOG.debug(f"{prefix}: ({status}) {status_message} (sleeping ~{sleep}s)")
+            time.sleep(sleep + random.random())
+            attempt += 1
+        raise TimeoutError(f"timed out after {opts.timeout}: {status_message}")
+
+
+class WarehousesEditWaiter:
+    raw_response: EditWarehouseResponse
+    """raw_response is the raw response of the Edit call."""
+    _service: WarehousesAPI
+    _id: str
+
+    def __init__(self, raw_response: EditWarehouseResponse, service: WarehousesAPI, id: str):
+        self._service = service
+        self.raw_response = raw_response
+        self._id = id
+
+    def WaitUntilDone(self, opts: Optional[WaitUntilDoneOptions] = None) -> GetWarehouseResponse:
+        if opts is None:
+            opts = WaitUntilDoneOptions()
+        deadline = time.time() + opts.timeout.total_seconds()
+        target_states = (State.RUNNING,)
+        failure_states = (
+            State.STOPPED,
+            State.DELETED,
+        )
+        status_message = "polling..."
+        attempt = 1
+        while time.time() < deadline:
+            poll = self._service.get(id=self._id)
+            status = poll.state
+            status_message = f"current status: {status}"
+            if poll.health:
+                status_message = poll.health.summary
+            if status in target_states:
+                return poll
+            if status in failure_states:
+                msg = f"failed to reach RUNNING, got {status}: {status_message}"
+                raise OperationFailed(msg)
+            prefix = f"id={self._id}"
+            sleep = attempt
+            if sleep > 10:
+                # sleep 10s max per attempt
+                sleep = 10
+            _LOG.debug(f"{prefix}: ({status}) {status_message} (sleeping ~{sleep}s)")
+            time.sleep(sleep + random.random())
+            attempt += 1
+        raise TimeoutError(f"timed out after {opts.timeout}: {status_message}")
+
+
+class WarehousesStartWaiter:
+    raw_response: StartWarehouseResponse
+    """raw_response is the raw response of the Start call."""
+    _service: WarehousesAPI
+    _id: str
+
+    def __init__(self, raw_response: StartWarehouseResponse, service: WarehousesAPI, id: str):
+        self._service = service
+        self.raw_response = raw_response
+        self._id = id
+
+    def WaitUntilDone(self, opts: Optional[WaitUntilDoneOptions] = None) -> GetWarehouseResponse:
+        if opts is None:
+            opts = WaitUntilDoneOptions()
+        deadline = time.time() + opts.timeout.total_seconds()
+        target_states = (State.RUNNING,)
+        failure_states = (
+            State.STOPPED,
+            State.DELETED,
+        )
+        status_message = "polling..."
+        attempt = 1
+        while time.time() < deadline:
+            poll = self._service.get(id=self._id)
+            status = poll.state
+            status_message = f"current status: {status}"
+            if poll.health:
+                status_message = poll.health.summary
+            if status in target_states:
+                return poll
+            if status in failure_states:
+                msg = f"failed to reach RUNNING, got {status}: {status_message}"
+                raise OperationFailed(msg)
+            prefix = f"id={self._id}"
+            sleep = attempt
+            if sleep > 10:
+                # sleep 10s max per attempt
+                sleep = 10
+            _LOG.debug(f"{prefix}: ({status}) {status_message} (sleeping ~{sleep}s)")
+            time.sleep(sleep + random.random())
+            attempt += 1
+        raise TimeoutError(f"timed out after {opts.timeout}: {status_message}")
+
+
+class WarehousesStopWaiter:
+    raw_response: StopWarehouseResponse
+    """raw_response is the raw response of the Stop call."""
+    _service: WarehousesAPI
+    _id: str
+
+    def __init__(self, raw_response: StopWarehouseResponse, service: WarehousesAPI, id: str):
+        self._service = service
+        self.raw_response = raw_response
+        self._id = id
+
+    def WaitUntilDone(self, opts: Optional[WaitUntilDoneOptions] = None) -> GetWarehouseResponse:
+        if opts is None:
+            opts = WaitUntilDoneOptions()
+        deadline = time.time() + opts.timeout.total_seconds()
+        target_states = (State.STOPPED,)
+        status_message = "polling..."
+        attempt = 1
+        while time.time() < deadline:
+            poll = self._service.get(id=self._id)
+            status = poll.state
+            status_message = f"current status: {status}"
+            if poll.health:
+                status_message = poll.health.summary
+            if status in target_states:
+                return poll
+            prefix = f"id={self._id}"
+            sleep = attempt
+            if sleep > 10:
+                # sleep 10s max per attempt
+                sleep = 10
+            _LOG.debug(f"{prefix}: ({status}) {status_message} (sleeping ~{sleep}s)")
+            time.sleep(sleep + random.random())
+            attempt += 1
+        raise TimeoutError(f"timed out after {opts.timeout}: {status_message}")
+
+
 class WarehousesAPI:
     """A SQL warehouse is a compute resource that lets you run SQL commands on data objects within Databricks
     SQL. Compute resources are infrastructure resources that provide processing capabilities in the cloud."""
@@ -9758,7 +9930,7 @@ class WarehousesAPI:
         spot_instance_policy: Optional[SpotInstancePolicy] = None,
         tags: Optional[EndpointTags] = None,
         warehouse_type: Optional[CreateWarehouseRequestWarehouseType] = None,
-    ) -> CreateWarehouseResponse:
+    ) -> WarehousesCreateWaiter:
         """Create a warehouse.
 
         Creates a new SQL warehouse.
@@ -9855,8 +10027,10 @@ class WarehousesAPI:
             "Content-Type": "application/json",
         }
 
-        res = self._api.do("POST", "/api/2.0/sql/warehouses", body=body, headers=headers)
-        return CreateWarehouseResponse.from_dict(res)
+        op_response = self._api.do("POST", "/api/2.0/sql/warehouses", body=body, headers=headers)
+        return WarehousesCreateWaiter(
+            service=self, response=CreateWarehouseResponse.from_dict(op_response), id=op_response["id"]
+        )
 
     def delete(self, id: str):
         """Delete a warehouse.
@@ -9892,7 +10066,7 @@ class WarehousesAPI:
         spot_instance_policy: Optional[SpotInstancePolicy] = None,
         tags: Optional[EndpointTags] = None,
         warehouse_type: Optional[EditWarehouseRequestWarehouseType] = None,
-    ):
+    ) -> WarehousesEditWaiter:
         """Update a warehouse.
 
         Updates the configuration for a SQL warehouse.
@@ -9990,7 +10164,8 @@ class WarehousesAPI:
             "Content-Type": "application/json",
         }
 
-        self._api.do("POST", f"/api/2.0/sql/warehouses/{id}/edit", body=body, headers=headers)
+        op_response = self._api.do("POST", f"/api/2.0/sql/warehouses/{id}/edit", body=body, headers=headers)
+        return WarehousesEditWaiter(service=self, response=EditWarehouseResponse.from_dict(op_response), id=id)
 
     def get(self, id: str) -> GetWarehouseResponse:
         """Get warehouse info.
@@ -10178,7 +10353,7 @@ class WarehousesAPI:
 
         self._api.do("PUT", "/api/2.0/sql/config/warehouses", body=body, headers=headers)
 
-    def start(self, id: str):
+    def start(self, id: str) -> WarehousesStartWaiter:
         """Start a warehouse.
 
         Starts a SQL warehouse.
@@ -10195,9 +10370,10 @@ class WarehousesAPI:
             "Accept": "application/json",
         }
 
-        self._api.do("POST", f"/api/2.0/sql/warehouses/{id}/start", headers=headers)
+        op_response = self._api.do("POST", f"/api/2.0/sql/warehouses/{id}/start", headers=headers)
+        return WarehousesStartWaiter(service=self, response=StartWarehouseResponse.from_dict(op_response), id=id)
 
-    def stop(self, id: str):
+    def stop(self, id: str) -> WarehousesStopWaiter:
         """Stop a warehouse.
 
         Stops a SQL warehouse.
@@ -10214,7 +10390,8 @@ class WarehousesAPI:
             "Accept": "application/json",
         }
 
-        self._api.do("POST", f"/api/2.0/sql/warehouses/{id}/stop", headers=headers)
+        op_response = self._api.do("POST", f"/api/2.0/sql/warehouses/{id}/stop", headers=headers)
+        return WarehousesStopWaiter(service=self, response=StopWarehouseResponse.from_dict(op_response), id=id)
 
     def update_permissions(
         self, warehouse_id: str, *, access_control_list: Optional[List[WarehouseAccessControlRequest]] = None

--- a/databricks/sdk/vectorsearch/v2/client.py
+++ b/databricks/sdk/vectorsearch/v2/client.py
@@ -82,9 +82,9 @@ class VectorSearchIndexesClient(VectorSearchIndexesAPI):
     **Index**: An efficient representation of your embedding vectors that supports real-time and
     efficient approximate nearest neighbor (ANN) search queries.
 
-    There are 2 types of Vector Search indexes: * **Delta Sync Index**: An index that automatically
+    There are 2 types of Vector Search indexes: - **Delta Sync Index**: An index that automatically
     syncs with a source Delta Table, automatically and incrementally updating the index as the
-    underlying data in the Delta Table changes. * **Direct Vector Access Index**: An index that
+    underlying data in the Delta Table changes. - **Direct Vector Access Index**: An index that
     supports direct read and write of vectors and metadata through our REST and SDK APIs. With this
     model, the user manages index updates.
     """

--- a/databricks/sdk/vectorsearch/v2/vectorsearch.py
+++ b/databricks/sdk/vectorsearch/v2/vectorsearch.py
@@ -1693,7 +1693,7 @@ class VectorSearchEndpointsAPI:
 
         op_response = self._api.do("POST", "/api/2.0/vector-search/endpoints", body=body, headers=headers)
         return VectorSearchEndpointsCreateEndpointWaiter(
-            service=self, response=EndpointInfo.from_dict(op_response), endpoint_name=op_response["name"]
+            service=self, raw_response=EndpointInfo.from_dict(op_response), endpoint_name=op_response["name"]
         )
 
     def delete_endpoint(self, endpoint_name: str):


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR adds waiters to long-running operations, which provides functionality to wait until a terminating state has been reached for the long-running operation.

## How is this tested?
I re-enabled one integration test that uses long-running operations. I will re-enable the rest of the tests in the next PR, as some of them first need mixins that are removed because we don't have waiters.
NO_CHANGELOG=true
