### PR TITLE
Use __file__-relative paths for test fixtures

### DIFF
--- a/tests/test_init_file.py
+++ b/tests/test_init_file.py
@@ -1,4 +1,9 @@
 import hashlib
+import pathlib
+
+# databricks/__init__.py lives one directory above this test, regardless
+# of where pytest was invoked from.
+_INIT_FILE = pathlib.Path(__file__).parent.parent / "databricks" / "__init__.py"
 
 
 def test_init_file_contents():
@@ -7,7 +12,7 @@ def test_init_file_contents():
 
     Also see https://github.com/databricks/databricks-sdk-py/issues/343#issuecomment-1866029118.
     """
-    with open("databricks/__init__.py") as f:
+    with open(_INIT_FILE) as f:
         init_file_contents = f.read()
 
     # This hash is the expected hash of the contents of `src/databricks/__init__.py`.

--- a/tests/test_model_serving_auth.py
+++ b/tests/test_model_serving_auth.py
@@ -1,3 +1,4 @@
+import pathlib
 import threading
 import time
 
@@ -7,6 +8,12 @@ from databricks.sdk.core import Config
 from databricks.sdk.credentials_provider import ModelServingUserCredentials
 
 from .conftest import raises
+
+# Test fixture files live next to this test, regardless of where pytest
+# was invoked from.
+_TESTDATA = pathlib.Path(__file__).parent / "testdata"
+_MODEL_SERVING_TEST_TOKEN = str(_TESTDATA / "model-serving-test-token")
+_MODEL_SERVING_TEST_TOKEN_V2 = str(_TESTDATA / "model-serving-test-token-v2")
 
 default_auth_base_error_message = (
     "default auth: cannot configure default credentials, "
@@ -24,7 +31,7 @@ default_auth_base_error_message = (
                 ("DB_MODEL_SERVING_HOST_URL", "x"),
             ],
             ["DATABRICKS_MODEL_SERVING_HOST_URL"],
-            "tests/testdata/model-serving-test-token",
+            _MODEL_SERVING_TEST_TOKEN,
         ),
         (
             [
@@ -32,7 +39,7 @@ default_auth_base_error_message = (
                 ("DB_MODEL_SERVING_HOST_URL", "x"),
             ],
             ["DATABRICKS_MODEL_SERVING_HOST_URL"],
-            "tests/testdata/model-serving-test-token",
+            _MODEL_SERVING_TEST_TOKEN,
         ),
         (
             [
@@ -40,7 +47,7 @@ default_auth_base_error_message = (
                 ("DATABRICKS_MODEL_SERVING_HOST_URL", "x"),
             ],
             ["DB_MODEL_SERVING_HOST_URL"],
-            "tests/testdata/model-serving-test-token",
+            _MODEL_SERVING_TEST_TOKEN,
         ),
         (
             [
@@ -48,7 +55,7 @@ default_auth_base_error_message = (
                 ("DATABRICKS_MODEL_SERVING_HOST_URL", "x"),
             ],
             ["DB_MODEL_SERVING_HOST_URL"],
-            "tests/testdata/model-serving-test-token",
+            _MODEL_SERVING_TEST_TOKEN,
         ),
     ],
 )
@@ -92,7 +99,7 @@ def test_model_serving_auth(env_values, del_env_values, oauth_file_name, monkeyp
         ),  # In Model Serving and Invalid File Name
         (
             [],
-            "tests/testdata/model-serving-test-token",
+            _MODEL_SERVING_TEST_TOKEN,
         ),  # Not in Model Serving and Valid File Name
     ],
 )
@@ -122,7 +129,7 @@ def test_model_serving_auth_refresh(monkeypatch, mocker):
     # patch mlflow to read the file from the test directory
     monkeypatch.setattr(
         "databricks.sdk.credentials_provider.ModelServingAuthProvider._MODEL_DEPENDENCY_OAUTH_TOKEN_FILE_PATH",
-        "tests/testdata/model-serving-test-token",
+        _MODEL_SERVING_TEST_TOKEN,
     )
     mocker.patch("databricks.sdk.config.Config._known_file_config_loader")
 
@@ -136,7 +143,7 @@ def test_model_serving_auth_refresh(monkeypatch, mocker):
     # Simulate refreshing the token by patching to to a new file
     monkeypatch.setattr(
         "databricks.sdk.credentials_provider.ModelServingAuthProvider._MODEL_DEPENDENCY_OAUTH_TOKEN_FILE_PATH",
-        "tests/testdata/model-serving-test-token-v2",
+        _MODEL_SERVING_TEST_TOKEN_V2,
     )
 
     monkeypatch.setattr(
@@ -172,7 +179,7 @@ def test_agent_user_credentials(monkeypatch, mocker):
     monkeypatch.setenv("DB_MODEL_SERVING_HOST_URL", "x")
     monkeypatch.setattr(
         "databricks.sdk.credentials_provider.ModelServingAuthProvider._MODEL_DEPENDENCY_OAUTH_TOKEN_FILE_PATH",
-        "tests/testdata/model-serving-test-token",
+        _MODEL_SERVING_TEST_TOKEN,
     )
 
     invokers_token_val = "databricks_invokers_token"


### PR DESCRIPTION
## Summary

Two tests hardcode relative paths (`tests/testdata/...` and `databricks/__init__.py`) that only resolve when pytest's cwd is the SDK root. Switch them to `pathlib.Path(__file__)`-based paths so they work no matter where pytest is launched.

## Why

Today's upstream invocation (`make test` from the SDK root) is the happy case, so it goes unnoticed. But pytest from any other directory — a different CWD, a CI runner that builds the source tree elsewhere, or a Bazel test sandbox — fails the tests with `FileNotFoundError`.

## What changed

### Interface changes

None.

### Behavioral changes

None (same fixture files, just resolved by absolute path).

### Internal changes

- `tests/test_model_serving_auth.py`: `\"tests/testdata/model-serving-test-token\"` and `\"...-v2\"` parameters replaced with constants computed from `pathlib.Path(__file__).parent / \"testdata\"`.
- `tests/test_init_file.py`: `open(\"databricks/__init__.py\")` replaced with `open(pathlib.Path(__file__).parent.parent / \"databricks\" / \"__init__.py\")`.

## How is this tested?

- `make test` from the SDK root: 2073 passed, 3 skipped, same baseline as main.
- `pytest tests/test_model_serving_auth.py tests/test_init_file.py` from outside the SDK root (e.g. `/tmp`): now passes (previously fails with `FileNotFoundError`).

NO_CHANGELOG=true