### PR TITLE
Add headers to HttpRequestResponse in OpenAI client.

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Release v0.60.0
 
 ### New Features and Improvements
+* Added headers to HttpRequestResponse in OpenAI client.
 
 ### Bug Fixes
 


### PR DESCRIPTION
## What changes are proposed in this pull request?
Adding headers to HttpRequestResponse when making http_request

Why?
Basically we need the response headers that is used in the MCP spec: https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#session-management
Specially Mcp-Session-Id header.


## How is this tested?
```
%pip install git+https://github.com/sunishsheth2009/databricks-sdk-py@sunish-add-headers
import requests
import uuid
from databricks.sdk import WorkspaceClient
from databricks.sdk.service.serving import ExternalFunctionRequestHttpMethod

# Step 1: Initialize session
init_payload = {
    "jsonrpc": "2.0",
    "id": "init-1",
    "method": "initialize",
    "params": {}
}

init_response = WorkspaceClient().serving_endpoints.http_request(
  conn="github-u2m-managed-connection",
  method=ExternalFunctionRequestHttpMethod.POST,
  path="/mcp",
  json=init_payload,
)

session_id = init_response.headers["mcp-session-id"]
if not session_id:
    print("No session ID returned by server.")

print(f"✅ Got MCP Session ID: {session_id}")


Output:
✅ Got MCP Session ID: 53220122-015c-4e2b-9edb-47580cefffd0
```