### PR TITLE
feat(apps): add databricks.apps module for Apps runtime client construction

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### New Features and Improvements
 
+* Add `databricks.apps` module with `get_workspace_client()` and `get_user_workspace_client()` helpers for code running inside Databricks Apps. Both pin `auth_type` explicitly so the SDK's auth validator does not raise `more than one authorization method configured` when both the app's SP env vars and a user OBO token are available in the same process. `get_user_workspace_client()` reads the user token from `X-Forwarded-Access-Token` without mutating process env vars, making it safe for concurrent request handlers. A `get_mcp_client()` placeholder is exposed; the real implementation will land alongside the mcp_server resource type (tracked separately).
+
 ### Security
 
 ### Bug Fixes

--- a/databricks/apps/__init__.py
+++ b/databricks/apps/__init__.py
@@ -1,0 +1,17 @@
+# See: https://packaging.python.org/guides/packaging-namespace-packages/#pkgutil-style-namespace-packages
+#
+# This file keeps databricks.apps as a pkgutil-style namespace package alongside
+# databricks.sdk. The content below is the public re-export surface.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)
+
+from databricks.apps._client import (
+    get_mcp_client,
+    get_user_workspace_client,
+    get_workspace_client,
+)
+
+__all__ = [
+    "get_mcp_client",
+    "get_user_workspace_client",
+    "get_workspace_client",
+]

