### PR TITLE
Add conftest policies for GitHub Actions

### DIFF
--- a/.github/conftest/README.md
+++ b/.github/conftest/README.md
@@ -1,0 +1,43 @@
+# Conftest policies for GitHub Actions
+
+This directory contains [Conftest](https://www.conftest.dev/) policies that
+validate GitHub Actions [workflows] and [composite actions]. They are evaluated
+by the [conftest workflow](../workflows/conftest.yml) on every push and pull
+request that touches `.github/`.
+
+## Adding a new rule
+
+1. Create a new `.rego` file under `rules/`.
+2. Use `package main` and add violations to `deny`.
+3. Include a comment block at the top of the file explaining the rule and how
+   to fix violations.
+4. Push — the conftest workflow picks up new rules automatically.
+
+Note that workflows and composite actions have different YAML schemas.
+Workflows define jobs under `jobs.<name>.steps`, while composite actions define
+steps under `runs.steps`. Rules that inspect steps must handle both.
+
+## Running locally
+
+```bash
+# Install conftest (macOS)
+brew install conftest
+
+# Run all policies against workflows and composite actions
+conftest test \
+  .github/workflows/*.yml \
+  .github/actions/*/action.yml \
+  --policy .github/conftest/rules
+```
+
+## References
+
+- [Conftest](https://www.conftest.dev/) — policy testing tool for configuration files
+- [Rego](https://www.openpolicyagent.org/docs/latest/policy-language/) — the policy language used by Conftest and OPA
+- [Workflow syntax](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions) — YAML schema for `.github/workflows/*.yml`
+- [Composite actions](https://docs.github.com/en/actions/sharing-automations/creating-actions/creating-a-composite-action) — YAML schema for `action.yml` in composite actions
+- [Security hardening](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions) — GitHub's guide to securing workflows
+- [Using third-party actions](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) — why pinning to commit SHAs matters
+
+[workflows]: https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions
+[composite actions]: https://docs.github.com/en/actions/sharing-automations/creating-actions/creating-a-composite-action

--- a/.github/conftest/rules/pinned_actions.rego
+++ b/.github/conftest/rules/pinned_actions.rego
@@ -1,0 +1,51 @@
+# Action pinning — supply-chain protection
+#
+# External actions must be pinned to a full 40-character commit SHA.
+# Mutable tags like @v1 can be reassigned to point at malicious commits.
+# Local composite actions (./...) are exempt.
+#
+# Good:  actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+# Bad:   actions/checkout@v4
+# Bad:   actions/checkout@main
+#
+# How to fix:
+#   1. Find the tag you want to pin (e.g. v4.3.1).
+#   2. Look up the commit SHA:
+#        git ls-remote --tags https://github.com/<owner>/<action>.git '<tag>^{}' '<tag>'
+#   3. Replace the tag with the SHA and add a comment with the tag name:
+#        uses: actions/checkout@<sha> # v4.3.1
+#
+# Always include the "# <tag>" suffix comment so humans can tell which
+# version is pinned. This cannot be enforced by conftest (YAML strips
+# comments during parsing), so it is a convention to follow manually.
+
+package main
+
+import rego.v1
+
+_is_pinned(ref) if {
+	regex.match(`^[^@]+@[0-9a-f]{40}$`, ref)
+}
+
+_is_local(ref) if {
+	startswith(ref, "./")
+}
+
+# Workflow files: jobs.<name>.steps[].uses
+deny contains msg if {
+	some job_name, job in input.jobs
+	some i, step in job.steps
+	step.uses
+	not _is_local(step.uses)
+	not _is_pinned(step.uses)
+	msg := sprintf("%s: step %d: action '%s' must be pinned to a full commit SHA", [job_name, i, step.uses])
+}
+
+# Composite actions: runs.steps[].uses
+deny contains msg if {
+	some i, step in input.runs.steps
+	step.uses
+	not _is_local(step.uses)
+	not _is_pinned(step.uses)
+	msg := sprintf("step %d: action '%s' must be pinned to a full commit SHA", [i, step.uses])
+}

--- a/.github/workflows/conftest.yml
+++ b/.github/workflows/conftest.yml
@@ -15,9 +15,7 @@ env:
 
 jobs:
   conftest:
-    runs-on:
-      group: databricks-eng-protected-runner-group
-      labels: linux-ubuntu-latest
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout

--- a/.github/workflows/conftest.yml
+++ b/.github/workflows/conftest.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install conftest
         run: |-

--- a/.github/workflows/conftest.yml
+++ b/.github/workflows/conftest.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Install conftest
-        run: |
+        run: |-
           curl -fsSL "https://github.com/open-policy-agent/conftest/releases/download/v${CONFTEST_VERSION}/conftest_${CONFTEST_VERSION}_Linux_x86_64.tar.gz" \
             -o conftest.tar.gz
           echo "${CONFTEST_SHA256}  conftest.tar.gz" | sha256sum --check --strict
@@ -31,7 +31,7 @@ jobs:
 
       - name: Run conftest
         shell: bash
-        run: |
+        run: |-
           shopt -s nullglob
           conftest test \
             .github/workflows/*.yml \

--- a/.github/workflows/conftest.yml
+++ b/.github/workflows/conftest.yml
@@ -1,0 +1,43 @@
+name: conftest
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/**'
+  pull_request:
+    paths:
+      - '.github/**'
+
+env:
+  CONFTEST_VERSION: "0.67.0"
+  CONFTEST_SHA256: "a98cfd236f3cadee16d860fbe31cc6edcb0da3efc317f661c7ccd097164b1fdf"
+
+jobs:
+  conftest:
+    runs-on:
+      group: databricks-eng-protected-runner-group
+      labels: linux-ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Install conftest
+        run: |
+          curl -fsSL "https://github.com/open-policy-agent/conftest/releases/download/v${CONFTEST_VERSION}/conftest_${CONFTEST_VERSION}_Linux_x86_64.tar.gz" \
+            -o conftest.tar.gz
+          echo "${CONFTEST_SHA256}  conftest.tar.gz" | sha256sum --check --strict
+          tar xz -f conftest.tar.gz conftest
+          sudo mv conftest /usr/local/bin/
+
+      - name: Run conftest
+        shell: bash
+        run: |
+          shopt -s nullglob
+          conftest test \
+            .github/workflows/*.yml \
+            .github/workflows/*.yaml \
+            .github/actions/*/action.yml \
+            .github/actions/*/action.yaml \
+            --policy .github/conftest/rules


### PR DESCRIPTION
- Add conftest workflow and policy rules (see .github/conftest/README.md)
- Add pinned-actions rule to enforce SHA pinning on external actions

NO_CHANGELOG=true