### PR TITLE
Update serving endpoint served entity limit in docs

### DIFF
--- a/databricks/sdk/service/serving.py
+++ b/databricks/sdk/service/serving.py
@@ -4458,7 +4458,7 @@ class ServingEndpointsAPI:
     Endpoints expose the underlying models as scalable REST API endpoints using serverless compute. This means
     the endpoints and associated compute resources are fully managed by Databricks and will not appear in your
     cloud account. A serving endpoint can consist of one or more MLflow models from the Databricks Model
-    Registry, called served entities. A serving endpoint can have at most ten served entities. You can
+    Registry, called served entities. A serving endpoint can have at most 15 served entities. You can
     configure traffic settings to define how requests should be routed to your served entities behind an
     endpoint. Additionally, you can configure the scale of resources that should be applied to each served
     entity."""

--- a/docs/workspace/serving/serving_endpoints.rst
+++ b/docs/workspace/serving/serving_endpoints.rst
@@ -10,7 +10,7 @@
     Endpoints expose the underlying models as scalable REST API endpoints using serverless compute. This means
     the endpoints and associated compute resources are fully managed by Databricks and will not appear in your
     cloud account. A serving endpoint can consist of one or more MLflow models from the Databricks Model
-    Registry, called served entities. A serving endpoint can have at most ten served entities. You can
+    Registry, called served entities. A serving endpoint can have at most 15 served entities. You can
     configure traffic settings to define how requests should be routed to your served entities behind an
     endpoint. Additionally, you can configure the scale of resources that should be applied to each served
     entity.


### PR DESCRIPTION
## Summary
Update the serving endpoint documentation to reflect the current limit of 15 served entities.

## Why
The documentation incorrectly states that a serving endpoint can have at most 10 served entities. The current limit is 15.

## What changed
Updated the served entity limit from 10 to 15 in the serving endpoint docstring and the corresponding `.rst` documentation. 

### Interface changes
None.

### Behavioral changes
None.

### Internal changes
None.

## How is this tested?
N/A — documentation-only change. Manually verified that both affected files now state the limit as 15.

Fixes #1496