### PR TITLE
Improve OBO error message to guide users on proper WorkspaceClient instantiation

### DIFF
--- a/databricks/sdk/credentials_provider.py
+++ b/databricks/sdk/credentials_provider.py
@@ -1138,7 +1138,13 @@ class ModelServingUserCredentials(CredentialsStrategy):
             header_factory = model_serving_auth_visitor(cfg, self.credential_type)
             if not header_factory:
                 raise ValueError(
-                    f"Unable to authenticate using {self.credential_type} in Databricks Model Serving Environment"
+                    "Unable to authenticate using model_serving_user_credentials in Databricks Model Serving Environment. "
+                    "This error typically occurs when the WorkspaceClient is instantiated at model-loading time rather than within a predict() or predict_stream() call. "
+                    "Please ensure you instantiate the WorkspaceClient inside your predict() or predict_stream() function. "
+                    "Additionally, verify that you have specified UserAuthPolicy when logging the agent model and that "
+                    "On Behalf of User Authorization for Agents is enabled in your workspace. "
+                    "Refer to the documentation for more information: https://docs.databricks.com/aws/en/generative-ai/agent-framework/authenticate-on-behalf-of-user. "
+                    "If the issue persists, contact Databricks Support."
                 )
             return header_factory
         else:


### PR DESCRIPTION
## What changes are proposed in this pull request?
The error message when attempting to use OBO user credentials in Databricks model serving now:
- Explains the most common cause: instantiating WorkspaceClient at model-loading time
- Provides clear guidance to instantiate within predict() or predict_stream()
- Maintains existing checks for UserAuthPolicy and workspace OBO enablement
- Links to documentation for additional help

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## How is this tested?
Unit tests