### PR TITLE
Add ServerlessUsagePolicyName to Config class

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New Features and Improvements
 
 * Increase async cache stale period from 3 to 5 minutes to cover the maximum monthly downtime of a 99.99% uptime SLA.
+* Expose ServerlessUsagePolicyName profile property in Config.
 
 ### Security
 

--- a/databricks/sdk/config.py
+++ b/databricks/sdk/config.py
@@ -112,7 +112,10 @@ class Config:
     auth_type: str = ConfigAttribute(env="DATABRICKS_AUTH_TYPE")
     cluster_id: str = ConfigAttribute(env="DATABRICKS_CLUSTER_ID")
     warehouse_id: str = ConfigAttribute(env="DATABRICKS_WAREHOUSE_ID")
+
+    # Serverless Compute ID and Serverless Usage Policy Name are used to set the serverless compute mode when using DB connect.
     serverless_compute_id: str = ConfigAttribute(env="DATABRICKS_SERVERLESS_COMPUTE_ID")
+    serverless_usage_policy_name: str = ConfigAttribute(env="DATABRICKS_SERVERLESS_USAGE_POLICY_NAME")
     skip_verify: bool = ConfigAttribute()
     http_timeout_seconds: float = ConfigAttribute()
     debug_truncate_bytes: int = ConfigAttribute(env="DATABRICKS_DEBUG_TRUNCATE_BYTES")

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -299,3 +299,32 @@ def test_config_auth_type_from_env(monkeypatch):
 
     assert cfg.auth_type == "basic"
     assert cfg.host == "https://x"
+
+
+def test_config_serverless_usage_policy_name_from_env(monkeypatch):
+    monkeypatch.setenv("DATABRICKS_HOST", "https://test.cloud.databricks.com")
+    monkeypatch.setenv("DATABRICKS_TOKEN", "test-token")
+    monkeypatch.setenv("DATABRICKS_SERVERLESS_USAGE_POLICY_NAME", "env-serverless-policy")
+    cfg = Config()
+
+    assert cfg.serverless_usage_policy_name == "env-serverless-policy"
+
+
+def test_config_serverless_usage_policy_name_from_config_file(monkeypatch):
+    monkeypatch.setenv("DATABRICKS_CONFIG_PROFILE", "serverless-policy")
+    set_home(monkeypatch, "/testdata/serverless")
+    cfg = Config()
+
+    assert cfg.auth_type == "pat"
+    assert cfg.host == "https://test.cloud.databricks.com"
+    assert cfg.serverless_usage_policy_name == "my-serverless-policy"
+
+
+def test_config_serverless_usage_policy_name_empty_from_config_file(monkeypatch):
+    monkeypatch.setenv("DATABRICKS_CONFIG_PROFILE", "serverless-policy-empty")
+    set_home(monkeypatch, "/testdata/serverless")
+    cfg = Config()
+
+    assert cfg.auth_type == "pat"
+    assert cfg.host == "https://test.cloud.databricks.com"
+    assert cfg.serverless_usage_policy_name is None

--- a/tests/testdata/serverless/.databrickscfg
+++ b/tests/testdata/serverless/.databrickscfg
@@ -1,0 +1,8 @@
+[serverless-policy]
+host = https://test.cloud.databricks.com
+token = test-token
+serverless_usage_policy_name = my-serverless-policy
+
+[serverless-policy-empty]
+host = https://test.cloud.databricks.com
+token = test-token


### PR DESCRIPTION


## What changes are proposed in this pull request?
This is a Databricks Config property used only by DB Connect. It is added to the SDK Config as a pass-through so DB Connect can access it.

## How is this tested?
Added unit tests:
  - `test_config_serverless_usage_policy_name_from_env`: Tests reading from `DATABRICKS_SERVERLESS_USAGE_POLICY_NAME` environment variable
  - `test_config_serverless_usage_policy_name_from_config_file`: Tests reading from `.databrickscfg` config file
  - `test_config_serverless_usage_policy_name_empty_from_config_file`: Tests that missing field returns None