### PR TITLE
Change x-databricks-parent-service with the x-databricks-parent-name in the Python Docs Generator

### DIFF
--- a/docs/gen-client-docs.py
+++ b/docs/gen-client-docs.py
@@ -298,13 +298,19 @@ class Generator:
         mapping = {}
         pkgs = {p.name: p for p in self.packages}
         spec = json.loads(self._openapi_spec())
+
+        tag_by_name = {t['name']: t for t in spec['tags']}
+
         for tag in spec['tags']:
             is_account=tag.get('x-databricks-is-accounts')
-            # Unique identifier for the tag. Note that the service name may not be unique
+            # Unique identifier for the tag. Note that the service name may not be unique.
             key = 'a' if is_account else 'w'
-            parent_service = tag.get('x-databricks-parent-service')
-            if parent_service:
-                # SDK generation removes the "account" prefix from account services
+
+            parent_name = tag.get('x-databricks-parent-name')
+            if parent_name:
+                parent_tag = tag_by_name[parent_name]
+                parent_service = parent_tag['x-databricks-service']
+                # SDK generation removes the "account" prefix from account services.
                 clean_parent_service = parent_service.lower().removeprefix("account")
                 key = f"{key}.{clean_parent_service}"
 


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/databricks/databricks-sdk-py/pull/1230/files) to review incremental changes.
- [**stack/py-update-fix**](https://github.com/databricks/databricks-sdk-py/pull/1230) [[Files changed](https://github.com/databricks/databricks-sdk-py/pull/1230/files)]

---------
## What changes are proposed in this pull request?

This PR updates the usage of x-databricks-parent-service (the service name of the parent) to x-databricks-parent-name (the tag name of the parent) in the Python Docs Generator because the latest Spec has changed upstream, and we now only populate x-databricks-parent-name.

## How is this tested?

Locally generated the SDK with the new Spec.

NO_CHANGELOG=true