### PR TITLE
docs: warn about secret exposure in DEBUG logs for dbutils.secrets

### DIFF
--- a/databricks/sdk/dbutils.py
+++ b/databricks/sdk/dbutils.py
@@ -152,13 +152,21 @@ class _SecretsUtil:
         self._api = secrets_api  # nolint
 
     def getBytes(self, scope: str, key: str) -> bytes:
-        """Gets the bytes representation of a secret value for the specified scope and key."""
+        """Gets the bytes representation of a secret value for the specified scope and key.
+        
+        Note: DEBUG logging may expose secrets via py4j clientserver. See `get()` for details.
+        """
         query = {"scope": scope, "key": key}
         raw = self._api._api.do("GET", "/api/2.0/secrets/get", query=query)
         return base64.b64decode(raw["value"])
-
+    
     def get(self, scope: str, key: str) -> str:
-        """Gets the string representation of a secret value for the specified secrets scope and key."""
+        """Gets the string representation of a secret value for the specified secrets scope and key.
+        
+        Warning: When Python root logger is set to DEBUG, the underlying py4j 
+        clientserver may log raw RPC payloads containing unmasked secret values. 
+        Avoid DEBUG level in production environments.
+        """
         val = self.getBytes(scope, key)
         string_value = val.decode()
         return string_value


### PR DESCRIPTION
Closes #1391

## Problem
When `logging.DEBUG` is enabled, py4j clientserver logs raw RPC responses which contain unmasked secrets from `dbutils.secrets.get`.

## Solution 
Add docstring warnings to `SecretsHandler.get()` and `getBytes()` advising users to avoid DEBUG level in production environments.

This follows security best practices used by boto3 and other SDKs when third-party logger output cannot be controlled.

## Testing
- [x] Verified docstrings render correctly
- [x] No functional changes to secret retrieval logic 
- [x] Python syntax check passes

NO_CHANGELOG=true