### PR TITLE
Add support for passing additional kwargs when instantiating an OpenAI client for Databricks model serving

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### New Features and Improvements
 
+* Added support for passing additional kwargs to `WorkspaceClient().serving_endpoints.get_open_ai_client()` ([#XXX](https://github.com/databricks/databricks-sdk-py/pull/XXX)). Users can now pass standard OpenAI client parameters like `timeout` and `max_retries` when creating an OpenAI client for Databricks Model Serving.
+
 ### Bug Fixes
 
 ### Documentation

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### New Features and Improvements
 
-* Added support for passing additional kwargs to `WorkspaceClient().serving_endpoints.get_open_ai_client()` ([#XXX](https://github.com/databricks/databricks-sdk-py/pull/XXX)). Users can now pass standard OpenAI client parameters like `timeout` and `max_retries` when creating an OpenAI client for Databricks Model Serving.
+* Added support for passing additional kwargs to `WorkspaceClient().serving_endpoints.get_open_ai_client()` ([#1025](https://github.com/databricks/databricks-sdk-py/pull/1025)). Users can now pass standard OpenAI client parameters like `timeout` and `max_retries` when creating an OpenAI client for Databricks Model Serving.
 
 ### Bug Fixes
 

--- a/databricks/sdk/mixins/open_ai_client.py
+++ b/databricks/sdk/mixins/open_ai_client.py
@@ -3,11 +3,9 @@ from typing import Dict, Optional
 
 from requests import Response
 
-from databricks.sdk.service.serving import (
-    ExternalFunctionRequestHttpMethod,
-    HttpRequestResponse,
-    ServingEndpointsAPI,
-)
+from databricks.sdk.service.serving import (ExternalFunctionRequestHttpMethod,
+                                            HttpRequestResponse,
+                                            ServingEndpointsAPI)
 
 
 class ServingEndpointsExt(ServingEndpointsAPI):

--- a/databricks/sdk/mixins/open_ai_client.py
+++ b/databricks/sdk/mixins/open_ai_client.py
@@ -3,7 +3,9 @@ from typing import Dict, Optional
 
 from requests import Response
 
-from databricks.sdk.service.serving import ExternalFunctionRequestHttpMethod, HttpRequestResponse, ServingEndpointsAPI
+from databricks.sdk.service.serving import (ExternalFunctionRequestHttpMethod,
+                                            HttpRequestResponse,
+                                            ServingEndpointsAPI)
 
 
 class ServingEndpointsExt(ServingEndpointsAPI):

--- a/databricks/sdk/mixins/open_ai_client.py
+++ b/databricks/sdk/mixins/open_ai_client.py
@@ -3,9 +3,11 @@ from typing import Dict, Optional
 
 from requests import Response
 
-from databricks.sdk.service.serving import (ExternalFunctionRequestHttpMethod,
-                                            HttpRequestResponse,
-                                            ServingEndpointsAPI)
+from databricks.sdk.service.serving import (
+    ExternalFunctionRequestHttpMethod,
+    HttpRequestResponse,
+    ServingEndpointsAPI,
+)
 
 
 class ServingEndpointsExt(ServingEndpointsAPI):
@@ -44,14 +46,19 @@ class ServingEndpointsExt(ServingEndpointsAPI):
                 Common parameters include:
                 - timeout (float): Request timeout in seconds (e.g., 30.0)
                 - max_retries (int): Maximum number of retries for failed requests (e.g., 3)
+                - default_headers (dict): Additional headers to include with requests
+                - default_query (dict): Additional query parameters to include with requests
 
-                Any parameter accepted by the OpenAI client constructor can be passed here.
+                Any parameter accepted by the OpenAI client constructor can be passed here,
+                except for the following parameters which are reserved for Databricks integration:
+                base_url, api_key, http_client
 
         Returns:
             OpenAI: An OpenAI client instance configured for Databricks Model Serving.
 
         Raises:
             ImportError: If the OpenAI library is not installed.
+            ValueError: If any reserved Databricks parameters are provided in kwargs.
 
         Example:
             >>> client = workspace_client.serving_endpoints.get_open_ai_client()
@@ -66,6 +73,15 @@ class ServingEndpointsExt(ServingEndpointsAPI):
         except Exception:
             raise ImportError(
                 "Open AI is not installed. Please install the Databricks SDK with the following command `pip install databricks-sdk[openai]`"
+            )
+
+        # Check for reserved parameters that should not be overridden
+        reserved_params = {"base_url", "api_key", "http_client"}
+        conflicting_params = reserved_params.intersection(kwargs.keys())
+        if conflicting_params:
+            raise ValueError(
+                f"Cannot override reserved Databricks parameters: {', '.join(sorted(conflicting_params))}. "
+                f"These parameters are automatically configured for Databricks Model Serving."
             )
 
         # Default parameters that are required for Databricks integration

--- a/databricks/sdk/mixins/open_ai_client.py
+++ b/databricks/sdk/mixins/open_ai_client.py
@@ -3,9 +3,7 @@ from typing import Dict, Optional
 
 from requests import Response
 
-from databricks.sdk.service.serving import (ExternalFunctionRequestHttpMethod,
-                                            HttpRequestResponse,
-                                            ServingEndpointsAPI)
+from databricks.sdk.service.serving import ExternalFunctionRequestHttpMethod, HttpRequestResponse, ServingEndpointsAPI
 
 
 class ServingEndpointsExt(ServingEndpointsAPI):
@@ -33,12 +31,12 @@ class ServingEndpointsExt(ServingEndpointsAPI):
 
     def get_open_ai_client(self, **kwargs):
         """Create an OpenAI client configured for Databricks Model Serving.
-        
+
         Returns an OpenAI client instance that is pre-configured to send requests to
         Databricks Model Serving endpoints. The client uses Databricks authentication
         to query endpoints within the workspace associated with the current WorkspaceClient
         instance.
-        
+
         Args:
             **kwargs: Additional parameters to pass to the OpenAI client constructor.
                 Common parameters include:
@@ -46,18 +44,18 @@ class ServingEndpointsExt(ServingEndpointsAPI):
                 - max_retries (int): Maximum number of retries for failed requests (e.g., 3)
 
                 Any parameter accepted by the OpenAI client constructor can be passed here.
-                
+
         Returns:
             OpenAI: An OpenAI client instance configured for Databricks Model Serving.
-            
+
         Raises:
             ImportError: If the OpenAI library is not installed.
-            
+
         Example:
             >>> client = workspace_client.serving_endpoints.get_open_ai_client()
             >>> # With custom timeout and retries
             >>> client = workspace_client.serving_endpoints.get_open_ai_client(
-            ...     timeout=30.0, 
+            ...     timeout=30.0,
             ...     max_retries=5
             ... )
         """
@@ -74,7 +72,7 @@ class ServingEndpointsExt(ServingEndpointsAPI):
             "api_key": "no-token",  # Passing in a placeholder to pass validations, this will not be used
             "http_client": self._get_authorized_http_client(),
         }
-        
+
         # Update with any additional parameters passed by the user
         client_params.update(kwargs)
 

--- a/tests/test_open_ai_mixin.py
+++ b/tests/test_open_ai_mixin.py
@@ -19,6 +19,44 @@ def test_open_ai_client(monkeypatch):
     assert client.api_key == "no-token"
 
 
+def test_open_ai_client_with_custom_params(monkeypatch):
+    from databricks.sdk import WorkspaceClient
+
+    monkeypatch.setenv("DATABRICKS_HOST", "test_host")
+    monkeypatch.setenv("DATABRICKS_TOKEN", "test_token")
+    w = WorkspaceClient(config=Config())
+    
+    # Test with timeout and max_retries parameters
+    client = w.serving_endpoints.get_open_ai_client(timeout=30.0, max_retries=3)
+
+    assert client.base_url == "https://test_host/serving-endpoints/"
+    assert client.api_key == "no-token"
+    assert client.timeout == 30.0
+    assert client.max_retries == 3
+
+
+def test_open_ai_client_with_additional_kwargs(monkeypatch):
+    from databricks.sdk import WorkspaceClient
+
+    monkeypatch.setenv("DATABRICKS_HOST", "test_host")
+    monkeypatch.setenv("DATABRICKS_TOKEN", "test_token")
+    w = WorkspaceClient(config=Config())
+    
+    # Test with additional kwargs that OpenAI client might accept
+    client = w.serving_endpoints.get_open_ai_client(
+        timeout=60.0,
+        max_retries=5,
+        default_headers={"Custom-Header": "test-value"}
+    )
+
+    assert client.base_url == "https://test_host/serving-endpoints/"
+    assert client.api_key == "no-token"
+    assert client.timeout == 60.0
+    assert client.max_retries == 5
+    assert "Custom-Header" in client.default_headers
+    assert client.default_headers["Custom-Header"] == "test-value"
+
+
 @pytest.mark.skipif(sys.version_info < (3, 8), reason="Requires Python > 3.7")
 def test_langchain_open_ai_client(monkeypatch):
     from databricks.sdk import WorkspaceClient

--- a/tests/test_open_ai_mixin.py
+++ b/tests/test_open_ai_mixin.py
@@ -25,7 +25,7 @@ def test_open_ai_client_with_custom_params(monkeypatch):
     monkeypatch.setenv("DATABRICKS_HOST", "test_host")
     monkeypatch.setenv("DATABRICKS_TOKEN", "test_token")
     w = WorkspaceClient(config=Config())
-    
+
     # Test with timeout and max_retries parameters
     client = w.serving_endpoints.get_open_ai_client(timeout=30.0, max_retries=3)
 
@@ -41,12 +41,10 @@ def test_open_ai_client_with_additional_kwargs(monkeypatch):
     monkeypatch.setenv("DATABRICKS_HOST", "test_host")
     monkeypatch.setenv("DATABRICKS_TOKEN", "test_token")
     w = WorkspaceClient(config=Config())
-    
+
     # Test with additional kwargs that OpenAI client might accept
     client = w.serving_endpoints.get_open_ai_client(
-        timeout=60.0,
-        max_retries=5,
-        default_headers={"Custom-Header": "test-value"}
+        timeout=60.0, max_retries=5, default_headers={"Custom-Header": "test-value"}
     )
 
     assert client.base_url == "https://test_host/serving-endpoints/"


### PR DESCRIPTION
## What changes are proposed in this pull request?

Per customer request, adds support for passing additional optional kwargs to `databricks.sdk.WorkspaceClient().get_open_ai_client()`. This enables use cases like specifying a custom timeout and retry policy for latency-sensitive workloads, e.g:

```
>>> # Configure custom timeout and retries
>>> client = workspace_client.serving_endpoints.get_open_ai_client(
...     timeout=30.0, 
...     max_retries=5
... )
```

## How is this tested?

Updated unit tests