### PR TITLE
Read experimental_files_ext_enable_storage_proxy config from env var

### DIFF
--- a/databricks/sdk/config.py
+++ b/databricks/sdk/config.py
@@ -259,7 +259,7 @@ class Config:
 
     # Whether to enable the storage proxy for file operations.
     # When enabled, the SDK will probe the storage proxy and use it if available.
-    experimental_files_ext_enable_storage_proxy: bool = False
+    experimental_files_ext_enable_storage_proxy: bool = ConfigAttribute(env="DATABRICKS_EXPERIMENTAL_FILES_EXT_ENABLE_STORAGE_PROXY")
 
     def __init__(
         self,


### PR DESCRIPTION
## Summary

Read `experimental_files_ext_enable_storage_proxy` from **`DATABRICKS_EXPERIMENTAL_FILES_EXT_ENABLE_STORAGE_PROXY`** so the storage-proxy flag can be set via env (not only in code).

## Why

Matches other `Config` env-backed flags and simplifies use in jobs/notebooks.

## What changed

- `databricks/sdk/config.py`: `experimental_files_ext_enable_storage_proxy` is now `ConfigAttribute(env="DATABRICKS_EXPERIMENTAL_FILES_EXT_ENABLE_STORAGE_PROXY")`.

## Testing

Manual check: set the env var, build `Config()` / `WorkspaceClient()`, confirm the flag is on. Existing tests that set the attribute in code still apply.