### PR TITLE
Fix error tracker URL to point to the Python SDK repo

### DIFF
--- a/databricks/sdk/errors/parser.py
+++ b/databricks/sdk/errors/parser.py
@@ -46,7 +46,7 @@ def _unknown_error(response: requests.Response, debug_headers: bool = False) -> 
     return (
         "This is likely a bug in the Databricks SDK for Python or the underlying "
         "API. Please report this issue with the following debugging information to the SDK issue tracker at "
-        f"https://github.com/databricks/databricks-sdk-go/issues. Request log:```{request_log}```"
+        f"https://github.com/databricks/databricks-sdk-py/issues. Request log:```{request_log}```"
     )
 
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -314,7 +314,7 @@ _test_case_other_errors = [
         want_message=(
             "unable to parse response. This is likely a bug in the Databricks SDK for Python or the underlying API. "
             "Please report this issue with the following debugging information to the SDK issue tracker at "
-            "https://github.com/databricks/databricks-sdk-go/issues. Request log:```GET /api/2.0/service\n"
+            "https://github.com/databricks/databricks-sdk-py/issues. Request log:```GET /api/2.0/service\n"
             "< 400 Bad Request\n"
             "< this is not a real response```"
         ),
@@ -343,7 +343,7 @@ _test_case_other_errors = [
             response_body=json.dumps("This is JSON but not a dictionary"),
         ),
         want_err_type=errors.NotFound,
-        want_message='unable to parse response. This is likely a bug in the Databricks SDK for Python or the underlying API. Please report this issue with the following debugging information to the SDK issue tracker at https://github.com/databricks/databricks-sdk-go/issues. Request log:```GET /api/2.0/service\n< 404 Not Found\n< "This is JSON but not a dictionary"```',
+        want_message='unable to parse response. This is likely a bug in the Databricks SDK for Python or the underlying API. Please report this issue with the following debugging information to the SDK issue tracker at https://github.com/databricks/databricks-sdk-py/issues. Request log:```GET /api/2.0/service\n< 404 Not Found\n< "This is JSON but not a dictionary"```',
     ),
     TestCase(
         name="unable_to_parse_response3",
@@ -353,7 +353,7 @@ _test_case_other_errors = [
             response_body=b"\x80",
         ),
         want_err_type=errors.NotFound,
-        want_message="unable to parse response. This is likely a bug in the Databricks SDK for Python or the underlying API. Please report this issue with the following debugging information to the SDK issue tracker at https://github.com/databricks/databricks-sdk-go/issues. Request log:```GET /api/2.0/service\n< 404 Not Found\n< �```",
+        want_message="unable to parse response. This is likely a bug in the Databricks SDK for Python or the underlying API. Please report this issue with the following debugging information to the SDK issue tracker at https://github.com/databricks/databricks-sdk-py/issues. Request log:```GET /api/2.0/service\n< 404 Not Found\n< �```",
     ),
 ]
 


### PR DESCRIPTION
## Summary

The "unable to parse response" fallback error now links to the `databricks-sdk-py` issue tracker instead of `databricks-sdk-go`.

## Why

That message is only emitted by the Python SDK, but it hard-coded the Go tracker URL, so affected users filed Python issues against the Go repo. Recent reports there (#1703, #1709, #1710) were Python runs that landed in the wrong place for this reason.

## How is this tested?

`tests/test_errors.py` passes; the three cases that asserted the old URL are updated.

NO_CHANGELOG=true