### PR TITLE
fix: select_spark_version(latest=True) no longer implicitly filters to scala 2.12

### DIFF
--- a/databricks/sdk/mixins/compute.py
+++ b/databricks/sdk/mixins/compute.py
@@ -81,7 +81,7 @@ class ClustersExt(compute.ClustersAPI):
         ml: bool = False,
         genomics: bool = False,
         gpu: bool = False,
-        scala: str = "2.12",
+        scala: str = "",
         spark_version: str = None,
         photon: bool = False,
         graviton: bool = False,
@@ -95,17 +95,19 @@ class ClustersExt(compute.ClustersAPI):
         :param genomics: bool
         :param gpu: bool
         :param scala: str
+            Scala version to filter on, e.g. "2.12" or "2.13". Leave empty (the default) to
+            consider every Scala version, matching the Go SDK's zero-value behavior.
         :param spark_version: str
         :param photon: bool
         :param graviton: bool
 
         :returns: `spark_version` compatible string
         """
-        # Logic ported from https://github.com/databricks/databricks-sdk-go/blob/main/service/compute/spark_version.go
+        # Logic ported from https://github.com/databricks/databricks-sdk-go/blob/main/service/compute/ext_spark_version.go
         versions = []
         sv = self.spark_versions()
         for version in sv.versions:
-            if "-scala" + scala not in version.key:
+            if scala and "-scala" + scala not in version.key:
                 continue
             matches = (
                 ("apache-spark-" not in version.key)

--- a/tests/test_compute_mixins.py
+++ b/tests/test_compute_mixins.py
@@ -1,6 +1,15 @@
+import json
+
 import pytest
 
 from databricks.sdk.mixins.compute import SemVer
+
+SPARK_VERSIONS_RESPONSE = {
+    "versions": [
+        {"key": "16.4.x-scala2.12", "name": "16.4"},
+        {"key": "18.2.x-scala2.13", "name": "18.2"},
+    ]
+}
 
 
 @pytest.mark.parametrize(
@@ -40,3 +49,25 @@ def test_sorting_semver():
         SemVer(1, 0, 0),
         SemVer(12, 0, 0),
     ]
+
+
+def test_select_spark_version_latest_ignores_scala_by_default(w, requests_mock):
+    # Regression test for https://github.com/databricks/databricks-sdk-py/issues/1487:
+    # select_spark_version(latest=True) implicitly filtered to the "2.12" default
+    # scala version before picking the latest, instead of considering every scala
+    # version like the Go SDK it's ported from does.
+    requests_mock.get(
+        "http://localhost/api/2.1/clusters/spark-versions",
+        text=json.dumps(SPARK_VERSIONS_RESPONSE),
+    )
+
+    assert w.clusters.select_spark_version(latest=True) == "18.2.x-scala2.13"
+
+
+def test_select_spark_version_latest_still_honors_an_explicit_scala(w, requests_mock):
+    requests_mock.get(
+        "http://localhost/api/2.1/clusters/spark-versions",
+        text=json.dumps(SPARK_VERSIONS_RESPONSE),
+    )
+
+    assert w.clusters.select_spark_version(latest=True, scala="2.12") == "16.4.x-scala2.12"


### PR DESCRIPTION
Fixes #1487.

## What's wrong

`select_spark_version()`'s `scala` parameter defaulted to `"2.12"`, and the filter loop applies it unconditionally — so `select_spark_version(latest=True)` silently narrows to scala-2.12 runtimes before picking "latest," instead of returning the true latest across all scala versions.

The code is explicitly a port of the Go SDK's `ext_spark_version.go` — checking that source confirms this is a porting bug, not intentional behavior: Go's `SparkVersionRequest.Scala` has no default, so an unset `Scala` is `""` (its zero value), and `strings.Contains(key, "-scala"+"")` matches every version's key (all contain the literal substring `"-scala"`) — i.e. Go's real default is "no scala filter." Python's explicit `"2.12"` default diverged from that.

## Fix

Changed the default to `scala: str = ""` and only apply the filter when `scala` is truthy, matching the Go SDK's actual behavior exactly. Callers who explicitly pass `scala="2.12"` (or any other version) are unaffected.

## Testing

Added two tests to `tests/test_compute_mixins.py` using the existing `w`/`requests_mock` fixtures: one confirming `select_spark_version(latest=True)` now returns the true latest across scala versions (reproduces the exact issue scenario — `16.4.x-scala2.12` vs `18.2.x-scala2.13`), one confirming an explicit `scala="2.12"` still filters correctly. Confirmed the first test fails on unpatched code with the exact reported wrong result, passes after the fix (`git stash` isolation).

`ruff check`/`ruff format --check` clean. Full unit suite (`pytest -m 'not integration and not benchmark'`): 2118 passed, 7 pre-existing failures in `test_open_ai_mixin.py` (missing optional `openai`/`langchain` extras in this environment) — unrelated, confirmed by the failure content (`ImportError`/`ModuleNotFoundError` for those packages).