### PR TITLE
Fix recursive file listing in volumes

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bug Fixes
 
+* Fixed recursive file lising in `WorkspaceClient.dbfs.list` on volumes. ([#1260](https://github.com/databricks/databricks-sdk-py/pull/1260))
+
 ### Documentation
 
 ### Internal Changes

--- a/databricks/sdk/mixins/files.py
+++ b/databricks/sdk/mixins/files.py
@@ -495,7 +495,7 @@ class _VolumesPath(_Path):
             next_path = queue.popleft()
             for file in self._api.list_directory_contents(next_path.as_string):
                 if recursive and file.is_directory:
-                    queue.append(self.child(file.name))
+                    queue.append(self.child(file.path))
                 if not recursive or not file.is_directory:
                     yield files.FileInfo(
                         path=file.path,


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fix recursive file listing on volumes. Fixes #1260 . The new code is analogous to `_DbfsPath`, were the recursion also happens on `file.path`.

## How is this tested?

Manually tested on a volume *with sub-sub-directories* using
```python
print(list(client.dbfs.list("/Volumes/...", recursive=True)))
```