### PR TITLE
[Internal] Resolve token_audience from token_federation_default_oidc_audiences in host metadata

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -18,6 +18,7 @@
 ### Internal Changes
 * Replace the async-disabling mechanism on token refresh failure with a 1-minute retry backoff. Previously, a single failed async refresh would disable proactive token renewal until the token expired. Now, the SDK waits a short cooldown period and retries, improving resilience to transient errors.
 * Extract `_resolve_profile` to simplify config file loading and improve `__settings__` error messages.
+* Resolve `token_audience` from the `token_federation_default_oidc_audiences` field in the host metadata discovery endpoint, removing the need for explicit audience configuration.
 
 ### API Changes
 * Add `create_catalog()`, `create_synced_table()`, `delete_catalog()`, `delete_synced_table()`, `get_catalog()` and `get_synced_table()` methods for [w.postgres](https://databricks-sdk-py.readthedocs.io/en/latest/workspace/postgres/postgres.html) workspace-level service.

--- a/databricks/sdk/config.py
+++ b/databricks/sdk/config.py
@@ -14,15 +14,13 @@ from . import useragent
 from ._base_client import _fix_host_if_needed
 from .client_types import ClientType, HostType
 from .clock import Clock, RealClock
-from .credentials_provider import CredentialsStrategy, DefaultCredentials, OAuthCredentialsProvider
-from .environments import ALL_ENVS, AzureEnvironment, Cloud, DatabricksEnvironment, get_environment_for_hostname
-from .oauth import (
-    OidcEndpoints,
-    Token,
-    get_azure_entra_id_workspace_endpoints,
-    get_endpoints_from_url,
-    get_host_metadata,
-)
+from .credentials_provider import (CredentialsStrategy, DefaultCredentials,
+                                   OAuthCredentialsProvider)
+from .environments import (ALL_ENVS, AzureEnvironment, Cloud,
+                           DatabricksEnvironment, get_environment_for_hostname)
+from .oauth import (OidcEndpoints, Token,
+                    get_azure_entra_id_workspace_endpoints,
+                    get_endpoints_from_url, get_host_metadata)
 
 logger = logging.getLogger("databricks.sdk")
 

--- a/databricks/sdk/config.py
+++ b/databricks/sdk/config.py
@@ -14,13 +14,15 @@ from . import useragent
 from ._base_client import _fix_host_if_needed
 from .client_types import ClientType, HostType
 from .clock import Clock, RealClock
-from .credentials_provider import (CredentialsStrategy, DefaultCredentials,
-                                   OAuthCredentialsProvider)
-from .environments import (ALL_ENVS, AzureEnvironment, Cloud,
-                           DatabricksEnvironment, get_environment_for_hostname)
-from .oauth import (OidcEndpoints, Token,
-                    get_azure_entra_id_workspace_endpoints,
-                    get_endpoints_from_url, get_host_metadata)
+from .credentials_provider import CredentialsStrategy, DefaultCredentials, OAuthCredentialsProvider
+from .environments import ALL_ENVS, AzureEnvironment, Cloud, DatabricksEnvironment, get_environment_for_hostname
+from .oauth import (
+    OidcEndpoints,
+    Token,
+    get_azure_entra_id_workspace_endpoints,
+    get_endpoints_from_url,
+    get_host_metadata,
+)
 
 logger = logging.getLogger("databricks.sdk")
 
@@ -655,10 +657,15 @@ class Config:
         if not self.cloud and meta.cloud:
             logger.debug(f"Resolved cloud from host metadata: {meta.cloud.value}")
             self.cloud = meta.cloud
+        if not self.token_audience and meta.token_federation_default_oidc_audiences:
+            audience = meta.token_federation_default_oidc_audiences[0]
+            logger.debug(
+                f"Resolved token_audience from host metadata token_federation_default_oidc_audiences: {audience}"
+            )
+            self.token_audience = audience
         # Account hosts use account_id as the OIDC token audience instead of the token endpoint.
         # This is a special case: when the metadata has no workspace_id, the host is acting as an
         # account-level endpoint and the audience must be scoped to the account.
-        # TODO: Add explicit audience to the metadata discovery endpoint.
         if not self.token_audience and not meta.workspace_id and self.account_id:
             logger.debug(f"Setting token_audience to account_id for account host: {self.account_id}")
             self.token_audience = self.account_id

--- a/databricks/sdk/oauth.py
+++ b/databricks/sdk/oauth.py
@@ -448,6 +448,7 @@ class HostMetadata:
     account_id: Optional[str] = None
     workspace_id: Optional[str] = None
     cloud: Optional[Cloud] = None
+    token_federation_default_oidc_audiences: Optional[List[str]] = None
 
     @staticmethod
     def from_dict(d: dict) -> "HostMetadata":
@@ -456,6 +457,7 @@ class HostMetadata:
             account_id=d.get("account_id"),
             workspace_id=d.get("workspace_id"),
             cloud=Cloud.parse(d.get("cloud", "")),
+            token_federation_default_oidc_audiences=d.get("token_federation_default_oidc_audiences"),
         )
 
     def as_dict(self) -> dict:
