### PR TITLE
Add getAll stub to dbutils.widgets

### DIFF
--- a/databricks/sdk/runtime/dbutils_stub.py
+++ b/databricks/sdk/runtime/dbutils_stub.py
@@ -301,6 +301,13 @@ class dbutils:
             ...
 
         @staticmethod
+        def getAll() -> dict[str, str]:
+            """Returns a dictionary of all widget names and their current values in the notebook.
+            :return: Dictionary of widget names and current values.
+            """
+            ...
+
+        @staticmethod
         def text(name: str, defaultValue: str, label: str = None):
             """Creates a text input widget with given name, default value and optional label for
             display


### PR DESCRIPTION
## Summary

The stub for `dbutils.widgets` is missing `getAll()`, which makes my typechecker unhappy.  

## Why

Not sure if these stubs are generated or manually added. Assuming they are manually added, I created the stub for `getAll()`.

### Interface changes

`dbutils_stub` now has `dbutils.widgets.getAll()` exposed for type checkers.
