### PR TITLE
Add X-Databricks-Org-Id to workspace/shares extensions and short-circuit get_workspace_id

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -8,6 +8,10 @@
 
 ### Bug Fixes
 
+* Add `X-Databricks-Org-Id` header to `WorkspaceExt.upload()` and `WorkspaceExt.download()` for SPOG host compatibility.
+* `WorkspaceClient.get_workspace_id()` now returns `Config.workspace_id` directly when set, instead of calling `/api/2.0/preview/scim/v2/Me`. This removes an API round-trip on every call where the workspace ID is already known (profile, `?o=` query param, env var, or host metadata) and fixes a failure on SPOG hosts where the unauthenticated probe request was rejected with `Unable to load OAuth Config`.
+* Add `X-Databricks-Org-Id` header to `SharesExt.list()` for SPOG host compatibility.
+
 ### Documentation
 
 ### Breaking Changes

--- a/databricks/sdk/__init__.py
+++ b/databricks/sdk/__init__.py
@@ -1066,7 +1066,16 @@ class WorkspaceClient:
         return self._files
 
     def get_workspace_id(self) -> int:
-        """Get the workspace ID of the workspace that this client is connected to."""
+        """Get the workspace ID of the workspace that this client is connected to.
+
+        If ``Config.workspace_id`` is already set (from the databrickscfg profile,
+        the ``DATABRICKS_WORKSPACE_ID`` env var, host metadata, or a ``?o=`` query
+        param), it is returned without an API round-trip. Otherwise the ID is
+        fetched from the ``X-Databricks-Org-Id`` response header on
+        ``/api/2.0/preview/scim/v2/Me``.
+        """
+        if self._config.workspace_id:
+            return int(self._config.workspace_id)
         response = self._api_client.do("GET", "/api/2.0/preview/scim/v2/Me", response_headers=["X-Databricks-Org-Id"])
         return int(response["X-Databricks-Org-Id"])
 

--- a/databricks/sdk/mixins/sharing.py
+++ b/databricks/sdk/mixins/sharing.py
@@ -31,6 +31,9 @@ class SharesExt(sharing.SharesAPI):
         headers = {
             "Accept": "application/json",
         }
+        cfg = self._api._cfg
+        if cfg.workspace_id:
+            headers["X-Databricks-Org-Id"] = cfg.workspace_id
 
         if "max_results" not in query:
             query["max_results"] = 0

--- a/databricks/sdk/mixins/workspace.py
+++ b/databricks/sdk/mixins/workspace.py
@@ -85,12 +85,17 @@ class WorkspaceExt(WorkspaceAPI):
             data["language"] = language.value
         if overwrite:
             data["overwrite"] = "true"
+        headers = {}
+        cfg = self._api._cfg
+        if cfg.workspace_id:
+            headers["X-Databricks-Org-Id"] = cfg.workspace_id
         try:
             return self._api.do(
                 "POST",
                 "/api/2.0/workspace/import",
                 files={"content": content},
                 data=data,
+                headers=headers,
             )
         except DatabricksError as e:
             if e.error_code == "INVALID_PARAMETER_VALUE":
@@ -113,5 +118,9 @@ class WorkspaceExt(WorkspaceAPI):
         query = {"path": path, "direct_download": "true"}
         if format:
             query["format"] = format.value
-        response = self._api.do("GET", "/api/2.0/workspace/export", query=query, raw=True)
+        headers = {}
+        cfg = self._api._cfg
+        if cfg.workspace_id:
+            headers["X-Databricks-Org-Id"] = cfg.workspace_id
+        response = self._api.do("GET", "/api/2.0/workspace/export", query=query, headers=headers, raw=True)
         return response["contents"]


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/databricks/databricks-sdk-py/pull/1397/files) to review incremental changes.
- [**stack/spog-ext-headers-fix**](https://github.com/databricks/databricks-sdk-py/pull/1397) [[Files changed](https://github.com/databricks/databricks-sdk-py/pull/1397/files)]

---------
## Summary

Ports two SPOG fixes from the Go SDK to the Python SDK:
- databricks/databricks-sdk-go#1634 — `X-Databricks-Org-Id` on `Workspace.Download()` / `Workspace.Upload()`
- databricks/databricks-sdk-go#1635 — short-circuit `CurrentWorkspaceID()` + `X-Databricks-Org-Id` on `SharesAPI.List()`

## Background

Hand-written extension methods in the mixins bypass the generated per-call header logic. On SPOG hosts, requests without `X-Databricks-Org-Id` are rejected by the proxy with:

```
Error: Unable to load OAuth Config (400 UNKNOWN)
```

Generated service methods (e.g. in `knowledgeassistants.py`, `files.py`, `oauth2.py`) already set this header when `cfg.workspace_id` is populated. This PR brings the hand-written extensions in line.

## Changes

**`databricks/sdk/mixins/workspace.py`** — `WorkspaceExt.upload()` and `WorkspaceExt.download()` now include `X-Databricks-Org-Id` when `cfg.workspace_id` is set.

**`databricks/sdk/mixins/sharing.py`** — `SharesExt.list()` same.

**`databricks/sdk/__init__.py`** — `WorkspaceClient.get_workspace_id()` returns `Config.workspace_id` directly when set, instead of calling `/api/2.0/preview/scim/v2/Me` just to read the ID off the response header. This removes an API round-trip whenever the workspace ID is already known (profile, `?o=` query param, `DATABRICKS_WORKSPACE_ID` env var, host metadata) and fixes the SPOG failure where the probe itself lacked the routing header. If `Config.workspace_id` is empty, the previous API fallback is preserved for non-SPOG hosts.

## Test plan

- [x] `pytest tests/test_files.py -k "upload or download or workspace"` — 115 passed
- [x] Imports verify (`WorkspaceExt`, `SharesExt`, `WorkspaceClient`)
- [ ] Integration tests on a SPOG host (would require real SPOG workspace)

This pull request and its description were written by Isaac.