--- a/databricks/apps/_client.py
+++ b/databricks/apps/_client.py
@@ -1,0 +1,153 @@
+"""Client helpers for code running inside Databricks Apps.
+
+Two client-construction helpers, each one correct by construction under concurrent requests:
+
+- :func:`get_workspace_client`: returns a SP-authenticated :class:`WorkspaceClient` that acts
+  as the app's service principal. Uses OAuth M2M via the ``DATABRICKS_CLIENT_ID`` /
+  ``DATABRICKS_CLIENT_SECRET`` env vars injected by the Apps runtime.
+
+- :func:`get_user_workspace_client`: returns an OBO (on-behalf-of) :class:`WorkspaceClient`
+  built from the ``X-Forwarded-Access-Token`` header that the Apps proxy adds to every
+  request. Uses PAT auth with an explicit token — *does not mutate process env vars*, so it
+  is safe to call concurrently from multiple request handlers.
+
+Both helpers explicitly set ``auth_type`` so the SDK's auth validator does not raise
+``more than one authorization method configured`` when both SP env vars and user tokens
+are available in the same process.
+
+A third helper, :func:`get_mcp_client`, is exposed as a placeholder and currently raises
+``NotImplementedError``. It will be wired up when MCP resource provisioning lands
+(tracked separately as SDK-02).
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Mapping, Optional, Protocol
+
+from databricks.sdk import WorkspaceClient
+
+_OBO_HEADER = "X-Forwarded-Access-Token"
+
+
+class _HasHeaders(Protocol):
+    """Minimal structural type for a request object with a ``headers`` mapping.
+
+    This covers Flask, FastAPI/Starlette, Django, and bare ``dict``-like objects without
+    requiring an import from any specific web framework.
+    """
+
+    headers: Mapping[str, str]
+
+
+def get_workspace_client(host: Optional[str] = None, **kwargs: Any) -> WorkspaceClient:
+    """Return a WorkspaceClient authenticated as the app's service principal.
+
+    Uses OAuth M2M with the SP credentials injected by the Apps container runtime
+    (``DATABRICKS_CLIENT_ID`` + ``DATABRICKS_CLIENT_SECRET``). ``auth_type`` is pinned to
+    ``"oauth-m2m"`` so the SDK does not also attempt to read ``DATABRICKS_TOKEN`` from
+    the environment and raise a dual-auth validation error.
+
+    Args:
+        host: Override for ``DATABRICKS_HOST``. Defaults to the env var.
+        **kwargs: Forwarded to :class:`WorkspaceClient`.
+
+    Returns:
+        A configured :class:`WorkspaceClient`.
+
+    Raises:
+        RuntimeError: If the required SP env vars are not set.
+    """
+    client_id = os.environ.get("DATABRICKS_CLIENT_ID", "")
+    client_secret = os.environ.get("DATABRICKS_CLIENT_SECRET", "")
+    if not client_id or not client_secret:
+        raise RuntimeError(
+            "get_workspace_client() requires DATABRICKS_CLIENT_ID and DATABRICKS_CLIENT_SECRET; "
+            "are you running inside a Databricks App container?"
+        )
+    return WorkspaceClient(
+        host=host or os.environ.get("DATABRICKS_HOST", ""),
+        client_id=client_id,
+        client_secret=client_secret,
+        auth_type="oauth-m2m",
+        **kwargs,
+    )
+
+
+def get_user_workspace_client(
+    request: Optional[_HasHeaders] = None,
+    *,
+    token: Optional[str] = None,
+    host: Optional[str] = None,
+    **kwargs: Any,
+) -> WorkspaceClient:
+    """Return a WorkspaceClient authenticated as the end user (OBO).
+
+    Reads the user's access token either from ``X-Forwarded-Access-Token`` on the passed
+    request, or from the explicit ``token`` argument. ``auth_type`` is pinned to ``"pat"``
+    so the SDK does not fall back to the SP env vars and raise a dual-auth validation
+    error when both are present.
+
+    This function is safe to call concurrently from multiple request handlers: it does
+    not mutate process environment variables (the historical workaround pattern that is
+    *not* thread-safe).
+
+    Args:
+        request: Any object with a ``headers`` mapping (Flask, FastAPI, Django, etc.).
+            If provided, the access token is read from ``X-Forwarded-Access-Token``.
+        token: Explicit user access token. Overrides the header if both are provided.
+        host: Override for ``DATABRICKS_HOST``. Defaults to the env var.
+        **kwargs: Forwarded to :class:`WorkspaceClient`.
+
+    Returns:
+        A configured :class:`WorkspaceClient`.
+
+    Raises:
+        ValueError: If no user token can be found from either the request or ``token``.
+    """
+    if token is None and request is not None:
+        token = _extract_obo_token(request)
+
+    if not token:
+        raise ValueError(
+            "get_user_workspace_client() could not find a user access token. Pass `request` "
+            "(with an X-Forwarded-Access-Token header) or an explicit `token` argument."
+        )
+
+    return WorkspaceClient(
+        host=host or os.environ.get("DATABRICKS_HOST", ""),
+        token=token,
+        auth_type="pat",
+        **kwargs,
+    )
+
+
+def get_mcp_client(*args: Any, **kwargs: Any):  # pragma: no cover - placeholder
+    """Placeholder for the Apps MCP client (tracked as SDK-02).
+
+    The MCP client is provisioned from ``mcp_server`` resources declared in ``app.yaml``.
+    Until the runtime wires that up, this helper raises ``NotImplementedError`` so callers
+    get a clear signal instead of a silent import failure.
+    """
+    raise NotImplementedError(
+        "databricks.apps.get_mcp_client is not yet implemented; tracked as SDK-02. "
+        "See the EMEA Apps gaps doc for status."
+    )
+
+
+def _extract_obo_token(request: _HasHeaders) -> Optional[str]:
+    headers = getattr(request, "headers", None)
+    if headers is None:
+        return None
+    # Most header mappings are case-insensitive, but fall back to a manual scan for
+    # the rare ones (e.g. bare dicts in test code) that are not.
+    try:
+        value = headers.get(_OBO_HEADER)
+        if value:
+            return value
+    except AttributeError:
+        pass
+    for key, value in dict(headers).items():
+        if key.lower() == _OBO_HEADER.lower():
+            return value
+    return None

--- a/tests/apps/test_client.py
+++ b/tests/apps/test_client.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import pytest
+
+from databricks.apps import (
+    get_mcp_client,
+    get_user_workspace_client,
+    get_workspace_client,
+)
+
+# Tests assert on the kwargs passed to WorkspaceClient — not on its constructed Config
+# object — to avoid triggering the SDK's eager host-metadata resolution during unit
+# tests. Auth-type correctness is about what we pass, not what the SDK resolves.
+
+
+class _FakeRequest:
+    def __init__(self, headers):
+        self.headers = headers
+
+
+def _clear_auth_env(monkeypatch):
+    for key in (
+        "DATABRICKS_HOST",
+        "DATABRICKS_CLIENT_ID",
+        "DATABRICKS_CLIENT_SECRET",
+        "DATABRICKS_TOKEN",
+        "DATABRICKS_CONFIG_FILE",
+        "DATABRICKS_CONFIG_PROFILE",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+@pytest.fixture
+def patch_workspace_client(mocker):
+    return mocker.patch("databricks.apps._client.WorkspaceClient")
+
+
+def test_get_workspace_client_uses_oauth_m2m(monkeypatch, patch_workspace_client):
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("DATABRICKS_HOST", "https://example.cloud.databricks.com")
+    monkeypatch.setenv("DATABRICKS_CLIENT_ID", "client-id")
+    monkeypatch.setenv("DATABRICKS_CLIENT_SECRET", "client-secret")
+
+    get_workspace_client()
+
+    patch_workspace_client.assert_called_once_with(
+        host="https://example.cloud.databricks.com",
+        client_id="client-id",
+        client_secret="client-secret",
+        auth_type="oauth-m2m",
+    )
+
+
+def test_get_workspace_client_raises_without_sp_env(monkeypatch):
+    _clear_auth_env(monkeypatch)
+    with pytest.raises(RuntimeError, match="DATABRICKS_CLIENT_ID"):
+        get_workspace_client()
+
+
+def test_get_user_workspace_client_from_request_header(monkeypatch, patch_workspace_client):
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("DATABRICKS_HOST", "https://example.cloud.databricks.com")
+
+    request = _FakeRequest({"X-Forwarded-Access-Token": "user-token"})
+    get_user_workspace_client(request)
+
+    patch_workspace_client.assert_called_once_with(
+        host="https://example.cloud.databricks.com",
+        token="user-token",
+        auth_type="pat",
+    )
+
+
+def test_get_user_workspace_client_with_dual_auth_present(monkeypatch, patch_workspace_client):
+    """Regression: the historical bug was that SP env vars + a user token made
+    WorkspaceClient raise 'more than one authorization method configured'.
+    Pinning auth_type='pat' here is what keeps that from happening."""
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("DATABRICKS_HOST", "https://example.cloud.databricks.com")
+    monkeypatch.setenv("DATABRICKS_CLIENT_ID", "client-id")
+    monkeypatch.setenv("DATABRICKS_CLIENT_SECRET", "client-secret")
+
+    get_user_workspace_client(token="user-token")
+
+    _, kwargs = patch_workspace_client.call_args
+    assert kwargs["auth_type"] == "pat"
+    assert kwargs["token"] == "user-token"
+
+
+def test_get_user_workspace_client_case_insensitive_header(monkeypatch, patch_workspace_client):
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("DATABRICKS_HOST", "https://example.cloud.databricks.com")
+
+    request = _FakeRequest({"x-forwarded-access-token": "user-token"})
+    get_user_workspace_client(request)
+
+    _, kwargs = patch_workspace_client.call_args
+    assert kwargs["token"] == "user-token"
+
+
+def test_get_user_workspace_client_does_not_mutate_env(monkeypatch, patch_workspace_client):
+    """Thread-safety contract: the helper must not pop DATABRICKS_CLIENT_ID / SECRET
+    from os.environ. That is the historical workaround that breaks under concurrency."""
+    import os
+
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("DATABRICKS_HOST", "https://example.cloud.databricks.com")
+    monkeypatch.setenv("DATABRICKS_CLIENT_ID", "client-id")
+    monkeypatch.setenv("DATABRICKS_CLIENT_SECRET", "client-secret")
+
+    get_user_workspace_client(token="user-token")
+
+    assert os.environ["DATABRICKS_CLIENT_ID"] == "client-id"
+    assert os.environ["DATABRICKS_CLIENT_SECRET"] == "client-secret"
+
+
+def test_get_user_workspace_client_without_token_raises(monkeypatch):
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("DATABRICKS_HOST", "https://example.cloud.databricks.com")
+
+    request = _FakeRequest({})
+    with pytest.raises(ValueError, match="user access token"):
+        get_user_workspace_client(request)
+
+
+def test_get_mcp_client_is_placeholder():
+    with pytest.raises(NotImplementedError, match="SDK-02"):
+        get_mcp_client()


### PR DESCRIPTION
## Summary

Adds a first-class `databricks.apps` module with helpers for code running inside Databricks Apps containers. Addresses the **SDK-01** gap from internal field feedback — the historical workaround (popping `DATABRICKS_CLIENT_ID` / `DATABRICKS_CLIENT_SECRET` from `os.environ` to avoid a dual-auth validation error) is not thread-safe and forces ~50 lines of boilerplate into every custom agent app.

## Public API

```python
from databricks.apps import (
    get_workspace_client,         # app's SP identity (OAuth M2M)
    get_user_workspace_client,    # user OBO (PAT via X-Forwarded-Access-Token)
    get_mcp_client,               # placeholder, SDK-02
)

# In a FastAPI / Flask / Django handler:
def handler(request):
    user = get_user_workspace_client(request)        # reads X-Forwarded-Access-Token
    # or explicit token:
    user = get_user_workspace_client(token=...)

    sp = get_workspace_client()                      # SP identity
```

## Why this is the right fix

The root cause is that `WorkspaceClient(token=..., host=...)` raises
`more than one authorization method configured: oauth and pat` when SP env vars are
*also* set — which is always true inside an Apps container. Both helpers here pin
`auth_type` explicitly (`oauth-m2m` and `pat`) so the validator never sees ambiguous
config. No env mutation, no global state, safe under concurrency.

`get_mcp_client()` is a placeholder that raises `NotImplementedError` with a pointer
to the SDK-02 follow-up so dependent code can import the symbol today and adopt the
real implementation when it lands.

## Test plan

- [x] `pytest tests/apps/` — 8 tests covering OAuth-M2M wiring, OBO header extraction (case-insensitive), explicit-token path, dual-auth regression, env-non-mutation invariant, missing-creds error paths, MCP placeholder
- [x] Smoke-import: `import databricks.sdk; import databricks.apps` both succeed
- [x] Tests assert on `WorkspaceClient` constructor kwargs rather than the constructed `Config` object, avoiding the SDK's eager host-metadata resolution in unit tests
- [ ] Integration test in a real Apps container (draft — pending)

## Out of scope

- `get_mcp_client()` real implementation — tracked as SDK-02 (depends on `mcp_server` resource type being honored at runtime)
- Backport to older SDK release lines

This pull request and its description were written by Claude (claude.ai).