### PR TITLE
[Internal] Reduce API roundtrips in integration test for listing workspace groups 

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -12,4 +12,6 @@
 
 ### Internal Changes
 
+* Increase count in integration test for listing workspace groups to reduce API calls and timeout. 
+
 ### API Changes

--- a/tests/integration/test_iam.py
+++ b/tests/integration/test_iam.py
@@ -28,7 +28,7 @@ def test_scim_get_user_as_dict(w):
     "path,call",
     [
         ("/api/2.0/preview/scim/v2/Users", lambda w: w.users.list(count=10)),
-        ("/api/2.0/preview/scim/v2/Groups", lambda w: w.groups.list(count=4)),
+        ("/api/2.0/preview/scim/v2/Groups", lambda w: w.groups.list(count=20)),
         (
             "/api/2.0/preview/scim/v2/ServicePrincipals",
             lambda w: w.service_principals.list(count=1),


### PR DESCRIPTION
## What changes are proposed in this pull request?
- Reduce API roundtrips in integration test for listing workspace groups 

## How is this tested?
- Updated test