@@ -464,6 +466,7 @@ class HostMetadata:
             "account_id": self.account_id,
             "workspace_id": self.workspace_id,
             "cloud": self.cloud.value if self.cloud else None,
+            "token_federation_default_oidc_audiences": self.token_federation_default_oidc_audiences,
         }
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -10,7 +10,8 @@ from urllib.parse import parse_qs
 import pytest
 
 from databricks.sdk import AccountClient, WorkspaceClient, oauth, useragent
-from databricks.sdk.config import ClientType, Config, HostType, with_product, with_user_agent_extra
+from databricks.sdk.config import (ClientType, Config, HostType, with_product,
+                                   with_user_agent_extra)
 from databricks.sdk.environments import Cloud
 from databricks.sdk.oauth import HostMetadata
 from databricks.sdk.version import __version__

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -10,8 +10,7 @@ from urllib.parse import parse_qs
 import pytest
 
 from databricks.sdk import AccountClient, WorkspaceClient, oauth, useragent
-from databricks.sdk.config import (ClientType, Config, HostType, with_product,
-                                   with_user_agent_extra)
+from databricks.sdk.config import ClientType, Config, HostType, with_product, with_user_agent_extra
 from databricks.sdk.environments import Cloud
 from databricks.sdk.oauth import HostMetadata
 from databricks.sdk.version import __version__
@@ -973,3 +972,77 @@ def test_resolve_host_metadata_does_not_overwrite_token_audience(mocker):
         token_audience="custom-audience",
     )
     assert config.token_audience == "custom-audience"
