### PR TITLE
Add EXTERNAL_IMPORT_TEST.md placeholder

### DIFF
--- a/EXTERNAL_IMPORT_TEST.md
+++ b/EXTERNAL_IMPORT_TEST.md
@@ -1,0 +1,8 @@
+# External import test
+
+Placeholder file added to exercise the OSS → Universe contribution
+import flow documented in
+`deco/oss/docs/databricks-sdk-py/external-contributions.md` (in
+`databricks-eng/universe`).
+
+Safe to delete once the import flow has been validated end-to-end.


### PR DESCRIPTION
## Summary

Adds a single new placeholder file (`EXTERNAL_IMPORT_TEST.md`) at the repo root, used to validate the OSS → Universe contribution-import flow described in the internal `external-contributions.md` runbook.

Brand new file, no existing content touched — chosen specifically to avoid any sync-conflict risk.

Safe to delete once the import flow has been exercised end-to-end.

## How is this tested?

N/A — content is a markdown placeholder, no behavior change.