### PR TITLE
Fix type annotations: replace builtin `any` with `typing.Any`

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Security
 
 ### Bug Fixes
+* Fix incorrect use of Python's `any` builtin as a type annotation; replace with `typing.Any` in `_internal.py`, `config.py`, `dbutils.py`, `oauth.py`, and `runtime/dbutils_stub.py` to resolve spurious mypy `[attr-defined]` errors.
 
 ### Documentation
 

--- a/databricks/sdk/config.py
+++ b/databricks/sdk/config.py
@@ -6,7 +6,7 @@ import os
 import pathlib
 import re
 import urllib.parse
-from typing import Dict, Iterable, List, Optional
+from typing import Any, Dict, Iterable, List, Optional
 
 import requests
 
@@ -14,13 +14,15 @@ from . import useragent
 from ._base_client import _fix_host_if_needed
 from .client_types import ClientType, HostType
 from .clock import Clock, RealClock
-from .credentials_provider import (CredentialsStrategy, DefaultCredentials,
-                                   OAuthCredentialsProvider)
-from .environments import (ALL_ENVS, AzureEnvironment, Cloud,
-                           DatabricksEnvironment, get_environment_for_hostname)
-from .oauth import (OidcEndpoints, Token,
-                    get_azure_entra_id_workspace_endpoints,
-                    get_endpoints_from_url, get_host_metadata)
+from .credentials_provider import CredentialsStrategy, DefaultCredentials, OAuthCredentialsProvider
+from .environments import ALL_ENVS, AzureEnvironment, Cloud, DatabricksEnvironment, get_environment_for_hostname
+from .oauth import (
+    OidcEndpoints,
+    Token,
+    get_azure_entra_id_workspace_endpoints,
+    get_endpoints_from_url,
+    get_host_metadata,
+)
 
 logger = logging.getLogger("databricks.sdk")
 
@@ -47,7 +49,7 @@ class ConfigAttribute:
             return None
         return cfg._inner.get(self.name, None)
 
-    def __set__(self, cfg: "Config", value: any):
+    def __set__(self, cfg: "Config", value: Any):
         cfg._inner[self.name] = self.transform(value)
 
     def __repr__(self) -> str:

--- a/databricks/sdk/dbutils.py
+++ b/databricks/sdk/dbutils.py
@@ -186,8 +186,8 @@ class _JobsUtil:
             self,
             taskKey: str,
             key: str,
-            default: any = None,
-            debugValue: any = None,
+            default: Any = None,
+            debugValue: Any = None,
         ) -> None:
             """
             Returns `debugValue` if present, throws an error otherwise as this implementation is always run outside of a job run
@@ -198,7 +198,7 @@ class _JobsUtil:
                 )
             return debugValue
 
-        def set(self, key: str, value: any) -> None:
+        def set(self, key: str, value: Any) -> None:
             """
             Sets a task value on the current task run
             """

--- a/databricks/sdk/oauth.py
+++ b/databricks/sdk/oauth.py
@@ -789,7 +789,7 @@ class OAuthClient:
         from .credentials_provider import credentials_strategy
 
         @credentials_strategy("noop", [])
-        def noop_credentials(_: any):
+        def noop_credentials(_: Any):
             return lambda: {}
 
         config = Config(host=host, credentials_strategy=noop_credentials)

--- a/databricks/sdk/runtime/dbutils_stub.py
+++ b/databricks/sdk/runtime/dbutils_stub.py
@@ -57,7 +57,7 @@ class dbutils:
         """
 
         @staticmethod
-        def summarize(df: any, precise: bool = False) -> None:
+        def summarize(df: typing.Any, precise: bool = False) -> None:
             """Summarize a Spark/pandas/Koalas DataFrame and visualize the statistics to get quick insights.
 
             Example: dbutils.data.summarize(df)
@@ -200,8 +200,8 @@ class dbutils:
             def get(
                 taskKey: str,
                 key: str,
-                default: any = None,
-                debugValue: any = None,
+                default: typing.Any = None,
+                debugValue: typing.Any = None,
             ) -> None:
                 """
                 Returns the latest task value that belongs to the current job run
@@ -209,7 +209,7 @@ class dbutils:
                 ...
 
             @staticmethod
-            def set(key: str, value: any) -> None:
+            def set(key: str, value: typing.Any) -> None:
                 """
                 Sets a task value on the current task run
                 """