+
+
+# ---------------------------------------------------------------------------
+# token_federation_default_oidc_audiences resolution from host metadata
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_host_metadata_sets_token_audience_from_token_federation_default_oidc_audiences(mocker):
+    """token_audience is set from token_federation_default_oidc_audiences in host metadata."""
+    mocker.patch(
+        "databricks.sdk.config.get_host_metadata",
+        return_value=HostMetadata.from_dict(
+            {
+                "oidc_endpoint": f"{_DUMMY_WS_HOST}/oidc",
+                "account_id": _DUMMY_ACCOUNT_ID,
+                "workspace_id": _DUMMY_WORKSPACE_ID,
+                "token_federation_default_oidc_audiences": [f"{_DUMMY_WS_HOST}/oidc/v1/token"],
+            }
+        ),
+    )
+    config = Config(host=_DUMMY_WS_HOST, token="t")
+    assert config.token_audience == f"{_DUMMY_WS_HOST}/oidc/v1/token"
+
+
+def test_resolve_host_metadata_token_federation_default_oidc_audiences_takes_priority_over_account_id_fallback(mocker):
+    """token_federation_default_oidc_audiences takes priority over the account_id fallback."""
+    mocker.patch(
+        "databricks.sdk.config.get_host_metadata",
+        return_value=HostMetadata.from_dict(
+            {
+                "oidc_endpoint": f"{_DUMMY_ACC_HOST}/oidc/accounts/{_DUMMY_ACCOUNT_ID}",
+                "account_id": _DUMMY_ACCOUNT_ID,
+                "token_federation_default_oidc_audiences": ["custom-audience-from-server"],
+            }
+        ),
+    )
+    config = Config(host=_DUMMY_ACC_HOST, token="t", account_id=_DUMMY_ACCOUNT_ID)
+    # token_federation_default_oidc_audiences should take priority over the account_id fallback
+    assert config.token_audience == "custom-audience-from-server"
+
+
+def test_resolve_host_metadata_token_federation_default_oidc_audiences_does_not_override_existing_token_audience(
+    mocker,
+):
+    """An explicitly set token_audience is not overwritten by token_federation_default_oidc_audiences."""
+    mocker.patch(
+        "databricks.sdk.config.get_host_metadata",
+        return_value=HostMetadata.from_dict(
+            {
+                "oidc_endpoint": f"{_DUMMY_WS_HOST}/oidc",
+                "account_id": _DUMMY_ACCOUNT_ID,
+                "workspace_id": _DUMMY_WORKSPACE_ID,
+                "token_federation_default_oidc_audiences": [f"{_DUMMY_WS_HOST}/oidc/v1/token"],
+            }
+        ),
+    )
+    config = Config(host=_DUMMY_WS_HOST, token="t", token_audience="my-custom-audience")
+    assert config.token_audience == "my-custom-audience"
+
+
+def test_resolve_host_metadata_falls_back_to_account_id_when_no_token_federation_default_oidc_audiences(mocker):
+    """When no token_federation_default_oidc_audiences and no workspace_id, falls back to account_id."""
+    mocker.patch(
+        "databricks.sdk.config.get_host_metadata",
+        return_value=HostMetadata.from_dict(
+            {
+                "oidc_endpoint": f"{_DUMMY_ACC_HOST}/oidc/accounts/{_DUMMY_ACCOUNT_ID}",
+                "account_id": _DUMMY_ACCOUNT_ID,
+            }
+        ),
+    )
+    config = Config(host=_DUMMY_ACC_HOST, token="t", account_id=_DUMMY_ACCOUNT_ID)
+    # No token_federation_default_oidc_audiences and no workspace_id → falls back to account_id
+    assert config.token_audience == _DUMMY_ACCOUNT_ID


### PR DESCRIPTION
  ## Summary

  Read the `token_federation_default_oidc_audiences` list from the `/.well-known/databricks-config` discovery endpoint and use the first element as  the `token_audience` when not explicitly configured. This removes the need for explicit audience configuration and replaces the TODO for adding an explicit audience to the metadata endpoint.

  ## Why

  Today, the SDK resolves the OIDC token audience through a fallback chain: an explicitly configured `token_audience`, or for account-level hosts,  the `account_id`. There was a TODO in the code to add explicit audience support from the metadata discovery endpoint.

  The discovery endpoint now returns a `token_federation_default_oidc_audiences` field (a list of audience strings). This PR reads that field and  uses it as the primary source for `token_audience`, which is more reliable than the `account_id` heuristic and works correctly for all host types (workspace, account, unified).

  ## What changed

  ### Interface changes

  - **`HostMetadata.token_federation_default_oidc_audiences: Optional[List[str]]`** — New field on the `HostMetadata` dataclass, parsed from the discovery endpoint response. Included in `from_dict()` and `as_dict()`.

  ### Behavioral changes

  - When `token_audience` is not explicitly configured and `token_federation_default_oidc_audiences` is present in host metadata, the SDK now sets `token_audience` to the first element of that list.
  - This takes priority over the existing `account_id` fallback (which only applies to account hosts without `workspace_id`).
  - An explicitly configured `token_audience` is never overwritten.

  ### Internal changes

  - Removed the `# TODO: Add explicit audience to the metadata discovery endpoint.` comment (now implemented).

  ## How is this tested?
- All integration tests passed (manually triggered)
- 4 new unit tests in `tests/test_config.py`:
  - `token_federation_default_oidc_audiences` sets `token_audience` (first element) when not explicitly configured.
  - `token_federation_default_oidc_audiences` takes priority over the `account_id` fallback for account hosts.
  - Explicitly configured `token_audience` is not overwritten by `token_federation_default_oidc_audiences`.
  - Falls back to `account_id` when `token_federation_default_oidc_audiences` is absent and no `workspace_id`.