### PR TITLE
Add sync-label check: PRs need the maintainer-applied 'sync' label

### DIFF
--- a/.github/workflows/sync-label.yml
+++ b/.github/workflows/sync-label.yml
@@ -1,0 +1,24 @@
+# This repository is a read-only mirror; the only PRs that should
+# merge are the release sync PRs from the internal source of truth.
+# This check fails unless the PR carries the `sync` label, which only
+# maintainers can apply — making every merge a deliberate act.
+# Temporary guard until release automation takes over merging.
+name: Sync label
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, labeled, unlabeled]
+
+jobs:
+  sync-label:
+    name: sync-label
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require the `sync` label
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'sync') }}
+        run: |
+          echo "::error::This PR does not carry the 'sync' label. This repository is a read-only mirror — only release sync PRs merge here. If this IS a release sync PR, a maintainer must apply the 'sync' label; community contributions are re-applied in the internal repository instead (see CONTRIBUTING.md)."
+          exit 1
+      - name: Label present
+        if: ${{ contains(github.event.pull_request.labels.*.name, 'sync') }}
+        run: echo "sync label present — this is a release sync PR."

--- a/.github/workflows/sync-label.yml
+++ b/.github/workflows/sync-label.yml
@@ -8,17 +8,26 @@ name: Sync label
 on:
   pull_request:
     types: [opened, reopened, synchronize, labeled, unlabeled]
+  # The label gate runs at PR level — a PR can't enter the merge queue
+  # until this check passes there. Merge-group events carry no label
+  # context, so on them the job passes trivially; without this trigger
+  # a required sync-label check would stall every queue entry.
+  merge_group:
+    types: [checks_requested]
 
 jobs:
   sync-label:
     name: sync-label
     runs-on: ubuntu-latest
     steps:
+      - name: Merge queue — gate already applied at PR level
+        if: ${{ github.event_name == 'merge_group' }}
+        run: echo "merge group — sync label was enforced when the PR entered the queue."
       - name: Require the `sync` label
-        if: ${{ !contains(github.event.pull_request.labels.*.name, 'sync') }}
+        if: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'sync') }}
         run: |
           echo "::error::This PR does not carry the 'sync' label. This repository is a read-only mirror — only release sync PRs merge here. If this IS a release sync PR, a maintainer must apply the 'sync' label; community contributions are re-applied in the internal repository instead (see CONTRIBUTING.md)."
           exit 1
       - name: Label present
-        if: ${{ contains(github.event.pull_request.labels.*.name, 'sync') }}
+        if: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'sync') }}
         run: echo "sync label present — this is a release sync PR."


### PR DESCRIPTION
## What

A required-check candidate that fails unless the PR carries the `sync` label. The label needs triage+ permission, so external contributors can't self-apply it — and maintainers must perform one deliberate act before a PR becomes mergeable, which is exactly the accidental-merge failure mode this guards against. Replaces the old `[sync]`-in-title convention (titles are author-controlled, i.e. spoofable).

The error message routes non-sync PRs to CONTRIBUTING.md's mirror flow.

Temporary: goes away once release automation owns merging.

## Try it

This PR itself is the test: the `sync-label` check should be failing right now. Applying the `sync` label should turn it green (the `labeled` event re-runs it); removing the label flips it back.

## Follow-ups (not this PR)

- Add `sync-label` to the required status checks in the repo ruleset (eng-dev-ecosystem) so it actually blocks.
- Sync the workflow file into the Universe subtree so the next release sync doesn't delete it.

This pull request and its description were written by Isaac.