### PR TITLE
Add timeout to requests in oauth.py

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -11,6 +11,7 @@
 * Add `X-Databricks-Org-Id` header to `WorkspaceExt.upload()` and `WorkspaceExt.download()` for SPOG host compatibility.
 * `WorkspaceClient.get_workspace_id()` now returns `Config.workspace_id` directly when set, instead of calling `/api/2.0/preview/scim/v2/Me`. This removes an API round-trip on every call where the workspace ID is already known (profile, `?o=` query param, env var, or host metadata) and fixes a failure on SPOG hosts where the unauthenticated probe request was rejected with `Unable to load OAuth Config`.
 * Add `X-Databricks-Org-Id` header to `SharesExt.list()` for SPOG host compatibility.
+* Add HTTP timeout to OAuth token refresh and endpoint discovery requests in `oauth.py` to prevent indefinite hangs when the OAuth endpoint is unreachable or slow.
 
 ### Documentation
 

--- a/databricks/sdk/oauth.py
+++ b/databricks/sdk/oauth.py
@@ -30,6 +30,13 @@ URL_ENCODED_CONTENT_TYPE = "application/x-www-form-urlencoded"
 JWT_BEARER_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:jwt-bearer"
 OIDC_TOKEN_PATH = "/oidc/v1/token"
 
+# Default timeout (in seconds) for OAuth HTTP calls. Matches the SDK's default
+# `http_timeout_seconds` in `_BaseClient`. These calls run inside the
+# `session.auth` header factory, which executes before the per-request timeout
+# configured on the underlying `requests.Session` takes effect, so an explicit
+# timeout is required to prevent hangs when the OAuth endpoint is unreachable.
+_OAUTH_DEFAULT_TIMEOUT_SECONDS = 60
+
 logger = logging.getLogger(__name__)
 
 
@@ -206,7 +213,7 @@ def retrieve_token(
         auth = requests.auth.HTTPBasicAuth(client_id, client_secret)
     else:
         auth = IgnoreNetrcAuth()
-    resp = requests.post(token_url, params, auth=auth, headers=headers)
+    resp = requests.post(token_url, params, auth=auth, headers=headers, timeout=_OAUTH_DEFAULT_TIMEOUT_SECONDS)
     if not resp.ok:
         if resp.headers["Content-Type"].startswith("application/json"):
             err = resp.json()
@@ -545,7 +552,11 @@ def get_azure_entra_id_workspace_endpoints(
     """
     # In Azure, this workspace endpoint redirects to the Entra ID authorization endpoint
     host = _fix_host_if_needed(host)
-    res = requests.get(f"{host}/oidc/oauth2/v2.0/authorize", allow_redirects=False)
+    res = requests.get(
+        f"{host}/oidc/oauth2/v2.0/authorize",
+        allow_redirects=False,
+        timeout=_OAUTH_DEFAULT_TIMEOUT_SECONDS,
+    )
     real_auth_url = res.headers.get("location")
     if not real_auth_url:
         return None
@@ -913,7 +924,7 @@ class PATOAuthTokenExchange(Refreshable):
         if self.authorization_details:
             params["authorization_details"] = self.authorization_details
 
-        resp = requests.post(token_exchange_url, params)
+        resp = requests.post(token_exchange_url, params, timeout=_OAUTH_DEFAULT_TIMEOUT_SECONDS)
         if not resp.ok:
             if resp.headers["Content-Type"].startswith("application/json"):
                 err = resp.json()

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -1,10 +1,15 @@
+from unittest.mock import MagicMock, patch
+
 import pytest
 
+from databricks.sdk import oauth as oauth_module
 from databricks.sdk._base_client import _BaseClient
-from databricks.sdk.oauth import (HostMetadata, OidcEndpoints, TokenCache,
+from databricks.sdk.oauth import (HostMetadata, OidcEndpoints,
+                                  PATOAuthTokenExchange, TokenCache,
                                   get_account_endpoints,
+                                  get_azure_entra_id_workspace_endpoints,
                                   get_endpoints_from_url, get_host_metadata,
-                                  get_workspace_endpoints)
+                                  get_workspace_endpoints, retrieve_token)
 
 from .clock import FakeClock
 
@@ -237,3 +242,56 @@ def test_get_endpoints_from_url(requests_mock):
         authorization_endpoint=f"{_DUMMY_HOST}/oidc/v1/authorize",
         token_endpoint=f"{_DUMMY_HOST}/oidc/v1/token",
     )
+
+
+# Regression tests for https://github.com/databricks/databricks-sdk-py/issues/1338:
+# the `requests.post` and `requests.get` calls in oauth.py must pass a `timeout=`
+# value to avoid hanging indefinitely when the OAuth endpoint is unreachable.
+
+
+def _ok_response(json_payload=None):
+    """Build a minimal mock Response for requests.post/get."""
+    resp = MagicMock()
+    resp.ok = True
+    resp.headers = {"Content-Type": "application/json"}
+    resp.json.return_value = json_payload or {
+        "access_token": "access",
+        "token_type": "Bearer",
+        "expires_in": 3600,
+    }
+    return resp
+
+
+def test_retrieve_token_passes_timeout():
+    with patch("databricks.sdk.oauth.requests.post", return_value=_ok_response()) as post:
+        retrieve_token(
+            client_id="id",
+            client_secret="secret",
+            token_url="https://example.com/oidc/v1/token",
+            params={"grant_type": "client_credentials"},
+            use_header=True,
+        )
+    post.assert_called_once()
+    assert post.call_args.kwargs.get("timeout") == oauth_module._OAUTH_DEFAULT_TIMEOUT_SECONDS
+
+
+def test_get_azure_entra_id_workspace_endpoints_passes_timeout():
+    redirect_resp = MagicMock()
+    redirect_resp.headers = {"location": "https://login.microsoftonline.com/tenant/oauth2/v2.0/authorize"}
+    with patch("databricks.sdk.oauth.requests.get", return_value=redirect_resp) as get:
+        endpoints = get_azure_entra_id_workspace_endpoints("https://my-workspace.cloud.databricks.com")
+    get.assert_called_once()
+    assert get.call_args.kwargs.get("timeout") == oauth_module._OAUTH_DEFAULT_TIMEOUT_SECONDS
+    assert endpoints is not None
+
+
+def test_pat_oauth_token_exchange_refresh_passes_timeout():
+    exchange = PATOAuthTokenExchange(
+        get_original_token=lambda: "dapi-pat-token",
+        host="https://my-workspace.cloud.databricks.com",
+        scopes="all-apis",
+    )
+    with patch("databricks.sdk.oauth.requests.post", return_value=_ok_response()) as post:
+        exchange.refresh()
+    post.assert_called_once()
+    assert post.call_args.kwargs.get("timeout") == oauth_module._OAUTH_DEFAULT_TIMEOUT_SECONDS


### PR DESCRIPTION
## Summary

`requests.post()` and `requests.get()` calls in `databricks/sdk/oauth.py` did not pass a `timeout=` parameter. Because token refresh runs inside `session.auth` (the `header_factory` callback), it executes before the SDK's per-request timeout on the underlying `requests.Session` takes effect. When the OAuth endpoint is unreachable or slow, the calls blocked indefinitely.

This PR adds a default 60s timeout to the three affected call sites:
- `retrieve_token()`
- `get_azure_entra_id_workspace_endpoints()`
- `PATOAuthTokenExchange.refresh()`

## Test plan

- [x] Added three regression tests that patch `requests.post`/`requests.get` and assert `timeout=` is passed at each call site.
- [x] `tests/test_oauth.py` passes locally (17 tests).

Fixes #1338