### PR TITLE
fix: correct typos 'recieve' and 'occured'

### DIFF
--- a/databricks/sdk/service/catalog.py
+++ b/databricks/sdk/service/catalog.py
@@ -13620,7 +13620,7 @@ class ModelVersionsAPI:
 
         The returned models are filtered based on the privileges of the calling user. For example, the
         metastore admin is able to list all the model versions. A regular user needs to be the owner or have
-        the **EXECUTE** privilege on the parent registered model to recieve the model versions in the
+        the **EXECUTE** privilege on the parent registered model to receive the model versions in the
         response. For the latter case, the caller must also be the owner or have the **USE_CATALOG** privilege
         on the parent catalog and the **USE_SCHEMA** privilege on the parent schema.
 
@@ -14786,7 +14786,7 @@ class RegisteredModelsAPI:
 
         The returned models are filtered based on the privileges of the calling user. For example, the
         metastore admin is able to list all the registered models. A regular user needs to be the owner or
-        have the **EXECUTE** privilege on the registered model to recieve the registered models in the
+        have the **EXECUTE** privilege on the registered model to receive the registered models in the
         response. For the latter case, the caller must also be the owner or have the **USE_CATALOG** privilege
         on the parent catalog and the **USE_SCHEMA** privilege on the parent schema.
 

--- a/databricks/sdk/service/jobs.py
+++ b/databricks/sdk/service/jobs.py
@@ -1801,7 +1801,7 @@ class ForEachTaskErrorMessageStats:
     """Describes the count of such error message encountered during the iterations."""
 
     error_message: Optional[str] = None
-    """Describes the error message occured during the iterations."""
+    """Describes the error message occurred during the iterations."""
 
     termination_category: Optional[str] = None
     """Describes the termination reason for the error message."""


### PR DESCRIPTION
Fixed typos in docstrings:
- 'recieve' → 'receive' in catalog.py (2 occurrences)
- 'occured' → 'occurred' in jobs.py (1 occurrence)