### PR TITLE
MCP Support in Workspace Client

### DIFF
--- a/databricks/sdk/__init__.py
+++ b/databricks/sdk/__init__.py
@@ -84,6 +84,7 @@ from databricks.sdk.service.marketplace import (
     ProviderExchangeFiltersAPI, ProviderExchangesAPI, ProviderFilesAPI,
     ProviderListingsAPI, ProviderPersonalizationRequestsAPI,
     ProviderProviderAnalyticsDashboardsAPI, ProviderProvidersAPI)
+from databricks.sdk.service.mcp import MCP
 from databricks.sdk.service.ml import (ExperimentsAPI, ForecastingAPI,
                                        ModelRegistryAPI)
 from databricks.sdk.service.oauth2 import (AccountFederationPolicyAPI,
@@ -132,7 +133,7 @@ from databricks.sdk.service.vectorsearch import (VectorSearchEndpointsAPI,
                                                  VectorSearchIndexesAPI)
 from databricks.sdk.service.workspace import (GitCredentialsAPI, ReposAPI,
                                               SecretsAPI, WorkspaceAPI)
-from databricks.sdk.service.mcp import MCP
+
 _LOG = logging.getLogger(__name__)
 
 
@@ -861,7 +862,7 @@ class WorkspaceClient:
         """The Forecasting API allows you to create and get serverless forecasting experiments."""
         return self._forecasting
 
-    @property 
+    @property
     def mcp(self) -> MCP:
         return self._mcp
 

--- a/databricks/sdk/__init__.py
+++ b/databricks/sdk/__init__.py
@@ -132,7 +132,7 @@ from databricks.sdk.service.vectorsearch import (VectorSearchEndpointsAPI,
                                                  VectorSearchIndexesAPI)
 from databricks.sdk.service.workspace import (GitCredentialsAPI, ReposAPI,
                                               SecretsAPI, WorkspaceAPI)
-
+from databricks.sdk.service.mcp import MCP
 _LOG = logging.getLogger(__name__)
 
 
@@ -337,6 +337,7 @@ class WorkspaceClient:
         self._workspace_bindings = pkg_catalog.WorkspaceBindingsAPI(self._api_client)
         self._workspace_conf = pkg_settings.WorkspaceConfAPI(self._api_client)
         self._forecasting = pkg_ml.ForecastingAPI(self._api_client)
+        self._mcp = MCP(self.config)
 
     @property
     def config(self) -> client.Config:
@@ -859,6 +860,10 @@ class WorkspaceClient:
     def forecasting(self) -> pkg_ml.ForecastingAPI:
         """The Forecasting API allows you to create and get serverless forecasting experiments."""
         return self._forecasting
+
+    @property 
+    def mcp(self) -> MCP:
+        return self._mcp
 
     def get_workspace_id(self) -> int:
         """Get the workspace ID of the workspace that this client is connected to."""

--- a/databricks/sdk/service/mcp.py
+++ b/databricks/sdk/service/mcp.py
@@ -1,0 +1,25 @@
+from mcp.client.auth import OAuthClientProvider, TokenStorage
+from mcp.shared.auth import OAuthToken
+
+class DatabricksTokenStorage(TokenStorage):
+    def __init__(self, config):
+        self.config = config
+
+    async def get_tokens(self) -> OAuthToken| None:
+        headers = self.config.authenticate()
+        token = headers["Authorization"].split("Bearer ")[1]
+        return OAuthToken(access_token=token, expires_in=60)
+    
+class MCP:
+    def __init__(self, config):
+        self._config = config
+        self.databricks_token_storage = DatabricksTokenStorage(config)
+
+    def oauth_provider(self):
+        return OAuthClientProvider(
+            server_url="",
+            client_metadata=None,
+            storage=self.databricks_token_storage,
+            redirect_handler=None,
+            callback_handler=None,
+        )

--- a/databricks/sdk/service/mcp.py
+++ b/databricks/sdk/service/mcp.py
@@ -1,21 +1,23 @@
 from mcp.client.auth import OAuthClientProvider, TokenStorage
 from mcp.shared.auth import OAuthToken
 
+
 class DatabricksTokenStorage(TokenStorage):
     def __init__(self, config):
         self.config = config
 
-    async def get_tokens(self) -> OAuthToken| None:
+    async def get_tokens(self) -> OAuthToken | None:
         headers = self.config.authenticate()
         token = headers["Authorization"].split("Bearer ")[1]
         return OAuthToken(access_token=token, expires_in=60)
-    
+
+
 class MCP:
     def __init__(self, config):
         self._config = config
         self.databricks_token_storage = DatabricksTokenStorage(config)
 
-    def oauth_provider(self):
+    def get_oauth_provider(self):
         return OAuthClientProvider(
             server_url="",
             client_metadata=None,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,9 @@ openai = [
     'langchain-openai; python_version > "3.7"',
     "httpx",
 ]
+mcp = [
+    "mcp>=1.9.1"
+]
 
 [tool.setuptools.dynamic]
 version = { attr = "databricks.sdk.version.__version__" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,8 @@ dev = [
     'langchain-openai; python_version > "3.7"',
     "httpx",
     "build", # some integration tests depend on the databricks-sdk-py wheel
+    "mcp>=1.9.1",
+    "pytest-asyncio"
 ]
 notebook = [
     "ipython>=8,<10",

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -1,0 +1,20 @@
+import time
+
+import httpx
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_mcp_oauth_provider(monkeypatch):
+    monkeypatch.setattr(time, "time", lambda: 100)
+    from databricks.sdk import WorkspaceClient
+
+    monkeypatch.setenv("DATABRICKS_HOST", "test_host")
+    monkeypatch.setenv("DATABRICKS_TOKEN", "test_token")
+
+    w = WorkspaceClient()
+    mcp_oauth_provider = w.mcp.get_oauth_provider()
+
+    request = httpx.Request("GET", "https://example.com")
+    response = await anext(mcp_oauth_provider.async_auth_flow(request))
+    assert response.headers["Authorization"] == "Bearer test_token"


### PR DESCRIPTION
## What changes are proposed in this pull request?

- Anthropic recently released MCP Servers and we are currently adding support for First Party (MCP Servers on Control Plane) and Third Party (MCP Servers on Databricks Apps).
- In order to authenticate to MCP servers, the MCP Python-sdk provides us with a OAuthTokenProvider class that we need to implement
- This pr uses the existing WorkspaceClient to populate the token in the Authorization headers of the OAuthTokenProvider so we can use it with the streamable_http client.

## How is this tested?

Added Unit tests.
E2E Test
```
import asyncio
from datetime import datetime, timedelta
from typing import Optional

from mcp.client.session import ClientSession
from mcp.client.streamable_http import streamablehttp_client
from databricks import sdk

workspace_client = sdk.WorkspaceClient(profile="dogfood")
async def query_mcp():
    async with streamablehttp_client(
        url="https://uc-mcp-server-aravind-6051921418418893.staging.aws.databricksapps.com/mcp/",
        auth=workspace_client.mcp.get_oauth_provider(),
    ) as (read_stream, write_stream, _):
        async with ClientSession(read_stream, write_stream) as session:
            await session.initialize()
            tools = await session.list_tools()
            print(tools)


async def main():
    await query_mcp()


if __name__ == "__main__":
    asyncio.run(main())
```
Running the above code with a databricks-cli authentication returns successfully
<img width="1263" alt="image" src="https://github.com/user-attachments/assets/777a321c-3e46-4ae1-8c91-9b83b768f6a1" />