### PR TITLE
Bound host-metadata discovery on Config init to the configured timeouts

### DIFF
--- a/databricks/sdk/config.py
+++ b/databricks/sdk/config.py
@@ -11,7 +11,7 @@ from typing import Dict, Iterable, List, Optional
 import requests
 
 from . import useragent
-from ._base_client import _fix_host_if_needed
+from ._base_client import _BaseClient, _fix_host_if_needed
 from .client_types import ClientType, HostType
 from .clock import Clock, RealClock
 from .credentials_provider import CredentialsStrategy, DefaultCredentials, OAuthCredentialsProvider
@@ -637,8 +637,17 @@ class Config:
         """
         if not self.host:
             return
+        # Host metadata is a best-effort discovery probe that falls back to the
+        # explicit configuration below on any failure. Build its client from the
+        # configured timeouts: otherwise it uses the default 300s retry budget,
+        # which blocks Config() initialization for ~5 minutes when the host is
+        # unreachable.
+        client = _BaseClient(
+            retry_timeout_seconds=self.retry_timeout_seconds,
+            http_timeout_seconds=self.http_timeout_seconds,
+        )
         try:
-            meta = get_host_metadata(self.host)
+            meta = get_host_metadata(self.host, client=client)
         except Exception as e:
             logger.warning(
                 f"Failed to automatically resolve config from host metadata: {e}. Falling back to explicit user provided configuration."

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -805,6 +805,19 @@ def test_resolve_host_metadata_called_for_non_unified(mocker):
     mock_get.assert_called_once()
 
 
+def test_resolve_host_metadata_uses_configured_timeouts(mocker):
+    """The discovery client honors the configured timeouts so an unreachable host
+    cannot block Config() init for the default 300s retry budget."""
+    mock_get = mocker.patch(
+        "databricks.sdk.config.get_host_metadata",
+        return_value=oauth.HostMetadata(oidc_endpoint=""),
+    )
+    Config(host=_DUMMY_WS_HOST, token="t", retry_timeout_seconds=7, http_timeout_seconds=3)
+    client = mock_get.call_args.kwargs["client"]
+    assert client._retry_timeout_seconds == 7
+    assert client._http_timeout_seconds == 3
+
+
 # ---------------------------------------------------------------------------
 # Cloud field tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Build the host-metadata discovery client on `Config` initialization from the configured `retry_timeout_seconds` / `http_timeout_seconds`, so an unreachable host no longer blocks `Config()` / `WorkspaceClient()` for ~5 minutes.

## Why

On initialization, `Config` resolves missing fields (`account_id`, `workspace_id`, `discovery_url`, `cloud`, `token_audience`) from the host's `/.well-known/databricks-config` discovery endpoint, via `_resolve_host_metadata` → `get_host_metadata`. This probe is best-effort: any failure is caught, logged, and the explicitly-provided configuration is used instead.

The problem is the client used for the probe. `get_host_metadata`'s default client is a no-argument `_BaseClient()`, so the probe ignores `retry_timeout_seconds` and `http_timeout_seconds` and always uses the default 300-second retry budget. When the host is unreachable — behind a proxy/firewall that drops connections, or a workspace that is down — initialization blocks for the full ~5 minutes before the probe gives up and falls back, even when `host`, `token`, and `auth_type` were all supplied explicitly and there was nothing to discover. Setting the timeouts on `Config` does not help today, because the probe never receives them.

This is the same class of problem as #1046 (and its fix #1085), which addresses the `oidc_endpoints` probe; this PR covers the separate `_resolve_host_metadata` → `get_host_metadata` probe.

## What changed

### Interface changes

None.

### Behavioral changes

`_resolve_host_metadata` now builds its `_BaseClient` from the configured `retry_timeout_seconds` / `http_timeout_seconds`, matching how `ApiClient` constructs its client. Callers that set shorter timeouts now get a fast, bounded failure against an unreachable host instead of a fixed ~5-minute block. The probe remains best-effort with the same fallback to explicit configuration, behavior is unchanged for reachable hosts, and the default timeout is unchanged (still 300s when not configured).

### Internal changes

None beyond the above.

## How is this tested?

- New unit test (`test_resolve_host_metadata_uses_configured_timeouts`) asserts the discovery client carries the configured timeouts; the existing `_resolve_host_metadata` suite still passes.
- Manual: against an unreachable host (`https://192.0.2.1`, RFC 5737 TEST-NET), `Config(host=..., token=..., auth_type="pat", retry_timeout_seconds=2, http_timeout_seconds=1)` returns in ~2.6s and logs the fallback warning, instead of blocking on the default 300s retry budget.
