### PR TITLE
Add options for the Long Running Operation.

### DIFF
--- a/databricks/sdk/common/lro.py
+++ b/databricks/sdk/common/lro.py
@@ -1,0 +1,17 @@
+from datetime import timedelta
+from typing import Optional
+
+
+class LroOptions:
+    """LroOptions is the options for the Long Running Operations.
+    DO NOT USE THIS OPTION. This option is still under development
+    and can be updated in the future without notice.
+    """
+
+    def __init__(self, *, timeout: Optional[timedelta] = None):
+        """
+        Args:
+            timeout: The timeout for the Long Running Operations.
+                    If not set, the default timeout is 20 minutes.
+        """
+        self.timeout = timeout or timedelta(minutes=20)


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/databricks/databricks-sdk-py/pull/1072/files) to review incremental changes.
- [**stack/add-lro-option**](https://github.com/databricks/databricks-sdk-py/pull/1072) [[Files changed](https://github.com/databricks/databricks-sdk-py/pull/1072/files)]

---------
## What changes are proposed in this pull request?

This PR adds the options for the Long Running Operation. Currently, it only has a timeout option similar to other SDKs, but it can be extended in the future.
 
## How is this tested?

N/A

NO_CHANGELOG=true