### PR TITLE
Add uv as a required dependency for codegen for early return

### DIFF
--- a/.codegen.json
+++ b/.codegen.json
@@ -5,7 +5,7 @@
     "databricks/sdk/version.py": "__version__ = \"$VERSION\""
   },
   "toolchain": {
-    "required": ["python3.12"],
+    "required": ["python3.12", "uv"],
     "pre_setup": [
       "python3.12 -m venv .databricks"
     ],


### PR DESCRIPTION
Add `uv` as a required dependency to ensure code generation as `uv` is used in one of the `post_generation` commands `make fmt`. This ensures that generation fails early on in environments which do not have uv rather then failing post generation.


## What changed



### Internal changes

Now the codegen checks if `uv` exists before starting code generation

## How is this tested?

N/A

NO_CHANGELOG=true
