### PR TITLE
Fix pytest-xdist serialization issues in nightly tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ Documentation = "https://databricks-sdk-py.readthedocs.io"
 dev = [
     "pytest",
     "pytest-cov",
-    "pytest-xdist",
+    "pytest-xdist>=3.6.1,<4.0",
     "pytest-mock",
     "black",
     "pycodestyle",


### PR DESCRIPTION
Pin pytest-xdist to version >=3.6.1,<4.0 to resolve ExceptionInfo serialization errors that were causing test failures in the nightly integration tests. The error occurred when pytest-xdist tried to serialize exception information between worker processes.