### PR TITLE
Add more retries for failing integration tests

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -14,8 +14,6 @@
 
 ### Internal Changes
 
-* Increase the number of re-runs for failing tests from 2 to 4 to improve the reliability of the test suite.
-
 ### API Changes
 * Add `table_deltasharing_open_dir_based` enum value for `databricks.sdk.service.catalog.SecurableKind`.
 * Add `creating` and `create_failed` enum values for `databricks.sdk.service.settings.NccPrivateEndpointRulePrivateLinkConnectionState`.


### PR DESCRIPTION
## What changes are proposed in this pull request?

As part of the automation of SDK updates, it is important that the tests on the PR pass before it is merged. Due to some tests being flaky, the integration tests often fail on the automated PRs leading to unmerged orphaned PRs. This PR increases the number of retries for failing tests to increase the reliability of the integration test suite.

## How is this tested?

N/A

NO_CHANGELOG=true