### PR TITLE
Add `dbutils/remote` to the user agent of calls made through the `RemoteDbUtils` client.

### DIFF
--- a/databricks/sdk/dbutils.py
+++ b/databricks/sdk/dbutils.py
@@ -210,7 +210,7 @@ class _JobsUtil:
 class RemoteDbUtils:
 
     def __init__(self, config: "Config" = None):
-        # Create a shallow copy of the config to allow the use of a custom 
+        # Create a shallow copy of the config to allow the use of a custom
         # user-agent while avoiding modifying the original config.
         self._config = Config() if not config else config.copy()
         self._config.with_user_agent_extra("dbutils", "remote")

--- a/tests/test_dbutils.py
+++ b/tests/test_dbutils.py
@@ -297,5 +297,5 @@ def test_dbutils_adds_user_agent(config):
 
     # Create dbutils and check that user-agent includes sdk-feature/dbutils
     dbutils = RemoteDbUtils(config)
-    
-    assert "sdk-feature/dbutils" in dbutils._config.user_agent
+
+    assert "dbutils/remote" in dbutils._config.user_agent


### PR DESCRIPTION
## What changes are proposed in this pull request?

Simple PR adding `dbutils/remote` to the user agent of calls made through the `RemoteDbUtils` client.

## How is this tested?

Unit + Integration tests.

NO_CHANGELOG=true