### PR TITLE
Fix incorrect URL in error message

### DIFF
--- a/databricks/sdk/errors/parser.py
+++ b/databricks/sdk/errors/parser.py
@@ -43,7 +43,7 @@ def _unknown_error(response: requests.Response, debug_headers: bool = False) -> 
     return (
         "This is likely a bug in the Databricks SDK for Python or the underlying "
         "API. Please report this issue with the following debugging information to the SDK issue tracker at "
-        f"https://github.com/databricks/databricks-sdk-go/issues. Request log:```{request_log}```"
+        f"https://github.com/databricks/databricks-sdk-py/issues. Request log:```{request_log}```"
     )
 
 


### PR DESCRIPTION
- Changed databricks-sdk-go to databricks-sdk-py in parser.py line 46
- This fixes the issue tracker URL to point to the correct Python SDK repository, instead of sending developer to the incorrect URL for reporting issues.
- Testing Done: N/A as this is was modifying string content only NO_CHANGELOG=true