### PR TITLE
Fix #1264

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Security
 
 ### Bug Fixes
+* Fixes TypeError in _unknown_error() when API returns unparseable error on streaming request (#1264) 
 
 ### Documentation
 

--- a/databricks/sdk/errors/parser.py
+++ b/databricks/sdk/errors/parser.py
@@ -43,7 +43,7 @@ def _unknown_error(response: requests.Response, debug_headers: bool = False) -> 
     return (
         "This is likely a bug in the Databricks SDK for Python or the underlying "
         "API. Please report this issue with the following debugging information to the SDK issue tracker at "
-        f"https://github.com/databricks/databricks-sdk-go/issues. Request log:```{request_log}```"
+        f"https://github.com/databricks/databricks-sdk-py/issues. Request log:```{request_log}```"
     )
 
 

--- a/databricks/sdk/logger/round_trip_logger.py
+++ b/databricks/sdk/logger/round_trip_logger.py
@@ -44,7 +44,10 @@ class RoundTrip:
             for k, v in request.headers.items():
                 sb.append(f"> * {k}: {self._only_n_bytes(v, self._debug_truncate_bytes)}")
         if request.body:
-            sb.append("> [raw stream]" if self._raw else self._redacted_dump("> ", request.body))
+            if self._raw or not isinstance(request.body, str):
+                sb.append("> [raw stream]")
+            else:
+                sb.append(self._redacted_dump("> ", request.body))
         sb.append(f"< {self._response.status_code} {self._response.reason}")
         if self._raw and self._response.headers.get("Content-Type", None) != "application/json":
             # Raw streams with `Transfer-Encoding: chunked` do not have `Content-Type` header


### PR DESCRIPTION
## What changes are proposed in this pull request?

- **WHAT**: Fixes TypeError crash in RoundTrip.generate() when handling unparseable API error responses 
and corrects the SDK issue tracker URL in error messages from databricks-sdk-go to databricks-sdk-py
 
- **WHY**: When _BaseClient.do() receives string/bytes data, it wraps it in BytesIO for retry/seek support (line 167-169 in _base_client.py). If the API returns an unparseable error response, _unknown_error() creates a RoundTrip object to generate debug information. However, it doesn't pass raw=True, causing _redacted_dump() to be called with the BytesIO object instead of a string. This results in len(body) failing with TypeError: object of type '_io.BytesIO' has no len().

  The fix checks if request.body is a string before calling _redacted_dump(). Non-string bodies (like BytesIO) are now logged as [raw stream], consistent with how raw streams are handled elsewhere in the codebase.

  Fixes #1264


## How is this tested?

- Added test_unknown_error_with_bytesio_request_body() in tests/test_errors.py that reproduces the exact scenario from the issue
- Updated 3 existing test cases to use the corrected SDK URL
