### PR TITLE
fix: handle non-string request bodies in error-logging round-trip dump

### DIFF
--- a/databricks/sdk/logger/round_trip_logger.py
+++ b/databricks/sdk/logger/round_trip_logger.py
@@ -44,7 +44,9 @@ class RoundTrip:
             for k, v in request.headers.items():
                 sb.append(f"> * {k}: {self._only_n_bytes(v, self._debug_truncate_bytes)}")
         if request.body:
-            sb.append("> [raw stream]" if self._raw else self._redacted_dump("> ", request.body))
+            sb.append(
+                "> [raw stream]" if self._raw else self._redacted_dump("> ", self._request_body_str(request.body))
+            )
         sb.append(f"< {self._response.status_code} {self._response.reason}")
         if self._raw and self._response.headers.get("Content-Type", None) != "application/json":
             # Raw streams with `Transfer-Encoding: chunked` do not have `Content-Type` header
@@ -53,6 +55,22 @@ class RoundTrip:
             decoded = self._response.content.decode("utf-8", errors="replace")
             sb.append(self._redacted_dump("< ", decoded))
         return "\n".join(sb)
+
+    @staticmethod
+    def _request_body_str(body: Any) -> str:
+        """Normalize a `requests.PreparedRequest.body` into a string safe to hand to `_redacted_dump`.
+
+        The body is usually `str` or `bytes`, but for a streamed upload (e.g. a file object passed as
+        `data=`) `requests` leaves it as the original file-like object. Reading it here for logging
+        purposes would consume the stream (which may already be at an unknown position after the actual
+        send) and isn't guaranteed to be UTF-8, so it's represented with a fixed placeholder instead of
+        being read.
+        """
+        if isinstance(body, str):
+            return body
+        if isinstance(body, (bytes, bytearray)):
+            return bytes(body).decode("utf-8", errors="replace")
+        return "[stream body]"
 
     @staticmethod
     def _mask(m: Dict[str, any]):

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,4 +1,5 @@
 import http.client
+import io
 import json
 from dataclasses import dataclass, field
 from typing import Any, List, Optional
@@ -24,13 +25,14 @@ def fake_raw_response(
     status_code: int,
     response_body: bytes,
     path: Optional[str] = None,
+    request_body: Any = None,
 ) -> requests.Response:
     resp = requests.Response()
     resp.status_code = status_code
     resp.reason = http.client.responses.get(status_code, "")
     if path is None:
         path = "/api/2.0/service"
-    resp.request = requests.Request(method, f"https://databricks.com{path}").prepare()
+    resp.request = requests.Request(method, f"https://databricks.com{path}", data=request_body).prepare()
     resp._content = response_body
     return resp
 
@@ -354,6 +356,49 @@ _test_case_other_errors = [
         ),
         want_err_type=errors.NotFound,
         want_message="unable to parse response. This is likely a bug in the Databricks SDK for Python or the underlying API. Please report this issue with the following debugging information to the SDK issue tracker at https://github.com/databricks/databricks-sdk-py/issues. Request log:```GET /api/2.0/service\n< 404 Not Found\n< �```",
+    ),
+    TestCase(
+        # A streamed upload (e.g. a file object passed as `data=`) leaves `request.body` as the
+        # original file-like object rather than str/bytes. Building the "unable to parse response"
+        # debug log used to crash with `TypeError: object of type '...' has no len()` trying to treat
+        # it as a string, masking the real API error entirely.
+        name="unable_to_parse_response_with_streamed_request_body",
+        response=fake_raw_response(
+            method="PUT",
+            status_code=400,
+            response_body=b"this is not a real response",
+            request_body=io.BytesIO(b"some file content"),
+        ),
+        want_err_type=errors.BadRequest,
+        want_message=(
+            "unable to parse response. This is likely a bug in the Databricks SDK for Python or the underlying API. "
+            "Please report this issue with the following debugging information to the SDK issue tracker at "
+            "https://github.com/databricks/databricks-sdk-py/issues. Request log:```PUT /api/2.0/service\n"
+            "> [stream body]\n"
+            "< 400 Bad Request\n"
+            "< this is not a real response```"
+        ),
+    ),
+    TestCase(
+        # A non-UTF8 bytes request body (e.g. binary file content) used to crash with
+        # `AttributeError: 'bytes' object has no attribute 'encode'` once JSON parsing failed on it,
+        # again masking the real API error.
+        name="unable_to_parse_response_with_non_utf8_bytes_request_body",
+        response=fake_raw_response(
+            method="PUT",
+            status_code=400,
+            response_body=b"this is not a real response",
+            request_body=b"\x80not json",
+        ),
+        want_err_type=errors.BadRequest,
+        want_message=(
+            "unable to parse response. This is likely a bug in the Databricks SDK for Python or the underlying API. "
+            "Please report this issue with the following debugging information to the SDK issue tracker at "
+            "https://github.com/databricks/databricks-sdk-py/issues. Request log:```PUT /api/2.0/service\n"
+            "> �not json\n"
+            "< 400 Bad Request\n"
+            "< this is not a real response```"
+        ),
     ),
 ]
 


### PR DESCRIPTION
## Summary

`RoundTrip.generate()` (`databricks/sdk/logger/round_trip_logger.py`) passes `request.body` directly to `_redacted_dump()`, which assumes a `str`. This crashes in two ways, both inside the "unable to parse response" debug-log path itself — so the crash masks the actual API error behind an unrelated Python traceback:

1. **Streamed upload** (a file-like object passed as `data=` to `requests`, e.g. `dbutils.files.upload` from a local file): `requests` leaves `request.body` as the original file object rather than reading it. `_redacted_dump`'s `len(body)` call then raises `TypeError: object of type '...' has no len()`.
2. **Non-UTF8 bytes body**: once JSON parsing fails, the fallback path calls `body.encode(...)` on an already-`bytes` value, raising `AttributeError: 'bytes' object has no attribute 'encode'`.

Fixes #1489 (the streamed-upload crash); the non-UTF8-bytes crash is the same root cause (an assumption that `request.body` is always `str`) so it's fixed and tested alongside it rather than left for a follow-up.

## Fix

Added `_request_body_str()` to normalize `request.body` into a string before it reaches `_redacted_dump`:
- `str` passes through unchanged.
- `bytes`/`bytearray` decode with `errors="replace"` (matching the existing pattern already used for `response.content` a few lines below).
- Anything else (a stream/file-like object) is represented with a fixed `"[stream body]"` placeholder rather than read — reading it here would consume the stream (which may already be at an unknown position after the actual send) with no guarantee its content is UTF-8 text.

## Test plan

- Added two cases to `tests/test_errors.py::test_get_api_error` covering both crash scenarios (streamed body via `io.BytesIO`, non-UTF8 `bytes` body), extending the existing `fake_raw_response` helper with an optional `request_body` parameter that's passed through to `requests.Request(..., data=...).prepare()` — this reproduces exactly how `requests` represents each body type in production, rather than hand-constructing a fake object.
- Both new tests verified to fail against pre-fix code (`git stash` the fix in `round_trip_logger.py`, rerun — one raises `TypeError`, the other `AttributeError`, matching the two reported/found crash shapes) and pass post-fix.
- `pytest tests/test_errors.py`: 52 passed.
- `pytest tests/` (excluding `tests/integration`): 2109 passed; the only failures (`test_open_ai_mixin.py`, 7 tests) are pre-existing in this environment due to the optional `openai`/`langchain` packages not being installed, unrelated to this change — confirmed by running that file alone and seeing the same `ModuleNotFoundError` on unmodified `main`.
- `ruff check` / `ruff format --check`: clean on both changed files.