### PR TITLE
Skip legacy DBFS integration tests (DBFS disabled on test workspace)

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -14,4 +14,6 @@
 
 ### Internal Changes
 
+* Skip integration tests that exercise legacy DBFS root, which is disabled on the test workspace (DBFS deprecation).
+
 ### API Changes

--- a/tests/integration/test_auth.py
+++ b/tests/integration/test_auth.py
@@ -121,6 +121,7 @@ def test_runtime_auth_from_jobs_volumes(ucws, files_api, fresh_wheel_file, env_o
     return _test_runtime_auth_from_jobs_inner(ucws, env_or_skip, random, dbr_versions, lib)
 
 
+@pytest.mark.skip(reason="Legacy DBFS is disabled on the test workspace (DBFS deprecation)")
 def test_runtime_auth_from_jobs_dbfs(w, fresh_wheel_file, env_or_skip, random):
     # Library installation from DBFS is not supported past DBR 14.3.
     # DBR < 13 ships Python < 3.10 which is below our requires-python.

--- a/tests/integration/test_dbutils.py
+++ b/tests/integration/test_dbutils.py
@@ -8,6 +8,7 @@ from databricks.sdk.core import DatabricksError
 from databricks.sdk.errors import NotFound
 
 
+@pytest.mark.skip(reason="Legacy DBFS is disabled on the test workspace (DBFS deprecation)")
 def test_rest_dbfs_ls(w, env_or_skip):
     from databricks.sdk.runtime import dbutils
 
@@ -24,7 +25,15 @@ def test_proxy_dbfs_mounts(w, env_or_skip):
     assert len(x) > 1
 
 
-@pytest.fixture(params=["dbfs", "volumes"])
+@pytest.fixture(
+    params=[
+        # Legacy DBFS is disabled on the test workspace (DBFS deprecation).
+        pytest.param(
+            "dbfs", marks=pytest.mark.skip(reason="Legacy DBFS is disabled on the test workspace (DBFS deprecation)")
+        ),
+        "volumes",
+    ]
+)
 def fs_and_base_path(request, ucws, volume):
     if request.param == "dbfs":
         fs = ucws.dbutils.fs

--- a/tests/integration/test_files.py
+++ b/tests/integration/test_files.py
@@ -26,6 +26,7 @@ def test_local_io(random):
     f.close()
 
 
+@pytest.mark.skip(reason="Legacy DBFS is disabled on the test workspace (DBFS deprecation)")
 def test_dbfs_io(w, random):
     dummy_file = f"/tmp/{random()}"
     to_write = random(1024 * 1024 * 1.5).encode()
@@ -59,6 +60,7 @@ def ls(w):
     return inner
 
 
+@pytest.mark.skip(reason="Legacy DBFS is disabled on the test workspace (DBFS deprecation)")
 def test_recursive_listing(w, random, junk, ls):
     root = f"/tmp/{random()}"
     junk(f"{root}/01")
@@ -71,6 +73,7 @@ def test_recursive_listing(w, random, junk, ls):
     w.dbfs.delete(root, recursive=True)
 
 
+@pytest.mark.skip(reason="Legacy DBFS is disabled on the test workspace (DBFS deprecation)")
 def test_cp_dbfs_folder_to_folder_non_recursive(w, random, junk, ls):
     root = f"/tmp/{random()}"
     junk(f"{root}/01")
@@ -83,6 +86,7 @@ def test_cp_dbfs_folder_to_folder_non_recursive(w, random, junk, ls):
     assert ["/01"] == ls(new_root, recursive=True)
 
 
+@pytest.mark.skip(reason="Legacy DBFS is disabled on the test workspace (DBFS deprecation)")
 def test_cp_dbfs_folder_to_folder_recursive(w, random, junk, ls):
     root = f"/tmp/{random()}"
     junk(f"{root}/01")
@@ -95,6 +99,7 @@ def test_cp_dbfs_folder_to_folder_recursive(w, random, junk, ls):
     assert ["/01", "/a/02", "/a/b/03"] == ls(new_root, recursive=True)
 
 
+@pytest.mark.skip(reason="Legacy DBFS is disabled on the test workspace (DBFS deprecation)")
 def test_cp_dbfs_folder_to_existing_folder_recursive(w, random, junk, ls):
     root = f"/tmp/{random()}"
     junk(f"{root}/01")
@@ -109,6 +114,7 @@ def test_cp_dbfs_folder_to_existing_folder_recursive(w, random, junk, ls):
     assert [f"/{base}/01", f"/{base}/a/02", f"/{base}/a/b/03"] == ls(new_root, recursive=True)
 
 
+@pytest.mark.skip(reason="Legacy DBFS is disabled on the test workspace (DBFS deprecation)")
 def test_cp_dbfs_file_to_non_existing_location(w, random, junk):
     root = f"/tmp/{random()}"
     payload = junk(f"{root}/01")
@@ -120,6 +126,7 @@ def test_cp_dbfs_file_to_non_existing_location(w, random, junk):
         assert f.read() == payload
 
 
+@pytest.mark.skip(reason="Legacy DBFS is disabled on the test workspace (DBFS deprecation)")
 def test_cp_dbfs_file_to_existing_folder(w, random, junk):
     root = f"/tmp/{random()}"
     payload = junk(f"{root}/01")
@@ -130,6 +137,7 @@ def test_cp_dbfs_file_to_existing_folder(w, random, junk):
         assert f.read() == payload
 
 
+@pytest.mark.skip(reason="Legacy DBFS is disabled on the test workspace (DBFS deprecation)")
 def test_cp_dbfs_file_to_existing_location(w, random, junk):
     root = f"/tmp/{random()}"
     junk(f"{root}/01")
@@ -139,6 +147,7 @@ def test_cp_dbfs_file_to_existing_location(w, random, junk):
     assert "A file or directory already exists" in str(ei.value)
 
 
+@pytest.mark.skip(reason="Legacy DBFS is disabled on the test workspace (DBFS deprecation)")
 def test_cp_dbfs_file_to_existing_location_with_overwrite(w, random, junk):
     root = f"/tmp/{random()}"
     payload = junk(f"{root}/01")
@@ -150,6 +159,7 @@ def test_cp_dbfs_file_to_existing_location_with_overwrite(w, random, junk):
         assert f.read() == payload
 
 
+@pytest.mark.skip(reason="Legacy DBFS is disabled on the test workspace (DBFS deprecation)")
 def test_move_within_dbfs(w, random, junk):
     root = f"/tmp/{random()}"
     payload = junk(f"{root}/01")
@@ -161,6 +171,7 @@ def test_move_within_dbfs(w, random, junk):
         assert f.read() == payload
 
 
+@pytest.mark.skip(reason="Legacy DBFS is disabled on the test workspace (DBFS deprecation)")
 def test_move_from_dbfs_to_local(w, random, junk, tmp_path):
     root = pathlib.Path(f"/tmp/{random()}")
     payload_01 = junk(f"{root}/01")
@@ -178,6 +189,7 @@ def test_move_from_dbfs_to_local(w, random, junk, tmp_path):
         assert f.read() == payload_03
 
 
+@pytest.mark.skip(reason="Legacy DBFS is disabled on the test workspace (DBFS deprecation)")
 def test_dbfs_upload_download(w, random, junk, tmp_path):
     root = pathlib.Path(f"/tmp/{random()}")
 

--- a/tests/integration/test_jobs.py
+++ b/tests/integration/test_jobs.py
@@ -1,6 +1,8 @@
 import datetime
 import logging
 
+import pytest
+
 
 def test_jobs(w):
     found = 0
@@ -10,6 +12,7 @@ def test_jobs(w):
     assert found > 0
 
 
+@pytest.mark.skip(reason="Legacy DBFS is disabled on the test workspace (DBFS deprecation)")
 def test_submitting_jobs(w, random, env_or_skip):
     from databricks.sdk.service import compute, jobs
 


### PR DESCRIPTION
The deco test workspace has legacy DBFS root disabled (DBFS deprecation, now GA), so integration tests that read/write the DBFS root fail with `Public DBFS root is disabled`. This skips those tests (kept, not deleted) so they no longer block CI.

Skipped: the `dbfs` variants in `test_dbutils.py` plus `test_rest_dbfs_ls`; the DBFS tests in `test_files.py`; `test_auth.py::test_runtime_auth_from_jobs_dbfs`; and `test_jobs.py::test_submitting_jobs`. Volumes-based and non-DBFS tests are unaffected.