### PR TITLE
Route integration-tests trigger through emu-access runner

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -35,8 +35,8 @@ jobs:
     name: Trigger Tests
 
     runs-on:
-      group: databricks-deco-testing-runner-group
-      labels: ubuntu-latest-deco
+      group: databricks-release-runner-group-emu-access
+      labels: linux-ubuntu-latest-emu-access
 
     needs: check-token
     if: github.event_name == 'pull_request'  && needs.check-token.outputs.has_token == 'true'


### PR DESCRIPTION
## Summary

Moves the `trigger-tests` job in `.github/workflows/integration-tests.yml` from the `databricks-deco-testing-runner-group` to `databricks-release-runner-group-emu-access`, so the cross-org GitHub App installation lookup against `databricks-eng` can succeed.

| | Before | After |
|---|---|---|
| Runner group | `databricks-deco-testing-runner-group` | `databricks-release-runner-group-emu-access` |
| Label | `ubuntu-latest-deco` | `linux-ubuntu-latest-emu-access` |

## Why

Between **2026-04-17** and **2026-04-20**, the `databricks` org tightened its IP allow list. Since then, every PR-triggered Integration Tests run on this repo has failed:

- `create-github-app-token` resolves the installation for `${{ secrets.ORG_NAME }}` (`databricks-eng`) by calling `/repos/databricks-eng/.../installation`.
- The deco runner group's egress IPs are no longer on the allow list, so that call returns **403**.
- The downstream `gh workflow run sdk-py-isolated-pr.yml -R databricks-eng/...` dispatch never happens.
- Merges still go through only because `merge_group` auto-approves the check without running tests.

The `emu-access` runner pool's egress IPs **are** on the allow list, so the installation lookup succeeds from there.

## Where the changes come from

Ported from the Go SDK fix: [databricks/databricks-sdk-go#1638](https://github.com/databricks/databricks-sdk-go/pull/1638) (supersedes #1616, verified green end-to-end on 2026-04-10).

The Go PR splits `trigger-tests` into two jobs:

- **`create-check`** — stays on deco, creates a same-org check run via the `databricks/...` check-runs API.
- **`trigger-tests`** — moves to emu-access, performs the cross-org `workflow_dispatch`.

## What this PR does differently

The Python SDK's `integration-tests.yml` **does not create a check run** in the PR flow — `trigger-tests` only performs the cross-org dispatch. Nothing needs to stay on the deco runner, so the equivalent minimal fix is a single runner-group change on the existing job rather than a two-job split. No job splitting, added dependencies, or `check_run_id` plumbing was needed here.

## How is this tested

This PR's own Integration Tests run is the test. Expected outcome:

- [ ] `trigger-tests` runs on the emu-access runner and `create-github-app-token` succeeds (no 403).
- [ ] A `sdk-py-isolated-pr` `workflow_dispatch` event appears on `databricks-eng/eng-dev-ecosystem`.
- [ ] The Integration Tests check on this PR transitions to `success` / `failure` based on the dispatched run.

---

`NO_CHANGELOG=true`

_This pull request and its description were written by Isaac._