### PR TITLE
Use CLOUD_PROVIDER instead of host to determine which tests to run

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -8,6 +8,7 @@ import sys
 import pytest
 
 from databricks.sdk import AccountClient, FilesAPI, FilesExt, WorkspaceClient
+from databricks.sdk.environments import Cloud
 from databricks.sdk.service.catalog import VolumeType
 
 
@@ -163,6 +164,13 @@ def _is_in_debug() -> bool:
         "_jb_pytest_runner.py",
         "testlauncher.py",
     ]
+
+
+def _is_cloud(cloud: Cloud) -> bool:
+    """Check if the CLOUD_PROVIDER environment variable matches the specified cloud provider."""
+    cloud_provider = os.getenv("CLOUD_PROVIDER", "").upper()
+    cloud_upper = cloud.value.upper()
+    return cloud_provider == cloud_upper
 
 
 @pytest.fixture(scope="function")

--- a/tests/integration/test_deployment.py
+++ b/tests/integration/test_deployment.py
@@ -2,9 +2,13 @@ import logging
 
 import pytest
 
+from databricks.sdk.environments import Cloud
+
+from .conftest import _is_cloud
+
 
 def test_workspaces(a):
-    if a.config.is_azure:
+    if _is_cloud(Cloud.AZURE):
         pytest.skip("not available on Azure")
     for w in a.workspaces.list():
         logging.info(f"Found workspace: {w.workspace_name}")


### PR DESCRIPTION
## What changes are proposed in this pull request?
Use CLOUD_PROVIDER instead of host to determine which tests to run. 

This decouples test run from host parsing and allows testing Cloud specific features on cloud agnostic hosts.

## How is this tested?
Check test run and validate that the test runs only when expected
<img width="1287" height="69" alt="Screenshot 2026-01-28 at 10 54 49" src="https://github.com/user-attachments/assets/cd4186bc-376e-489b-9656-e45fa0a84834" />
<img width="1408" height="85" alt="Screenshot 2026-01-28 at 10 55 34" src="https://github.com/user-attachments/assets/80990058-167a-4cdf-acbe-748b795d4293" />




NO_CHANGELOG=true