### PR TITLE
feat: improve error message for missing cluster_id in dbutils

### DIFF
--- a/databricks/sdk/dbutils.py
+++ b/databricks/sdk/dbutils.py
@@ -243,7 +243,16 @@ class RemoteDbUtils:
     def _cluster_id(self) -> str:
         cluster_id = self._config.cluster_id
         if not cluster_id:
-            message = "cluster_id is required in the configuration"
+            message = (
+                "cluster_id is required in the configuration to use dbutils. "
+                "Please configure a cluster_id using one of the following methods:\n"
+                "  1. Set the DATABRICKS_CLUSTER_ID environment variable\n"
+                "  2. Add cluster_id to your ~/.databrickscfg profile\n"
+                "  3. Pass cluster_id directly to the Config object: "
+                "Config(cluster_id='your-cluster-id')\n\n"
+                "For more information, see: "
+                "https://docs.databricks.com/en/dev-tools/sdk-python.html#configure-cluster-id"
+            )
             raise ValueError(self._config.wrap_debug_info(message))
         return cluster_id
 


### PR DESCRIPTION
## Summary

Improves the error message when users try to use dbutils without configuring a cluster_id.

## Problem

When calling `dbutils.help()` or any dbutils method without setting up a cluster, users would get a generic error:
```
DatabricksError: Missing required field: cluster_id
```

This doesn't help users understand how to fix the issue.

## Solution

The new error message provides clear resolution steps:

```
cluster_id is required in the configuration to use dbutils. Please configure a cluster_id using one of the following methods:
  1. Set the DATABRICKS_CLUSTER_ID environment variable
  2. Add cluster_id to your ~/.databrickscfg profile
  3. Pass cluster_id directly to the Config object: Config(cluster_id='your-cluster-id')

For more information, see: https://docs.databricks.com/en/dev-tools/sdk-python.html#configure-cluster-id
```

## Changes

- Updated `_cluster_id` property in `RemoteDbUtils` class to provide a detailed error message with:
  - Clear explanation of why the error occurred
  - Three different methods to configure cluster_id
  - Link to relevant documentation

Closes #51