### PR TITLE
Increase async cache stale period from 3 to 5 minutes.

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### New Features and Improvements
 
+* Increase async cache stale period from 3 to 5 minutes to cover the maximum monthly downtime of a 99.99% uptime SLA.
+
 ### Security
 
 ### Bug Fixes

--- a/databricks/sdk/oauth.py
+++ b/databricks/sdk/oauth.py
@@ -247,7 +247,9 @@ class Refreshable(TokenSource):
 
     _EXECUTOR = None
     _EXECUTOR_LOCK = threading.Lock()
-    _DEFAULT_STALE_DURATION = timedelta(minutes=3)
+    # Default duration for the stale period. This value is chosen to cover the
+    # maximum monthly downtime allowed by a 99.99% uptime SLA (~4.38 minutes).
+    _DEFAULT_STALE_DURATION = timedelta(minutes=5)
 
     @classmethod
     def _get_executor(cls):


### PR DESCRIPTION
## Changes

Increases the default async cache stale period from 3 minutes to 5 minutes.

## Rationale

The 5-minute stale period covers the maximum monthly downtime allowed by a 99.99% uptime SLA (~4.38 minutes). This ensures that even during the worst-case downtime scenario, the cache can continue serving stale tokens while waiting for the auth service to recover (assuming continuous traffic).