### PR TITLE
Fix FilesExt should fallback when Presigned URL is not available

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New Features and Improvements
 
 ### Bug Fixes
+- Fix `FilesExt` can fail to upload and download data when Presigned URLs are not available in certain environments (e.g. Serverless GPU clusters).
 
 ### Documentation
 


### PR DESCRIPTION


## What changes are proposed in this pull request?

Provide the readers and reviewers with the information they need to understand
this PR in a comprehensive manner. 

Specifically, try to answer the two following questions:

- **WHAT** 
  - Fix `FilesExt`'s upload and download should fallback when Presigned URLs are not available in certain compute types.
- **WHY**
  - In some newer compute clusters (e.g. model serving clusters), creating presigned URL through Files API is not possible yet. Client should fallback in such circumstances to not using Presigned URL. Or else the customer wouldn't be able to upload or download data using w.files.

## How is this tested?

It is tested using unit tests.