### PR TITLE
Enable async token refresh by default

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Release v0.51.0
 
 ### New Features and Improvements
+* Made async token refresh the default behavior. Added `disable_async_token_refresh` configuration option to disable it if needed ([#952](https://github.com/databricks/databricks-sdk-py/pull/952)).
+  To disable async token refresh, set environment variable `DATABRICKS_DISABLE_ASYNC_TOKEN_REFRESH=true` or configure it in your config object.
+  The previous `enable_experimental_async_token_refresh` option has been removed as async refresh is now the default.
 
 ### Bug Fixes
 

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -3,9 +3,9 @@
 ## Release v0.51.0
 
 ### New Features and Improvements
-* Made async token refresh the default behavior. Added `disable_async_token_refresh` configuration option to disable it if needed ([#952](https://github.com/databricks/databricks-sdk-py/pull/952)).
-  To disable async token refresh, set environment variable `DATABRICKS_DISABLE_ASYNC_TOKEN_REFRESH=true` or configure it in your config object.
-  The previous `enable_experimental_async_token_refresh` option has been removed as async refresh is now the default.
+* Enabled asynchronous token refreshes by default. A new `disable_async_token_refresh` configuration option has been added to allow disabling this feature if necessary ([#952](https://github.com/databricks/databricks-sdk-py/pull/952)).
+  To disable asynchronous token refresh, set the environment variable `DATABRICKS_DISABLE_ASYNC_TOKEN_REFRESH=true` or configure it within your configuration object.
+  The previous `enable_experimental_async_token_refresh` option has been removed as asynchronous refresh is now the default behavior.
 
 ### Bug Fixes
 

--- a/databricks/sdk/__init__.py
+++ b/databricks/sdk/__init__.py
@@ -289,7 +289,7 @@ class WorkspaceClient:
         self._service_principals = service.iam.ServicePrincipalsAPI(self._api_client)
         self._serving_endpoints = serving_endpoints
         serving_endpoints_data_plane_token_source = DataPlaneTokenSource(
-            self._config.host, self._config.oauth_token, not self._config.enable_experimental_async_token_refresh
+            self._config.host, self._config.oauth_token, self._config.disable_async_token_refresh
         )
         self._serving_endpoints_data_plane = service.serving.ServingEndpointsDataPlaneAPI(
             self._api_client, serving_endpoints, serving_endpoints_data_plane_token_source
@@ -758,7 +758,7 @@ class WorkspaceClient:
 
     @property
     def tables(self) -> service.catalog.TablesAPI:
-        """A table resides in the third layer of Unity Catalog’s three-level namespace."""
+        """A table resides in the third layer of Unity Catalog's three-level namespace."""
         return self._tables
 
     @property

--- a/databricks/sdk/config.py
+++ b/databricks/sdk/config.py
@@ -95,9 +95,7 @@ class Config:
     max_connections_per_pool: int = ConfigAttribute()
     databricks_environment: Optional[DatabricksEnvironment] = None
 
-    enable_experimental_async_token_refresh: bool = ConfigAttribute(
-        env="DATABRICKS_ENABLE_EXPERIMENTAL_ASYNC_TOKEN_REFRESH"
-    )
+    disable_async_token_refresh: bool = ConfigAttribute(env="DATABRICKS_DISABLE_ASYNC_TOKEN_REFRESH")
 
     enable_experimental_files_api_client: bool = ConfigAttribute(env="DATABRICKS_ENABLE_EXPERIMENTAL_FILES_API_CLIENT")
     files_api_client_download_max_total_recovers = None

--- a/databricks/sdk/credentials_provider.py
+++ b/databricks/sdk/credentials_provider.py
@@ -191,7 +191,7 @@ def oauth_service_principal(cfg: "Config") -> Optional[CredentialsProvider]:
         token_url=oidc.token_endpoint,
         scopes=["all-apis"],
         use_header=True,
-        disable_async=not cfg.enable_experimental_async_token_refresh,
+        disable_async=cfg.disable_async_token_refresh,
     )
 
     def inner() -> Dict[str, str]:
@@ -291,7 +291,7 @@ def azure_service_principal(cfg: "Config") -> CredentialsProvider:
             token_url=f"{aad_endpoint}{cfg.azure_tenant_id}/oauth2/token",
             endpoint_params={"resource": resource},
             use_params=True,
-            disable_async=not cfg.enable_experimental_async_token_refresh,
+            disable_async=cfg.disable_async_token_refresh,
         )
 
     _ensure_host_present(cfg, token_source_for)
@@ -357,7 +357,7 @@ def github_oidc_azure(cfg: "Config") -> Optional[CredentialsProvider]:
         token_url=f"{aad_endpoint}{cfg.azure_tenant_id}/oauth2/token",
         endpoint_params=params,
         use_params=True,
-        disable_async=not cfg.enable_experimental_async_token_refresh,
+        disable_async=cfg.disable_async_token_refresh,
     )
 
     def refreshed_headers() -> Dict[str, str]:
@@ -694,7 +694,7 @@ class DatabricksCliTokenSource(CliTokenSource):
             token_type_field="token_type",
             access_token_field="access_token",
             expiry_field="expiry",
-            disable_async=not cfg.enable_experimental_async_token_refresh,
+            disable_async=cfg.disable_async_token_refresh,
         )
 
     @staticmethod


### PR DESCRIPTION
## What changes are proposed in this pull request?
Enable async token refresh by default.

## How is this tested?
Integration test will now run using async token refresh.