--- a/databricks/sdk/service/_internal.py
+++ b/databricks/sdk/service/_internal.py
@@ -8,13 +8,13 @@ from google.protobuf.timestamp_pb2 import Timestamp
 from databricks.sdk.common.types.fieldmask import FieldMask
 
 
-def _from_dict(d: Dict[str, any], field: str, cls: Type) -> any:
+def _from_dict(d: Dict[str, Any], field: str, cls: Type) -> Any:
     if field not in d or d[field] is None:
         return None
     return getattr(cls, "from_dict")(d[field])
 
 
-def _repeated_dict(d: Dict[str, any], field: str, cls: Type) -> any:
+def _repeated_dict(d: Dict[str, Any], field: str, cls: Type) -> Any:
     if field not in d or not d[field]:
         return []
     from_dict = getattr(cls, "from_dict")
@@ -28,14 +28,14 @@ def _get_enum_value(cls: Type, value: str) -> Optional[Type]:
     )
 
 
-def _enum(d: Dict[str, any], field: str, cls: Type) -> any:
+def _enum(d: Dict[str, Any], field: str, cls: Type) -> Any:
     """Unknown enum values are returned as None."""
     if field not in d or not d[field]:
         return None
     return _get_enum_value(cls, d[field])
 
 
-def _repeated_enum(d: Dict[str, any], field: str, cls: Type) -> any:
+def _repeated_enum(d: Dict[str, Any], field: str, cls: Type) -> Any:
     """For now, unknown enum values are not included in the response."""
     if field not in d or not d[field]:
         return None

--- a/databricks/sdk/service/_internal.py
+++ b/databricks/sdk/service/_internal.py
@@ -1,6 +1,6 @@
 import datetime
 import urllib.parse
-from typing import Callable, Dict, Generic, List, Optional, Type, TypeVar
+from typing import Any, Callable, Dict, Generic, List, Optional, Type, TypeVar
 
 from google.protobuf.duration_pb2 import Duration
 from google.protobuf.timestamp_pb2 import Timestamp
@@ -143,13 +143,13 @@ ReturnType = TypeVar("ReturnType")
 
 class Wait(Generic[ReturnType]):
 
-    def __init__(self, waiter: Callable, response: any = None, **kwargs) -> None:
+    def __init__(self, waiter: Callable, response: Any = None, **kwargs) -> None:
         self.response = response
 
         self._waiter = waiter
         self._bind = kwargs
 
-    def __getattr__(self, key) -> any:
+    def __getattr__(self, key) -> Any:
         return self._bind[key]
 
     def bind(self) -> dict:


### PR DESCRIPTION
## Summary

Replaces all uses of the Python builtin `any` as a type annotation with `typing.Any` across the SDK, fixing incorrect type inference by mypy.

## Why

`any` used as a type annotation refers to the builtin function `any(iterable: Iterable) -> bool`, not the `typing.Any` wildcard. mypy treats annotated parameters and return values as having the type of that callable, which causes spurious `[attr-defined]` errors when code accesses attributes on those values at runtime. For example, `Wait.response` was inferred as `(Iterable[object]) -> bool`, so any attribute access like `.run_id` would fail a mypy check even though the code is correct. The fix is mechanical: replace every `: any` / `-> any` annotation with `typing.Any`, which is the correct way to express "this value is intentionally untyped."

## What changed

### Interface changes

None.

### Behavioral changes

None.

### Internal changes

- **`databricks/sdk/service/_internal.py`** - Fixed `_from_dict`, `_repeated_dict`, `_enum`, `_repeated_enum`, `Wait.__init__`, and `Wait.__getattr__`; added `Any` to the `typing` import.
- **`databricks/sdk/config.py`** - Fixed `ConfigAttribute.__set__`; added `Any` to the `typing` import.
- **`databricks/sdk/dbutils.py`** - Fixed `taskValues.get` (×2) and `taskValues.set`.
- **`databricks/sdk/oauth.py`** - Fixed the `noop_credentials` parameter annotation.
- **`databricks/sdk/runtime/dbutils_stub.py`** - Fixed `data.summarize`, `jobs.taskValues.get` (×2), and `jobs.taskValues.set`.

## How is this tested?

Type-annotation-only change with no behavioral effect. Verified with `black --check` (all files pass). A mypy run on code that accesses attributes of annotated values (e.g. `Wait.response.run_id`) will no longer produce spurious `[attr-defined]` errors.