### PR TITLE
Add include_shared_data parameter to list_share function

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### New Features and Improvements
 
+* Add `include_shared_data` param to `databricks.sdk.service.sharing.SharesAPI.list_shares` so that it's possible to fetch shared_data when listing all shares.
+
 ### Security
 
 ### Bug Fixes

--- a/databricks/sdk/service/sharing.py
+++ b/databricks/sdk/service/sharing.py
@@ -3318,7 +3318,7 @@ class SharesAPI:
 
         self._api.do("DELETE", f"/api/2.1/unity-catalog/shares/{name}", headers=headers)
 
-    def get(self, name: str, *, include_shared_data: Optional[bool] = None, ) -> ShareInfo:
+    def get(self, name: str, *, include_shared_data: Optional[bool] = None) -> ShareInfo:
         """Gets a data object share from the metastore. The caller must have the USE_SHARE privilege on the
         metastore or be the owner of the share.
 
@@ -3420,7 +3420,6 @@ class SharesAPI:
             query["max_results"] = max_results
         if page_token is not None:
             query["page_token"] = page_token
-
         headers = {
             "Accept": "application/json",
         }

--- a/databricks/sdk/service/sharing.py
+++ b/databricks/sdk/service/sharing.py
@@ -3318,7 +3318,7 @@ class SharesAPI:
 
         self._api.do("DELETE", f"/api/2.1/unity-catalog/shares/{name}", headers=headers)
 
-    def get(self, name: str, *, include_shared_data: Optional[bool] = None) -> ShareInfo:
+    def get(self, name: str, *, include_shared_data: Optional[bool] = None, ) -> ShareInfo:
         """Gets a data object share from the metastore. The caller must have the USE_SHARE privilege on the
         metastore or be the owner of the share.
 
@@ -3345,7 +3345,7 @@ class SharesAPI:
         return ShareInfo.from_dict(res)
 
     def list_shares(
-        self, *, max_results: Optional[int] = None, page_token: Optional[str] = None
+        self, *, max_results: Optional[int] = None, page_token: Optional[str] = None, include_shared_data: Optional[bool]= None
     ) -> Iterator[ShareInfo]:
         """Gets an array of data object shares from the metastore. If the caller has the USE_SHARE privilege on
         the metastore, all shares are returned. Otherwise, only shares owned by the caller are returned. There
@@ -3361,6 +3361,8 @@ class SharesAPI:
           response.
         :param page_token: str (optional)
           Opaque pagination token to go to next page based on previous query.
+        :param include_shared_data: bool (optional)
+          Query for data to include in the share.
 
         :returns: Iterator over :class:`ShareInfo`
         """
@@ -3370,6 +3372,8 @@ class SharesAPI:
             query["max_results"] = max_results
         if page_token is not None:
             query["page_token"] = page_token
+        if include_shared_data is not None:
+            query["include_shared_data"] = include_shared_data
         headers = {
             "Accept": "application/json",
         }
@@ -3416,6 +3420,7 @@ class SharesAPI:
             query["max_results"] = max_results
         if page_token is not None:
             query["page_token"] = page_token
+
         headers = {
             "Accept": "application/json",
         }


### PR DESCRIPTION
<!--
  This template provides a recommended structure for PR descriptions.
  Adapt it freely — the goal is clarity, not rigid compliance.
  The three-section format (Summary / Why / What Changed) helps reviewers
  understand the change quickly and makes the PR easier to revisit later.
-->

## Summary

Adds `include_shared_data` param to list_shares function just like get function so that while fetching the shareinfo, their object info is also fetched.

## Why

Currently we can use list_shares to fetch share info but unlike get function, there's no way to also specify that we also need to get shared_data information (objects key). 

The PR adds `include_shared_data` param just like get function so that user can indicate the need to getch shared data.

Alternative to this approach is to use `get` function independently on each share again to fetch shared_data for them which is an extra unnecessary step since we can do it inside list_shares.
 
<!--
  Explain the problem that motivated this change. A reviewer who reads only
  this section should understand why the PR exists and what problem it solves.

  - Start with the status quo: how things work today and what limitation exists.
  - Explain who is affected and what they cannot do (or must work around).
  - If alternatives were considered and rejected, briefly mention why.
  - End with how this PR addresses the gap.

  The "why" is the most important part of a PR description — it usually
  cannot be inferred from the code itself.
-->

## What changed

### Interface changes

Adds an optional param to list_shares function with default to None (not changing existing behaviours). If this param is provided with True value, it will fetch the sahred data:

```
w = WorkspaceClient()

shares = w.providers.list_shares(name=created.name, include_shared_data=True)
# using include_shared_data=True, shared data information is also fetched and objects key is not empty anymore
```


### Behavioral changes

Existing behavior is not changed.


### Internal changes

Addition of extra param: include_shared_data with default value `None`.
<!--
  Refactoring, file moves, implementation details, test infrastructure.
  Things that don't affect the public API or user-visible behavior.
-->

## How is this tested?

Built the package and ran locally to fetch the shared data (no unit test available for this module at the moment)

<!--
  Describe any tests you have done, especially tests that are not part of
  the unit tests (e.g. local tests, integration tests, manual verification).

  ALWAYS ANSWER THIS QUESTION: answer with "N/A" if tests are not applicable
  to your PR (e.g. if the PR only modifies comments). Do not be afraid of
  answering "Not tested" if the PR has not been tested. Being clear about what
  has been done and not done provides important context to the reviewers.
-->
