### PR TITLE
Return error if explicit scopes set with databricks-cli auth

### DIFF
--- a/databricks/sdk/config.py
+++ b/databricks/sdk/config.py
@@ -267,6 +267,7 @@ class Config:
         self._header_factory = None
         self._inner = {}
         self._user_agent_other_info = []
+        self._scopes_explicitly_set = "scopes" in kwargs
         self._custom_headers = custom_headers or {}
         if credentials_strategy and credentials_provider:
             raise ValueError("When providing `credentials_strategy` field, `credential_provider` cannot be specified.")

--- a/databricks/sdk/credentials_provider.py
+++ b/databricks/sdk/credentials_provider.py
@@ -917,6 +917,12 @@ class DatabricksCliTokenSource(CliTokenSource):
         raise err
 
 
+_ERR_CUSTOM_SCOPES_NOT_SUPPORTED = (
+    "custom scopes are not supported with databricks-cli auth; "
+    "scopes are determined by what was last used when logging in with `databricks auth login`"
+)
+
+
 @oauth_credentials_strategy("databricks-cli", ["host"])
 def databricks_cli(cfg: "Config") -> Optional[CredentialsProvider]:
     try:
@@ -934,6 +940,9 @@ def databricks_cli(cfg: "Config") -> Optional[CredentialsProvider]:
         raise e
 
     logger.info("Using Databricks CLI authentication")
+
+    if cfg.scopes and cfg._scopes_explicitly_set:
+        raise ValueError(_ERR_CUSTOM_SCOPES_NOT_SUPPORTED)
 
     def inner() -> Dict[str, str]:
         token = token_source.token()


### PR DESCRIPTION
## What

Reject explicit custom scopes when `databricks-cli` auth is selected. Tracks whether scopes were user-provided (`_scopes_explicitly_set`) vs loaded from a profile, and raises `ValueError` if `databricks-cli` auth is selected.

## Why

The CLI's token store does not support scopes, so scopes used with databricks-cli auth are silently ignored currently. This returns an error instead of ignoring, informing users that the scopes they use when doing auth login are used, not what they pass in explicitly.

## Tests
- Explicit scopes + CLI installed → `ValueError`
- Explicit scopes + CLI absent → `None` (allows fallback)
- Profile-loaded scopes + CLI installed → succeeds
- No scopes + CLI absent → `None`

---
NO_CHANGELOG=true